### PR TITLE
feat: scope threads board API by community

### DIFF
--- a/fido-server/src/api/posts.rs
+++ b/fido-server/src/api/posts.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::{
     api::{ApiError, ApiResult},
-    http::{extract_client_ip, extract_user_agent, AuthenticatedUser, OptionalUser},
+    http::{extract_client_ip, extract_user_agent, AuthenticatedUser},
     security::validation::validate_post_content,
     security::{AuditEvent, AuditEventType},
     services::posts::PostService,
@@ -57,12 +57,19 @@ fn update_post_rate_limit(state: &AppState, user_id: &Uuid) -> Result<(), ApiErr
 
 #[derive(Deserialize)]
 pub struct GetPostsQuery {
+    community_id: Uuid,
     #[serde(default = "default_limit")]
     limit: i32,
     #[serde(default)]
     sort: Option<String>,
     #[serde(default)]
     username: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct PendingPostsQuery {
+    #[serde(default = "default_limit")]
+    limit: i32,
 }
 
 fn default_limit() -> i32 {
@@ -72,10 +79,10 @@ fn default_limit() -> i32 {
 /// GET /posts - Get posts with sorting and limit (optionally filtered by username)
 pub async fn get_posts(
     State(state): State<AppState>,
-    OptionalUser(user_id): OptionalUser,
+    AuthenticatedUser(user_id): AuthenticatedUser,
     Query(query): Query<GetPostsQuery>,
 ) -> ApiResult<Json<Vec<Post>>> {
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
 
     // Parse and validate sort order - reject invalid values
     let sort_order = if let Some(sort_str) = query.sort.as_deref() {
@@ -89,9 +96,30 @@ pub async fn get_posts(
         SortOrder::Newest
     };
 
-    let posts = service.get_posts(sort_order, query.limit, query.username.as_deref(), user_id)?;
+    let posts = service.get_posts(
+        query.community_id,
+        sort_order,
+        query.limit,
+        query.username.as_deref(),
+        user_id,
+    )?;
 
     Ok(Json(posts))
+}
+
+/// GET /communities/:id/posts/pending - Get pending threads awaiting approval.
+pub async fn get_pending_posts(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Path(community_id): Path<Uuid>,
+    Query(query): Query<PendingPostsQuery>,
+) -> ApiResult<Json<Vec<Post>>> {
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
+    Ok(Json(service.get_pending_posts(
+        community_id,
+        user_id,
+        query.limit,
+    )?))
 }
 
 /// POST /posts - Create a new post
@@ -101,7 +129,7 @@ pub async fn create_post(
     headers: HeaderMap,
     Json(payload): Json<CreatePostRequest>,
 ) -> ApiResult<Json<Post>> {
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
     let client_ip = extract_client_ip(&headers);
     let user_agent = extract_user_agent(&headers);
 
@@ -124,6 +152,12 @@ pub async fn create_post(
     let author = service.get_user_by_id(&author_id)?;
 
     // Create post
+    let community = state
+        .repos
+        .communities
+        .get_by_id(&payload.community_id)?
+        .ok_or_else(|| ApiError::NotFound("Community not found".to_string()))?;
+
     let post = Post {
         id: Uuid::new_v4(),
         author_id,
@@ -133,7 +167,7 @@ pub async fn create_post(
         created_at: Utc::now(),
         upvotes: 0,
         downvotes: 0,
-        approved: true,
+        approved: !community.require_thread_approval,
         hashtags: Vec::new(),
         user_vote: None,        // New posts have no votes yet
         parent_post_id: None,   // Top-level post
@@ -158,7 +192,7 @@ pub async fn vote_on_post(
     Path(post_id): Path<String>,
     Json(payload): Json<VoteRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
     // Parse post ID
     let post_id = Uuid::parse_str(&post_id)
         .map_err(|_| ApiError::BadRequest("Invalid post ID".to_string()))?;
@@ -181,13 +215,13 @@ pub async fn vote_on_post(
 pub async fn get_replies(
     State(state): State<AppState>,
     Path(post_id): Path<String>,
-    OptionalUser(user_id): OptionalUser,
+    AuthenticatedUser(user_id): AuthenticatedUser,
 ) -> ApiResult<Json<Vec<Post>>> {
     // Parse post ID
     let post_id = Uuid::parse_str(&post_id)
         .map_err(|_| ApiError::BadRequest("Invalid post ID".to_string()))?;
 
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
     let replies = service.get_replies(&post_id, user_id)?;
 
     Ok(Json(replies))
@@ -201,7 +235,7 @@ pub async fn create_reply(
     headers: HeaderMap,
     Json(payload): Json<fido_types::CreateReplyRequest>,
 ) -> ApiResult<Json<Post>> {
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
     let client_ip = extract_client_ip(&headers);
     let user_agent = extract_user_agent(&headers);
 
@@ -225,7 +259,7 @@ pub async fn create_reply(
     check_post_rate_limit(&state, &author_id)?;
 
     // Get the post being replied to
-    let target_post = service.get_post(&parent_post_id, None)?;
+    let target_post = service.get_post(&parent_post_id, author_id)?;
 
     // Use the actual parent_post_id for true nested replies
     let actual_parent_id = parent_post_id;
@@ -288,7 +322,7 @@ pub async fn update_post(
     headers: HeaderMap,
     Json(payload): Json<fido_types::UpdatePostRequest>,
 ) -> ApiResult<Json<Post>> {
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
     let client_ip = extract_client_ip(&headers);
     let user_agent = extract_user_agent(&headers);
 
@@ -312,7 +346,7 @@ pub async fn update_post(
     service.verify_ownership(&user_id, &post_id)?;
 
     // Get existing post
-    let mut post = service.get_post(&post_id, None)?;
+    let mut post = service.get_post(&post_id, user_id)?;
 
     // Update content
     post.content = payload.content.clone();
@@ -329,7 +363,7 @@ pub async fn delete_post(
     AuthenticatedUser(user_id): AuthenticatedUser,
     Path(post_id): Path<String>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
     // Parse post ID
     let post_id = Uuid::parse_str(&post_id)
         .map_err(|_| ApiError::BadRequest("Invalid post ID".to_string()))?;
@@ -338,7 +372,7 @@ pub async fn delete_post(
     service.verify_ownership(&user_id, &post_id)?;
 
     // Check if post exists
-    let _ = service.get_post(&post_id, None)?;
+    let _ = service.get_post(&post_id, user_id)?;
 
     // Delete post (cascade will handle replies and votes)
     service.delete_post(&post_id)?;
@@ -354,13 +388,13 @@ pub async fn delete_post(
 pub async fn get_post(
     State(state): State<AppState>,
     Path(post_id): Path<String>,
-    OptionalUser(user_id): OptionalUser,
+    AuthenticatedUser(user_id): AuthenticatedUser,
 ) -> ApiResult<Json<Post>> {
     // Parse post ID
     let post_id = Uuid::parse_str(&post_id)
         .map_err(|_| ApiError::BadRequest("Invalid post ID".to_string()))?;
 
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
     let post = service.get_post(&post_id, user_id)?;
 
     Ok(Json(post))
@@ -370,13 +404,13 @@ pub async fn get_post(
 pub async fn get_thread(
     State(state): State<AppState>,
     Path(post_id): Path<String>,
-    OptionalUser(user_id): OptionalUser,
+    AuthenticatedUser(user_id): AuthenticatedUser,
 ) -> ApiResult<Json<serde_json::Value>> {
     // Parse post ID
     let post_id = Uuid::parse_str(&post_id)
         .map_err(|_| ApiError::BadRequest("Invalid post ID".to_string()))?;
 
-    let service = PostService::new(state.repos.clone());
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
     let (root_post, replies) = service.get_thread_parts(&post_id, user_id)?;
 
     // Return root post with all replies
@@ -384,4 +418,257 @@ pub async fn get_thread(
         "post": root_post,
         "replies": replies
     })))
+}
+
+/// POST /posts/:id/approve - Approve a pending top-level thread.
+pub async fn approve_post(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Path(post_id): Path<String>,
+) -> ApiResult<Json<Post>> {
+    let post_id = Uuid::parse_str(&post_id)
+        .map_err(|_| ApiError::BadRequest("Invalid post ID".to_string()))?;
+
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
+    Ok(Json(service.approve_post(user_id, &post_id)?))
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use fido_types::{Community, Membership, MembershipRole, User};
+
+    use crate::{db::repositories::Repositories, db::Database};
+
+    fn test_user(username: &str) -> User {
+        User {
+            id: Uuid::new_v4(),
+            username: username.to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        }
+    }
+
+    fn setup_state() -> anyhow::Result<(AppState, Uuid, Uuid, Uuid)> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repos = Repositories::new(db.pool.clone());
+
+        let admin = test_user("admin");
+        let member = test_user("member");
+        repos.users.create(&admin)?;
+        repos.users.create(&member)?;
+
+        let community = Community {
+            id: Uuid::new_v4(),
+            github_repo_id: 7007,
+            owner: "octocat".to_string(),
+            name: "threads".to_string(),
+            claimed_by: Some(admin.id),
+            require_thread_approval: true,
+            created_at: Utc::now(),
+        };
+        repos.communities.create(&community)?;
+        repos.memberships.insert(&Membership {
+            community_id: community.id,
+            user_id: admin.id,
+            role: MembershipRole::Admin,
+            created_at: Utc::now(),
+        })?;
+        repos.memberships.insert(&Membership {
+            community_id: community.id,
+            user_id: member.id,
+            role: MembershipRole::Member,
+            created_at: Utc::now(),
+        })?;
+
+        let state = {
+            let _guard = crate::test_utils::env_lock().lock().unwrap();
+            std::env::set_var("FIDO_TOKEN_KEY", STANDARD.encode([7u8; 32]));
+            AppState::new_with_repos(db, repos)?
+        };
+
+        Ok((state, admin.id, member.id, community.id))
+    }
+
+    #[tokio::test]
+    async fn approval_required_thread_is_pending_until_admin_approves() -> anyhow::Result<()> {
+        let (state, admin_id, member_id, community_id) = setup_state()?;
+
+        let created = create_post(
+            State(state.clone()),
+            AuthenticatedUser(member_id),
+            HeaderMap::new(),
+            Json(CreatePostRequest {
+                community_id,
+                content: "needs review".to_string(),
+            }),
+        )
+        .await
+        .expect("member can create pending thread")
+        .0;
+        assert!(!created.approved);
+
+        let visible = get_posts(
+            State(state.clone()),
+            AuthenticatedUser(member_id),
+            Query(GetPostsQuery {
+                community_id,
+                limit: 10,
+                sort: None,
+                username: None,
+            }),
+        )
+        .await
+        .expect("member can list approved feed")
+        .0;
+        assert!(visible.is_empty());
+
+        let pending = get_pending_posts(
+            State(state.clone()),
+            AuthenticatedUser(admin_id),
+            Path(community_id),
+            Query(PendingPostsQuery { limit: 10 }),
+        )
+        .await
+        .expect("admin can list pending threads")
+        .0;
+        assert_eq!(pending[0].id, created.id);
+
+        let approved = approve_post(
+            State(state.clone()),
+            AuthenticatedUser(admin_id),
+            Path(created.id.to_string()),
+        )
+        .await
+        .expect("admin can approve")
+        .0;
+        assert!(approved.approved);
+
+        let visible = get_posts(
+            State(state),
+            AuthenticatedUser(member_id),
+            Query(GetPostsQuery {
+                community_id,
+                limit: 10,
+                sort: None,
+                username: None,
+            }),
+        )
+        .await
+        .expect("approved thread appears in feed")
+        .0;
+        assert_eq!(visible[0].id, created.id);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_list_or_approve_pending_threads() -> anyhow::Result<()> {
+        let (state, _admin_id, member_id, community_id) = setup_state()?;
+
+        let created = create_post(
+            State(state.clone()),
+            AuthenticatedUser(member_id),
+            HeaderMap::new(),
+            Json(CreatePostRequest {
+                community_id,
+                content: "member pending".to_string(),
+            }),
+        )
+        .await
+        .expect("member can create pending thread")
+        .0;
+
+        let pending_err = get_pending_posts(
+            State(state.clone()),
+            AuthenticatedUser(member_id),
+            Path(community_id),
+            Query(PendingPostsQuery { limit: 10 }),
+        )
+        .await
+        .expect_err("member cannot list pending threads");
+        assert_eq!(pending_err.into_response().status(), StatusCode::FORBIDDEN);
+
+        let approve_err = approve_post(
+            State(state),
+            AuthenticatedUser(member_id),
+            Path(created.id.to_string()),
+        )
+        .await
+        .expect_err("member cannot approve pending thread");
+        assert_eq!(approve_err.into_response().status(), StatusCode::FORBIDDEN);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn approved_feed_is_scoped_to_requested_community() -> anyhow::Result<()> {
+        let (state, _admin_id, member_id, community_id) = setup_state()?;
+        let other_community = Community {
+            id: Uuid::new_v4(),
+            github_repo_id: 7008,
+            owner: "octocat".to_string(),
+            name: "other".to_string(),
+            claimed_by: None,
+            require_thread_approval: false,
+            created_at: Utc::now(),
+        };
+        state.repos.communities.create(&other_community)?;
+        state.repos.memberships.insert(&Membership {
+            community_id: other_community.id,
+            user_id: member_id,
+            role: MembershipRole::Member,
+            created_at: Utc::now(),
+        })?;
+
+        let requested_post = Post {
+            id: Uuid::new_v4(),
+            author_id: member_id,
+            author_username: "member".to_string(),
+            community_id,
+            content: "requested board".to_string(),
+            created_at: Utc::now(),
+            upvotes: 0,
+            downvotes: 0,
+            approved: true,
+            hashtags: Vec::new(),
+            user_vote: None,
+            parent_post_id: None,
+            reply_count: 0,
+            reply_to_user_id: None,
+            reply_to_username: None,
+        };
+        let other_post = Post {
+            id: Uuid::new_v4(),
+            community_id: other_community.id,
+            content: "other board".to_string(),
+            ..requested_post.clone()
+        };
+        state.repos.posts.create(&requested_post)?;
+        state.repos.posts.create(&other_post)?;
+
+        let visible = get_posts(
+            State(state),
+            AuthenticatedUser(member_id),
+            Query(GetPostsQuery {
+                community_id,
+                limit: 10,
+                sort: None,
+                username: None,
+            }),
+        )
+        .await
+        .expect("member can list requested community")
+        .0;
+
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].id, requested_post.id);
+        Ok(())
+    }
 }

--- a/fido-server/src/db/repositories/post_repository.rs
+++ b/fido-server/src/db/repositories/post_repository.rs
@@ -66,7 +66,12 @@ impl PostRepository {
     /// - Each enum value maps to a hardcoded SQL clause
     /// - The API layer validates sort order before calling this method
     /// - All other parameters (limit) use parameterized queries
-    pub fn get_posts(&self, sort_order: SortOrder, limit: i32) -> Result<Vec<Post>> {
+    pub fn get_posts(
+        &self,
+        community_id: &Uuid,
+        sort_order: SortOrder,
+        limit: i32,
+    ) -> Result<Vec<Post>> {
         let conn = self.pool.get()?;
 
         // Safe: order_clause is built from whitelisted enum values only
@@ -85,7 +90,7 @@ impl PostRepository {
              FROM posts p
              JOIN users u ON p.author_id = u.id
              LEFT JOIN users u2 ON p.reply_to_user_id = u2.id
-             WHERE p.parent_post_id IS NULL
+             WHERE p.community_id = ? AND p.parent_post_id IS NULL AND p.approved = 1
              {}
              LIMIT ?",
             order_clause
@@ -94,7 +99,29 @@ impl PostRepository {
         let mut stmt = conn.prepare(&query)?;
 
         let posts = stmt
-            .query_map([limit], map_post_row)?
+            .query_map(params![community_id.to_string(), limit], map_post_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(posts)
+    }
+
+    /// Get pending top-level posts for admin approval.
+    pub fn get_pending_posts(&self, community_id: &Uuid, limit: i32) -> Result<Vec<Post>> {
+        let conn = self.pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT p.id, p.author_id, u.username, p.content, p.created_at, p.upvotes, p.downvotes, p.parent_post_id,
+                    (SELECT COUNT(*) FROM posts WHERE parent_post_id = p.id) as reply_count,
+                    p.reply_to_user_id, u2.username as reply_to_username, p.community_id, p.approved
+             FROM posts p
+             JOIN users u ON p.author_id = u.id
+             LEFT JOIN users u2 ON p.reply_to_user_id = u2.id
+             WHERE p.community_id = ? AND p.parent_post_id IS NULL AND p.approved = 0
+             ORDER BY p.created_at ASC
+             LIMIT ?",
+        )?;
+
+        let posts = stmt
+            .query_map(params![community_id.to_string(), limit], map_post_row)?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(posts)
@@ -160,6 +187,17 @@ impl PostRepository {
         )
         .context("Failed to update vote counts")?;
 
+        Ok(())
+    }
+
+    /// Mark a top-level thread as approved.
+    pub fn approve(&self, post_id: &Uuid) -> Result<()> {
+        let conn = self.pool.get()?;
+        conn.execute(
+            "UPDATE posts SET approved = 1 WHERE id = ? AND parent_post_id IS NULL",
+            [post_id.to_string()],
+        )
+        .context("Failed to approve post")?;
         Ok(())
     }
 
@@ -235,6 +273,7 @@ impl PostRepository {
     /// - All other parameters (username, limit) use parameterized queries
     pub fn get_posts_by_username(
         &self,
+        community_id: &Uuid,
         username: &str,
         sort_order: SortOrder,
         limit: i32,
@@ -257,7 +296,7 @@ impl PostRepository {
              FROM posts p
              JOIN users u ON p.author_id = u.id
              LEFT JOIN users u2 ON p.reply_to_user_id = u2.id
-             WHERE LOWER(u.username) = LOWER(?) AND p.parent_post_id IS NULL
+             WHERE p.community_id = ? AND LOWER(u.username) = LOWER(?) AND p.parent_post_id IS NULL AND p.approved = 1
              {}
              LIMIT ?",
             order_clause
@@ -266,7 +305,10 @@ impl PostRepository {
         let mut stmt = conn.prepare(&query)?;
 
         let posts = stmt
-            .query_map(params![username, limit], map_post_row)?
+            .query_map(
+                params![community_id.to_string(), username, limit],
+                map_post_row,
+            )?
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(posts)

--- a/fido-server/src/events.rs
+++ b/fido-server/src/events.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use fido_types::Message;
+use fido_types::{Message, Post};
 
 #[derive(Debug, Clone)]
 pub enum ServerEvent {
     MessageCreated(Message),
+    ThreadCreated(Post),
+    ThreadPendingApproval(Post),
 }
 
 pub trait EventBus: Send + Sync {
@@ -20,6 +22,9 @@ impl EventBus for NoopEventBus {
         match event {
             ServerEvent::MessageCreated(message) => {
                 let _ = message.id;
+            }
+            ServerEvent::ThreadCreated(post) | ServerEvent::ThreadPendingApproval(post) => {
+                let _ = post.id;
             }
         }
         Ok(())

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -78,6 +78,7 @@ pub fn create_router(state: AppState) -> Router {
         // Post routes
         .route("/posts", get(api::posts::get_posts))
         .route("/posts", post(api::posts::create_post))
+        .route("/posts/:id/approve", post(api::posts::approve_post))
         .route("/posts/:id/vote", post(api::posts::vote_on_post))
         .route("/posts/:id/replies", get(api::posts::get_replies))
         .route("/posts/:id/reply", post(api::posts::create_reply))
@@ -117,6 +118,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/communities/:id/channels",
             get(api::chat::list_community_channels),
+        )
+        .route(
+            "/communities/:id/posts/pending",
+            get(api::posts::get_pending_posts),
         )
         .route(
             "/communities/:id/claim",

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -285,6 +285,7 @@ async fn main() {
         // Post routes
         .route("/posts", get(api::posts::get_posts))
         .route("/posts", post(api::posts::create_post))
+        .route("/posts/:id/approve", post(api::posts::approve_post))
         .route("/posts/:id/vote", post(api::posts::vote_on_post))
         .route("/posts/:id/replies", get(api::posts::get_replies))
         .route("/posts/:id/reply", post(api::posts::create_reply))
@@ -324,6 +325,10 @@ async fn main() {
         .route(
             "/communities/:id/channels",
             get(api::chat::list_community_channels),
+        )
+        .route(
+            "/communities/:id/posts/pending",
+            get(api::posts::get_pending_posts),
         )
         .route(
             "/communities/:id/claim",

--- a/fido-server/src/services/chat.rs
+++ b/fido-server/src/services/chat.rs
@@ -188,6 +188,9 @@ mod tests {
         assert_eq!(events.len(), 1);
         match &events[0] {
             ServerEvent::MessageCreated(created) => assert_eq!(created.id, message.id),
+            ServerEvent::ThreadCreated(_) | ServerEvent::ThreadPendingApproval(_) => {
+                panic!("expected message event")
+            }
         }
         Ok(())
     }

--- a/fido-server/src/services/posts.rs
+++ b/fido-server/src/services/posts.rs
@@ -2,77 +2,99 @@
 
 use uuid::Uuid;
 
-use crate::api::{ApiError, ApiResult};
-use crate::db::repositories::Repositories;
-use fido_types::{Post, SortOrder, User, VoteDirection};
+use crate::{
+    api::{ApiError, ApiResult},
+    db::repositories::Repositories,
+    events::{ServerEvent, SharedEventBus},
+};
+use fido_types::{MembershipRole, Post, SortOrder, User, VoteDirection};
 
 pub struct PostService {
     repos: Repositories,
+    event_bus: SharedEventBus,
 }
 
 impl PostService {
-    pub fn new(repos: Repositories) -> Self {
-        Self { repos }
+    pub fn new(repos: Repositories, event_bus: SharedEventBus) -> Self {
+        Self { repos, event_bus }
     }
 
     pub fn get_posts(
         &self,
+        community_id: Uuid,
         sort_order: SortOrder,
         limit: i32,
         username: Option<&str>,
-        user_id: Option<Uuid>,
+        user_id: Uuid,
     ) -> ApiResult<Vec<Post>> {
+        self.require_membership(user_id, community_id)?;
         let mut posts = match username {
-            Some(user) => self
+            Some(user) => {
+                self.repos
+                    .posts
+                    .get_posts_by_username(&community_id, user, sort_order, limit)?
+            }
+            None => self
                 .repos
                 .posts
-                .get_posts_by_username(user, sort_order, limit)?,
-            None => self.repos.posts.get_posts(sort_order, limit)?,
+                .get_posts(&community_id, sort_order, limit)?,
         };
 
-        self.populate_posts(&mut posts, user_id)?;
+        self.populate_posts(&mut posts, Some(user_id))?;
 
         Ok(posts)
     }
 
-    pub fn get_replies(&self, post_id: &Uuid, user_id: Option<Uuid>) -> ApiResult<Vec<Post>> {
-        self.repos
+    pub fn get_pending_posts(
+        &self,
+        community_id: Uuid,
+        user_id: Uuid,
+        limit: i32,
+    ) -> ApiResult<Vec<Post>> {
+        self.require_admin(user_id, community_id)?;
+        let mut posts = self.repos.posts.get_pending_posts(&community_id, limit)?;
+        self.populate_posts(&mut posts, Some(user_id))?;
+        Ok(posts)
+    }
+
+    pub fn get_replies(&self, post_id: &Uuid, user_id: Uuid) -> ApiResult<Vec<Post>> {
+        let parent = self
+            .repos
             .posts
             .get_by_id(post_id)?
             .ok_or_else(|| ApiError::NotFound("Post not found".to_string()))?;
+        self.ensure_visible(&parent, user_id)?;
 
         let mut replies = self.repos.posts.get_replies(post_id)?;
-        self.populate_posts(&mut replies, user_id)?;
+        self.populate_posts(&mut replies, Some(user_id))?;
 
         Ok(replies)
     }
 
-    pub fn get_post(&self, post_id: &Uuid, user_id: Option<Uuid>) -> ApiResult<Post> {
+    pub fn get_post(&self, post_id: &Uuid, user_id: Uuid) -> ApiResult<Post> {
         let mut post = self
             .repos
             .posts
             .get_by_id(post_id)?
             .ok_or_else(|| ApiError::NotFound("Post not found".to_string()))?;
 
-        self.populate_post(&mut post, user_id)?;
+        self.ensure_visible(&post, user_id)?;
+        self.populate_post(&mut post, Some(user_id))?;
 
         Ok(post)
     }
 
-    pub fn get_thread_parts(
-        &self,
-        post_id: &Uuid,
-        user_id: Option<Uuid>,
-    ) -> ApiResult<(Post, Vec<Post>)> {
+    pub fn get_thread_parts(&self, post_id: &Uuid, user_id: Uuid) -> ApiResult<(Post, Vec<Post>)> {
         let mut root_post = self
             .repos
             .posts
             .get_by_id(post_id)?
             .ok_or_else(|| ApiError::NotFound("Post not found".to_string()))?;
-        self.populate_post(&mut root_post, user_id)?;
+        self.ensure_visible(&root_post, user_id)?;
+        self.populate_post(&mut root_post, Some(user_id))?;
 
         let mut replies = self.repos.posts.get_replies(post_id)?;
-        self.populate_posts(&mut replies, user_id)?;
+        self.populate_posts(&mut replies, Some(user_id))?;
 
         Ok((root_post, replies))
     }
@@ -85,7 +107,16 @@ impl PostService {
     }
 
     pub fn create_post(&self, post: &Post) -> ApiResult<()> {
+        self.require_membership(post.author_id, post.community_id)?;
         self.repos.posts.create(post)?;
+        if post.parent_post_id.is_none() {
+            let event = if post.approved {
+                ServerEvent::ThreadCreated(post.clone())
+            } else {
+                ServerEvent::ThreadPendingApproval(post.clone())
+            };
+            self.event_bus.emit(event)?;
+        }
         Ok(())
     }
 
@@ -105,15 +136,35 @@ impl PostService {
         post_id: &Uuid,
         direction: VoteDirection,
     ) -> ApiResult<()> {
-        self.repos
+        let post = self
+            .repos
             .posts
             .get_by_id(post_id)?
             .ok_or_else(|| ApiError::NotFound("Post not found".to_string()))?;
+        self.ensure_visible(&post, *user_id)?;
 
         self.repos.votes.upsert_vote(user_id, post_id, direction)?;
         self.repos.posts.update_vote_counts(post_id)?;
 
         Ok(())
+    }
+
+    pub fn approve_post(&self, user_id: Uuid, post_id: &Uuid) -> ApiResult<Post> {
+        let mut post = self
+            .repos
+            .posts
+            .get_by_id(post_id)?
+            .ok_or_else(|| ApiError::NotFound("Post not found".to_string()))?;
+        if post.parent_post_id.is_some() {
+            return Err(ApiError::BadRequest(
+                "Replies do not require approval".to_string(),
+            ));
+        }
+        self.require_admin(user_id, post.community_id)?;
+        self.repos.posts.approve(post_id)?;
+        post.approved = true;
+        self.populate_post(&mut post, Some(user_id))?;
+        Ok(post)
     }
 
     pub fn verify_ownership(&self, user_id: &Uuid, post_id: &Uuid) -> ApiResult<()> {
@@ -146,6 +197,36 @@ impl PostService {
             }
         }
 
+        Ok(())
+    }
+
+    fn ensure_visible(&self, post: &Post, user_id: Uuid) -> ApiResult<()> {
+        self.require_membership(user_id, post.community_id)?;
+        if !post.approved && post.parent_post_id.is_none() {
+            self.require_admin(user_id, post.community_id)?;
+        }
+        Ok(())
+    }
+
+    fn require_membership(&self, user_id: Uuid, community_id: Uuid) -> ApiResult<()> {
+        self.repos
+            .memberships
+            .get(&community_id, &user_id)?
+            .ok_or_else(|| ApiError::Forbidden("Community membership required".to_string()))?;
+        Ok(())
+    }
+
+    fn require_admin(&self, user_id: Uuid, community_id: Uuid) -> ApiResult<()> {
+        let membership = self
+            .repos
+            .memberships
+            .get(&community_id, &user_id)?
+            .ok_or_else(|| ApiError::Forbidden("Community membership required".to_string()))?;
+        if membership.role != MembershipRole::Admin {
+            return Err(ApiError::Forbidden(
+                "Community admin role required".to_string(),
+            ));
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- require authenticated community membership for post feeds, single post/thread/replies, votes, updates, deletes, and replies
- scope approved top-level feed queries by community and add admin-only pending thread queue
- add admin approval endpoint and emit no-op thread lifecycle events
- cover approval flow, non-admin rejection, and community feed isolation with sqlite-backed tests

## Validation
- cargo test -p fido-server --features sqlite-tests
- cargo check
- cargo clippy -p fido-server --lib --features sqlite-tests -- -D warnings

Note: cargo clippy --all-targets --all-features -- -D warnings is blocked by pre-existing placeholder assert!(true) calls in fido-server/tests/hashtag_integration_tests.rs.