### PR TITLE
feat: add channel chat API

### DIFF
--- a/fido-server/src/api/chat.rs
+++ b/fido-server/src/api/chat.rs
@@ -1,0 +1,247 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::HeaderMap,
+    Json,
+};
+use chrono::{Duration, Utc};
+use fido_types::{Channel, Message, SendChannelMessageRequest};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::{
+    api::{ApiError, ApiResult},
+    http::{extract_client_ip, extract_user_agent, AuthenticatedUser},
+    security::validation::validate_post_content,
+    security::{AuditEvent, AuditEventType},
+    services::chat::{ChatService, DEFAULT_MESSAGE_LIMIT},
+    state::AppState,
+};
+
+#[derive(Debug, Deserialize)]
+pub struct MessageHistoryQuery {
+    #[serde(default)]
+    before: Option<Uuid>,
+    #[serde(default)]
+    after: Option<Uuid>,
+    #[serde(default = "default_message_limit")]
+    limit: i32,
+}
+
+fn default_message_limit() -> i32 {
+    DEFAULT_MESSAGE_LIMIT
+}
+
+fn check_channel_message_rate_limit(state: &AppState, user_id: &Uuid) -> Result<(), ApiError> {
+    let last_message_at = state
+        .repos
+        .rate_limits
+        .get_last_dm_at(user_id)
+        .map_err(|e| ApiError::InternalError(e.to_string()))?;
+
+    if let Some(last_message) = last_message_at {
+        let elapsed = Utc::now().signed_duration_since(last_message);
+        let rate_limit_duration = Duration::seconds(1);
+        if elapsed < rate_limit_duration {
+            return Err(ApiError::TooManyRequests(
+                "Rate limit exceeded. Please wait 1 second before sending another message."
+                    .to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn update_channel_message_rate_limit(state: &AppState, user_id: &Uuid) -> Result<(), ApiError> {
+    state
+        .repos
+        .rate_limits
+        .update_last_dm_at(user_id, Utc::now())
+        .map_err(|e| ApiError::InternalError(e.to_string()))
+}
+
+pub async fn list_community_channels(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Path(community_id): Path<Uuid>,
+) -> ApiResult<Json<Vec<Channel>>> {
+    let service = ChatService::new(state.repos.clone(), state.event_bus.clone());
+    Ok(Json(service.list_channels(user_id, community_id)?))
+}
+
+pub async fn get_channel_messages(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Path(channel_id): Path<Uuid>,
+    Query(query): Query<MessageHistoryQuery>,
+) -> ApiResult<Json<Vec<Message>>> {
+    if query.before.is_some() && query.after.is_some() {
+        return Err(ApiError::BadRequest(
+            "before and after cursors are mutually exclusive".to_string(),
+        ));
+    }
+
+    let service = ChatService::new(state.repos.clone(), state.event_bus.clone());
+    Ok(Json(service.list_messages(
+        user_id,
+        channel_id,
+        query.before,
+        query.after,
+        query.limit,
+    )?))
+}
+
+pub async fn send_channel_message(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    headers: HeaderMap,
+    Path(channel_id): Path<Uuid>,
+    Json(payload): Json<SendChannelMessageRequest>,
+) -> ApiResult<Json<Message>> {
+    let client_ip = extract_client_ip(&headers);
+    let user_agent = extract_user_agent(&headers);
+
+    if let Err(e) = validate_post_content(&payload.content) {
+        let _ = state.audit_logger.log(
+            AuditEvent::new(AuditEventType::ValidationFailure)
+                .with_optional_ip_address(client_ip)
+                .with_optional_user_agent(user_agent)
+                .with_details(format!("Channel message validation failed: {}", e)),
+        );
+        return Err(ApiError::BadRequest(e.to_string()));
+    }
+
+    check_channel_message_rate_limit(&state, &user_id)?;
+    let service = ChatService::new(state.repos.clone(), state.event_bus.clone());
+    let message = service.send_message(user_id, channel_id, payload.content)?;
+    update_channel_message_rate_limit(&state, &user_id)?;
+
+    Ok(Json(message))
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use fido_types::{Community, Membership, MembershipRole, User};
+
+    use crate::{db::repositories::Repositories, db::Database};
+
+    fn setup_state() -> anyhow::Result<(AppState, Uuid, Uuid, Uuid)> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repos = Repositories::new(db.pool.clone());
+        let user = User {
+            id: Uuid::new_v4(),
+            username: "member".to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        };
+        repos.users.create(&user)?;
+
+        let community = Community {
+            id: Uuid::new_v4(),
+            github_repo_id: 99,
+            owner: "octocat".to_string(),
+            name: "hello".to_string(),
+            claimed_by: None,
+            require_thread_approval: false,
+            created_at: Utc::now(),
+        };
+        repos.communities.create(&community)?;
+
+        let channel = Channel {
+            id: Uuid::new_v4(),
+            community_id: community.id,
+            name: "general".to_string(),
+            created_at: Utc::now(),
+        };
+        repos.channels.create(&channel)?;
+        repos.memberships.insert(&Membership {
+            community_id: community.id,
+            user_id: user.id,
+            role: MembershipRole::Member,
+            created_at: Utc::now(),
+        })?;
+
+        let state = {
+            let _guard = crate::test_utils::env_lock().lock().unwrap();
+            std::env::set_var("FIDO_TOKEN_KEY", STANDARD.encode([8u8; 32]));
+            AppState::new_with_repos(db, repos)?
+        };
+        Ok((state, user.id, community.id, channel.id))
+    }
+
+    #[tokio::test]
+    async fn handler_sends_and_lists_channel_messages() -> anyhow::Result<()> {
+        let (state, user_id, community_id, channel_id) = setup_state()?;
+
+        let channels = list_community_channels(
+            State(state.clone()),
+            AuthenticatedUser(user_id),
+            Path(community_id),
+        )
+        .await
+        .expect("member can list channels")
+        .0;
+        assert_eq!(channels.len(), 1);
+
+        let sent = send_channel_message(
+            State(state.clone()),
+            AuthenticatedUser(user_id),
+            HeaderMap::new(),
+            Path(channel_id),
+            Json(SendChannelMessageRequest {
+                content: "hello channel".to_string(),
+            }),
+        )
+        .await
+        .expect("member can send message")
+        .0;
+        assert_eq!(sent.channel_id, channel_id);
+
+        let messages = get_channel_messages(
+            State(state),
+            AuthenticatedUser(user_id),
+            Path(channel_id),
+            Query(MessageHistoryQuery {
+                before: None,
+                after: None,
+                limit: 10,
+            }),
+        )
+        .await
+        .expect("member can list messages")
+        .0;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].content, "hello channel");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_mutually_exclusive_cursors() -> anyhow::Result<()> {
+        let (state, user_id, _community_id, channel_id) = setup_state()?;
+
+        let err = get_channel_messages(
+            State(state),
+            AuthenticatedUser(user_id),
+            Path(channel_id),
+            Query(MessageHistoryQuery {
+                before: Some(Uuid::new_v4()),
+                after: Some(Uuid::new_v4()),
+                limit: 10,
+            }),
+        )
+        .await
+        .expect_err("both cursors should be rejected");
+
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        Ok(())
+    }
+}

--- a/fido-server/src/api/mod.rs
+++ b/fido-server/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod auth;
+pub mod chat;
 pub mod communities;
 pub mod config;
 pub mod dms;

--- a/fido-server/src/db/repositories/message_repository.rs
+++ b/fido-server/src/db/repositories/message_repository.rs
@@ -35,11 +35,10 @@ impl MessageRepository {
         Ok(())
     }
 
-    /// List messages in a channel with cursor pagination on (channel_id, id).
+    /// List messages in a channel with cursor pagination on (channel_id, created_at, id).
     ///
-    /// `after` returns messages with id greater than the cursor (older-to-newer window);
-    /// `before` returns the newest messages with id less than the cursor. When neither is
-    /// supplied the newest `limit` messages are returned. Results are always ascending by id.
+    /// Cursors are message ids, but ordering is by creation time with id as a tiebreaker.
+    /// Results are returned oldest-to-newest.
     pub fn list(
         &self,
         channel_id: &Uuid,
@@ -53,11 +52,28 @@ impl MessageRepository {
         let mut messages = if let Some(after) = after {
             let mut stmt = conn.prepare(
                 "SELECT id, channel_id, author_id, content, created_at FROM messages
-                 WHERE channel_id = ? AND id > ? ORDER BY id ASC LIMIT ?",
+                 WHERE channel_id = ?
+                   AND (
+                     created_at > (SELECT created_at FROM messages WHERE id = ? AND channel_id = ?)
+                     OR (
+                       created_at = (SELECT created_at FROM messages WHERE id = ? AND channel_id = ?)
+                       AND id > ?
+                     )
+                   )
+                 ORDER BY created_at ASC, id ASC
+                 LIMIT ?",
             )?;
             let rows = stmt
                 .query_map(
-                    params![channel_id_str, after.to_string(), limit],
+                    params![
+                        channel_id_str,
+                        after.to_string(),
+                        channel_id_str,
+                        after.to_string(),
+                        channel_id_str,
+                        after.to_string(),
+                        limit
+                    ],
                     map_message_row,
                 )?
                 .collect::<Result<Vec<_>, _>>()?;
@@ -65,11 +81,28 @@ impl MessageRepository {
         } else if let Some(before) = before {
             let mut stmt = conn.prepare(
                 "SELECT id, channel_id, author_id, content, created_at FROM messages
-                 WHERE channel_id = ? AND id < ? ORDER BY id DESC LIMIT ?",
+                 WHERE channel_id = ?
+                   AND (
+                     created_at < (SELECT created_at FROM messages WHERE id = ? AND channel_id = ?)
+                     OR (
+                       created_at = (SELECT created_at FROM messages WHERE id = ? AND channel_id = ?)
+                       AND id < ?
+                     )
+                   )
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT ?",
             )?;
             let mut rows = stmt
                 .query_map(
-                    params![channel_id_str, before.to_string(), limit],
+                    params![
+                        channel_id_str,
+                        before.to_string(),
+                        channel_id_str,
+                        before.to_string(),
+                        channel_id_str,
+                        before.to_string(),
+                        limit
+                    ],
                     map_message_row,
                 )?
                 .collect::<Result<Vec<_>, _>>()?;
@@ -78,7 +111,7 @@ impl MessageRepository {
         } else {
             let mut stmt = conn.prepare(
                 "SELECT id, channel_id, author_id, content, created_at FROM messages
-                 WHERE channel_id = ? ORDER BY id DESC LIMIT ?",
+                 WHERE channel_id = ? ORDER BY created_at DESC, id DESC LIMIT ?",
             )?;
             let mut rows = stmt
                 .query_map(params![channel_id_str, limit], map_message_row)?
@@ -111,7 +144,7 @@ fn map_message_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Message> {
 mod tests {
     use super::*;
     use crate::db::Database;
-    use chrono::Utc;
+    use chrono::{TimeZone, Utc};
 
     fn setup() -> Result<(Database, Uuid, Uuid)> {
         let db = Database::in_memory()?;
@@ -145,13 +178,19 @@ mod tests {
         Ok((db, channel_id, user_id))
     }
 
-    fn make_message(channel_id: Uuid, author_id: Uuid, id: Uuid, content: &str) -> Message {
+    fn make_message(
+        channel_id: Uuid,
+        author_id: Uuid,
+        id: Uuid,
+        content: &str,
+        second: u32,
+    ) -> Message {
         Message {
             id,
             channel_id,
             author_id,
             content: content.to_string(),
-            created_at: Utc::now(),
+            created_at: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, second).unwrap(),
         }
     }
 
@@ -160,13 +199,13 @@ mod tests {
         let (db, channel_id, user_id) = setup()?;
         let repo = MessageRepository::new(db.pool.clone());
 
-        // ids chosen so ordering is deterministic
-        let a = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let b = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
-        let c = Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap();
-        repo.create(&make_message(channel_id, user_id, a, "first"))?;
-        repo.create(&make_message(channel_id, user_id, b, "second"))?;
-        repo.create(&make_message(channel_id, user_id, c, "third"))?;
+        // ids intentionally do not match chronological order
+        let a = Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap();
+        let b = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let c = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        repo.create(&make_message(channel_id, user_id, a, "first", 1))?;
+        repo.create(&make_message(channel_id, user_id, b, "second", 2))?;
+        repo.create(&make_message(channel_id, user_id, c, "third", 3))?;
 
         let all = repo.list(&channel_id, None, None, 10)?;
         assert_eq!(all.len(), 3);
@@ -180,12 +219,12 @@ mod tests {
         let (db, channel_id, user_id) = setup()?;
         let repo = MessageRepository::new(db.pool.clone());
 
-        let a = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let b = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
-        let c = Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap();
-        repo.create(&make_message(channel_id, user_id, a, "first"))?;
-        repo.create(&make_message(channel_id, user_id, b, "second"))?;
-        repo.create(&make_message(channel_id, user_id, c, "third"))?;
+        let a = Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap();
+        let b = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let c = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        repo.create(&make_message(channel_id, user_id, a, "first", 1))?;
+        repo.create(&make_message(channel_id, user_id, b, "second", 2))?;
+        repo.create(&make_message(channel_id, user_id, c, "third", 3))?;
 
         let after = repo.list(&channel_id, None, Some(&a), 10)?;
         assert_eq!(after.len(), 2);

--- a/fido-server/src/db/schema.rs
+++ b/fido-server/src/db/schema.rs
@@ -44,8 +44,8 @@ CREATE TABLE IF NOT EXISTS messages (
     FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
--- Index for cursor pagination on (channel_id, id)
-CREATE INDEX IF NOT EXISTS idx_messages_channel_id ON messages(channel_id, id);
+-- Index for cursor pagination on channel history
+CREATE INDEX IF NOT EXISTS idx_messages_channel_history ON messages(channel_id, created_at, id);
 
 -- Posts table
 CREATE TABLE IF NOT EXISTS posts (

--- a/fido-server/src/events.rs
+++ b/fido-server/src/events.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use fido_types::Message;
+
+#[derive(Debug, Clone)]
+pub enum ServerEvent {
+    MessageCreated(Message),
+}
+
+pub trait EventBus: Send + Sync {
+    fn emit(&self, event: ServerEvent) -> Result<()>;
+}
+
+#[derive(Debug, Default)]
+pub struct NoopEventBus;
+
+impl EventBus for NoopEventBus {
+    fn emit(&self, event: ServerEvent) -> Result<()> {
+        match event {
+            ServerEvent::MessageCreated(message) => {
+                let _ = message.id;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub type SharedEventBus = Arc<dyn EventBus>;

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod api;
 pub mod config;
 pub mod db;
+pub mod events;
 pub mod http;
 pub mod mention;
 pub mod oauth;
@@ -114,12 +115,20 @@ pub fn create_router(state: AppState) -> Router {
         .route("/communities", get(api::communities::list_communities))
         .route("/communities/:id", get(api::communities::get_community))
         .route(
+            "/communities/:id/channels",
+            get(api::chat::list_community_channels),
+        )
+        .route(
             "/communities/:id/claim",
             post(api::communities::claim_community),
         )
         .route(
             "/communities/:id/membership",
             delete(api::communities::leave_community),
+        )
+        .route(
+            "/channels/:id/messages",
+            get(api::chat::get_channel_messages).post(api::chat::send_channel_message),
         )
         // User routes
         .route("/users/search", get(api::friends::search_users))

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod config;
 mod db;
+mod events;
 mod http;
 mod mention;
 mod oauth;
@@ -321,12 +322,20 @@ async fn main() {
         .route("/communities", get(api::communities::list_communities))
         .route("/communities/:id", get(api::communities::get_community))
         .route(
+            "/communities/:id/channels",
+            get(api::chat::list_community_channels),
+        )
+        .route(
             "/communities/:id/claim",
             post(api::communities::claim_community),
         )
         .route(
             "/communities/:id/membership",
             delete(api::communities::leave_community),
+        )
+        .route(
+            "/channels/:id/messages",
+            get(api::chat::get_channel_messages).post(api::chat::send_channel_message),
         )
         // User routes
         .route("/users/search", get(api::friends::search_users))

--- a/fido-server/src/services/chat.rs
+++ b/fido-server/src/services/chat.rs
@@ -1,0 +1,204 @@
+//! Channel chat business logic.
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::{
+    api::{ApiError, ApiResult},
+    db::repositories::Repositories,
+    events::{ServerEvent, SharedEventBus},
+};
+use fido_types::{Channel, Message};
+
+pub const DEFAULT_MESSAGE_LIMIT: i32 = 50;
+pub const MAX_MESSAGE_LIMIT: i32 = 100;
+
+pub struct ChatService {
+    repos: Repositories,
+    event_bus: SharedEventBus,
+}
+
+impl ChatService {
+    pub fn new(repos: Repositories, event_bus: SharedEventBus) -> Self {
+        Self { repos, event_bus }
+    }
+
+    pub fn list_channels(&self, user_id: Uuid, community_id: Uuid) -> ApiResult<Vec<Channel>> {
+        self.repos
+            .communities
+            .get_by_id(&community_id)?
+            .ok_or_else(|| ApiError::NotFound("Community not found".to_string()))?;
+        self.require_membership(user_id, community_id)?;
+        Ok(self.repos.channels.list_by_community(&community_id)?)
+    }
+
+    pub fn list_messages(
+        &self,
+        user_id: Uuid,
+        channel_id: Uuid,
+        before: Option<Uuid>,
+        after: Option<Uuid>,
+        limit: i32,
+    ) -> ApiResult<Vec<Message>> {
+        let channel = self.require_channel(channel_id)?;
+        self.require_membership(user_id, channel.community_id)?;
+        let limit = normalize_limit(limit)?;
+        Ok(self
+            .repos
+            .messages
+            .list(&channel_id, before.as_ref(), after.as_ref(), limit)?)
+    }
+
+    pub fn send_message(
+        &self,
+        user_id: Uuid,
+        channel_id: Uuid,
+        content: String,
+    ) -> ApiResult<Message> {
+        let channel = self.require_channel(channel_id)?;
+        self.require_membership(user_id, channel.community_id)?;
+
+        let message = Message {
+            id: Uuid::new_v4(),
+            channel_id,
+            author_id: user_id,
+            content,
+            created_at: Utc::now(),
+        };
+        self.repos.messages.create(&message)?;
+        self.event_bus
+            .emit(ServerEvent::MessageCreated(message.clone()))?;
+
+        Ok(message)
+    }
+
+    fn require_channel(&self, channel_id: Uuid) -> ApiResult<Channel> {
+        self.repos
+            .channels
+            .get_by_id(&channel_id)?
+            .ok_or_else(|| ApiError::NotFound("Channel not found".to_string()))
+    }
+
+    fn require_membership(&self, user_id: Uuid, community_id: Uuid) -> ApiResult<()> {
+        self.repos
+            .memberships
+            .get(&community_id, &user_id)?
+            .ok_or_else(|| ApiError::Forbidden("Community membership required".to_string()))?;
+        Ok(())
+    }
+}
+
+pub fn normalize_limit(limit: i32) -> ApiResult<i32> {
+    if !(1..=MAX_MESSAGE_LIMIT).contains(&limit) {
+        return Err(ApiError::BadRequest(format!(
+            "limit must be between 1 and {}",
+            MAX_MESSAGE_LIMIT
+        )));
+    }
+    Ok(limit)
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use crate::{
+        db::Database,
+        events::{EventBus, ServerEvent},
+    };
+    use anyhow::Result;
+    use fido_types::{Community, Membership, MembershipRole, User};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct RecordingEventBus {
+        events: Mutex<Vec<ServerEvent>>,
+    }
+
+    impl EventBus for RecordingEventBus {
+        fn emit(&self, event: ServerEvent) -> Result<()> {
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    fn setup() -> Result<(
+        Database,
+        Repositories,
+        Arc<RecordingEventBus>,
+        Uuid,
+        Uuid,
+        Uuid,
+    )> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repos = Repositories::new(db.pool.clone());
+        let user = User {
+            id: Uuid::new_v4(),
+            username: "member".to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        };
+        repos.users.create(&user)?;
+
+        let community = Community {
+            id: Uuid::new_v4(),
+            github_repo_id: 42,
+            owner: "octocat".to_string(),
+            name: "hello".to_string(),
+            claimed_by: None,
+            require_thread_approval: false,
+            created_at: Utc::now(),
+        };
+        repos.communities.create(&community)?;
+
+        let channel = Channel {
+            id: Uuid::new_v4(),
+            community_id: community.id,
+            name: "general".to_string(),
+            created_at: Utc::now(),
+        };
+        repos.channels.create(&channel)?;
+        repos.memberships.insert(&Membership {
+            community_id: community.id,
+            user_id: user.id,
+            role: MembershipRole::Member,
+            created_at: Utc::now(),
+        })?;
+
+        let event_bus = Arc::new(RecordingEventBus::default());
+        Ok((db, repos, event_bus, user.id, community.id, channel.id))
+    }
+
+    #[test]
+    fn send_message_persists_and_emits_event() -> Result<()> {
+        let (_db, repos, event_bus, user_id, _community_id, channel_id) = setup()?;
+        let service = ChatService::new(repos.clone(), event_bus.clone());
+
+        let message = service
+            .send_message(user_id, channel_id, "hello channel".to_string())
+            .expect("member can send message");
+
+        let messages = repos.messages.list(&channel_id, None, None, 10)?;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].id, message.id);
+
+        let events = event_bus.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ServerEvent::MessageCreated(created) => assert_eq!(created.id, message.id),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_non_member_send() -> Result<()> {
+        let (_db, repos, event_bus, _user_id, _community_id, channel_id) = setup()?;
+        let service = ChatService::new(repos, event_bus);
+
+        let result = service.send_message(Uuid::new_v4(), channel_id, "nope".to_string());
+        assert!(matches!(result, Err(ApiError::Forbidden(_))));
+        Ok(())
+    }
+}

--- a/fido-server/src/services/mod.rs
+++ b/fido-server/src/services/mod.rs
@@ -1,5 +1,6 @@
 //! Service layer for business logic.
 
+pub mod chat;
 pub mod communities;
 pub mod dms;
 pub mod friends;

--- a/fido-server/src/state.rs
+++ b/fido-server/src/state.rs
@@ -1,9 +1,11 @@
 use crate::db::repositories::Repositories;
 use crate::db::Database;
+use crate::events::{NoopEventBus, SharedEventBus};
 use crate::security::AuditLogger;
 use crate::services::github::GithubService;
 use crate::session::SessionManager;
 use anyhow::Result;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -13,6 +15,7 @@ pub struct AppState {
     pub session_manager: SessionManager,
     pub audit_logger: AuditLogger,
     pub github_service: GithubService,
+    pub event_bus: SharedEventBus,
 }
 
 impl AppState {
@@ -26,12 +29,14 @@ impl AppState {
         let session_manager = SessionManager::new(repos.sessions.clone());
         let audit_logger = AuditLogger::new(repos.audit.clone());
         let github_service = GithubService::from_env(repos.clone())?;
+        let event_bus = Arc::new(NoopEventBus);
         Ok(Self {
             db,
             repos,
             session_manager,
             audit_logger,
             github_service,
+            event_bus,
         })
     }
 

--- a/fido-types/src/models.rs
+++ b/fido-types/src/models.rs
@@ -244,6 +244,11 @@ pub struct SendMessageRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct SendChannelMessageRequest {
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateBioRequest {
     pub bio: String,
 }


### PR DESCRIPTION
Implements stint 0006.\n\nSummary:\n- Adds channel-scoped message history/send endpoints and community channel listing.\n- Gates chat reads/sends by community membership and validates message content through existing post validation.\n- Adds a no-op event bus surface and emits MessageCreated for new channel messages.\n- Fixes message repository pagination to use cursor message created_at/id ordering instead of random UUID ordering.\n\nValidation:\n- cargo test -p fido-server --features sqlite-tests\n- cargo check --workspace\n\nNote:\n- stint check currently fails on an unrelated planning graph issue: task 0018 references missing blocker 0017.