### PR TITLE
Add Railway hosting support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
     apt-get install -y \
         ca-certificates \
         nginx \
+        gettext-base \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
@@ -37,7 +38,7 @@ COPY --from=builder /app/target/release/fido-server /usr/local/bin/fido-server
 COPY --from=builder /app/target/release/fido /usr/local/bin/fido
 
 # Copy configuration files
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf /etc/nginx/nginx.conf.template
 COPY start.sh /usr/local/bin/start.sh
 
 # Copy web assets
@@ -51,23 +52,19 @@ RUN mkdir -p /data /var/log/fido && chmod 755 /data /var/log/fido
 
 # Environment variables
 ENV HOST=0.0.0.0
-# External listener (nginx). Cloud Run injects PORT at runtime.
+# External listener (nginx). Railway/Cloud Run inject PORT at runtime.
 ENV PORT=8080
 # Internal API listener (fido-server) behind nginx.
 ENV FIDO_SERVER_PORT=3000
 ENV TTYD_PORT=7681
-ENV NGINX_PORT=8080
 ENV DATABASE_PATH=/data/fido.db
 ENV LOG_DIR=/var/log/fido
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=1
 
-# Health check
+# Health check uses the PORT env var (Railway overrides it at runtime)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
-
-# Expose nginx port (all services proxied through here)
-EXPOSE 8080
+    CMD curl -f http://localhost:${PORT}/health || exit 1
 
 # Use start script as entrypoint
 ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,7 +16,7 @@ http {
     }
     
     server {
-        listen 8080;
+        listen ${NGINX_PORT};
         root /var/www/html;
         
         # Health check endpoint
@@ -61,9 +61,7 @@ http {
             
             proxy_pass http://ttyd_server/ttyd/;
             
-            # Allow embedding ttyd in Firebase Hosting origins.
-            # Note: X-Frame-Options does not support multiple allowed origins.
-            add_header Content-Security-Policy "frame-ancestors 'self' https://fido-prod-ijb.web.app https://fido-prod-ijb.firebaseapp.com;" always;
+            add_header Content-Security-Policy "frame-ancestors 'self' https://fido-prod-ijb.web.app https://fido-prod-ijb.firebaseapp.com https://*.up.railway.app;" always;
         }
         
         # API routes go to fido-server (catch-all after specific routes)

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration with defaults
-# `PORT` is the externally exposed port in managed environments (Cloud Run/Fly).
+# `PORT` is the externally exposed port in managed environments (Railway/Cloud Run).
 # Keep fido-server on an internal port to avoid colliding with nginx.
 APP_PORT=${PORT:-8080}
 FIDO_SERVER_PORT=${FIDO_SERVER_PORT:-3000}
@@ -32,11 +32,11 @@ else
     FIDO_TUI_BIN="./target/release/fido"
 fi
 
-# Docker image nginx.conf proxies to 127.0.0.1:3000.
-# Prevent accidental misconfiguration from environment overrides.
-if [ "$ENV_MODE" = "docker" ] && [ "$FIDO_SERVER_PORT" != "3000" ]; then
-    echo -e "${YELLOW}Warning: forcing FIDO_SERVER_PORT=3000 in docker mode to match nginx upstream${NC}"
-    FIDO_SERVER_PORT=3000
+# Render nginx config template with runtime port values.
+if [ "$ENV_MODE" = "docker" ] && [ -f /etc/nginx/nginx.conf.template ]; then
+    export NGINX_PORT
+    envsubst '${NGINX_PORT}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+    echo -e "${GREEN}  ✓ nginx.conf rendered (listen on port $NGINX_PORT)${NC}"
 fi
 
 echo -e "${BLUE}╔══════════════════════════════════════════════╗${NC}"


### PR DESCRIPTION
## Summary
- Adds `railway.toml` for Dockerfile-based builds with health check
- Makes nginx listen port dynamic via `envsubst` templating (Railway injects `PORT` at runtime)
- Updates Docker health check to use `$PORT` instead of hardcoded 8080
- Adds `*.up.railway.app` to CSP frame-ancestors for ttyd embedding

## Deploy steps
1. Create a Railway project, link this repo
2. Set env vars: `GITHUB_CLIENT_ID`, `RUST_LOG=info`, plus any from `.env`
3. Add a volume mounted at `/data` for SQLite persistence
4. Deploy -- Railway auto-detects the Dockerfile

## Test plan
- [ ] `docker build` succeeds locally
- [ ] Container starts with `PORT=9999` and nginx listens on 9999
- [ ] `/health` returns 200
- [ ] GitHub Device Flow login works
- [ ] ttyd terminal loads at `/ttyd/`
- [ ] SQLite data persists across redeploys (volume at `/data`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)