### PR TITLE
Enforce DM message requests

### DIFF
--- a/fido-server/src/api/dms.rs
+++ b/fido-server/src/api/dms.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::{
     api::{ApiError, ApiResult},
     http::AuthenticatedUser,
-    services::dms::{ConversationSummary, DMService},
+    services::dms::{ConversationSummary, DMService, DmRequestSummary},
     state::AppState,
 };
 use fido_types::{DirectMessage, SendMessageRequest};
@@ -52,7 +52,7 @@ pub async fn get_conversations(
     State(state): State<AppState>,
     AuthenticatedUser(user_id): AuthenticatedUser,
 ) -> ApiResult<Json<Vec<ConversationSummary>>> {
-    let service = DMService::new(state.repos.clone());
+    let service = DMService::new(state.repos.clone(), state.event_bus.clone());
     let conversations = service.get_conversations(&user_id)?;
 
     Ok(Json(conversations))
@@ -68,7 +68,7 @@ pub async fn get_conversation(
     let other_user_id = Uuid::parse_str(&other_user_id)
         .map_err(|_| ApiError::BadRequest("Invalid user ID".to_string()))?;
 
-    let service = DMService::new(state.repos.clone());
+    let service = DMService::new(state.repos.clone(), state.event_bus.clone());
     let messages = service.get_conversation(&user_id, &other_user_id)?;
 
     Ok(Json(messages))
@@ -84,12 +84,51 @@ pub async fn mark_messages_read(
     let other_user_id = Uuid::parse_str(&other_user_id)
         .map_err(|_| ApiError::BadRequest("Invalid user ID".to_string()))?;
 
-    let service = DMService::new(state.repos.clone());
+    let service = DMService::new(state.repos.clone(), state.event_bus.clone());
     service.mark_messages_read(&user_id, &other_user_id)?;
 
     Ok(Json(serde_json::json!({
         "success": true,
         "message": "Messages marked as read"
+    })))
+}
+
+/// GET /dms/requests - List pending DM requests for current user
+pub async fn get_pending_requests(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+) -> ApiResult<Json<Vec<DmRequestSummary>>> {
+    let service = DMService::new(state.repos.clone(), state.event_bus.clone());
+    Ok(Json(service.get_pending_requests(&user_id)?))
+}
+
+/// POST /dms/requests/:user_id/accept - Accept a pending DM request
+pub async fn accept_request(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Path(requester_id): Path<Uuid>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let service = DMService::new(state.repos.clone(), state.event_bus.clone());
+    service.accept_request(&user_id, &requester_id)?;
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "message": "DM request accepted"
+    })))
+}
+
+/// POST /dms/requests/:user_id/decline - Decline a pending DM request
+pub async fn decline_request(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Path(requester_id): Path<Uuid>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let service = DMService::new(state.repos.clone(), state.event_bus.clone());
+    service.decline_request(&user_id, &requester_id)?;
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "message": "DM request declined"
     })))
 }
 
@@ -99,7 +138,7 @@ pub async fn send_message(
     AuthenticatedUser(from_user_id): AuthenticatedUser,
     Json(payload): Json<SendMessageRequest>,
 ) -> ApiResult<Json<DirectMessage>> {
-    let service = DMService::new(state.repos.clone());
+    let service = DMService::new(state.repos.clone(), state.event_bus.clone());
 
     // Check rate limit (1 DM per 1 second)
     check_dm_rate_limit(&state, &from_user_id)?;
@@ -121,7 +160,7 @@ pub async fn delete_conversation(
     let other_user_id = Uuid::parse_str(&other_user_id)
         .map_err(|_| ApiError::BadRequest("Invalid user ID format".to_string()))?;
 
-    let service = DMService::new(state.repos.clone());
+    let service = DMService::new(state.repos.clone(), state.event_bus.clone());
     service.delete_conversation(&user_id, &other_user_id)?;
 
     Ok(Json(serde_json::json!({

--- a/fido-server/src/db/repositories/dm_conversation_repository.rs
+++ b/fido-server/src/db/repositories/dm_conversation_repository.rs
@@ -36,6 +36,23 @@ impl DmConversationRepository {
         Ok(conversation)
     }
 
+    /// List pending request conversations where `recipient_id` is not the initiator.
+    pub fn list_pending_for_recipient(&self, recipient_id: &Uuid) -> Result<Vec<DmConversation>> {
+        let conn = self.pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT user_a, user_b, state, initiator_id, created_at FROM dm_conversations
+             WHERE state = 'pending'
+               AND (user_a = ? OR user_b = ?)
+               AND initiator_id != ?
+             ORDER BY created_at DESC",
+        )?;
+        let recipient = recipient_id.to_string();
+        let conversations = stmt
+            .query_map((&recipient, &recipient, &recipient), map_conversation_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(conversations)
+    }
+
     /// Create a conversation for a pair of users, in any argument order.
     pub fn create(
         &self,

--- a/fido-server/src/db/repositories/dm_repository.rs
+++ b/fido-server/src/db/repositories/dm_repository.rs
@@ -87,6 +87,25 @@ impl DirectMessageRepository {
         Ok(messages)
     }
 
+    /// Count all messages exchanged by two users, including messages hidden by either user.
+    pub fn count_between(&self, user1_id: &Uuid, user2_id: &Uuid) -> Result<i64> {
+        let conn = self.pool.get()?;
+        let count = conn.query_row(
+            "SELECT COUNT(*)
+             FROM direct_messages
+             WHERE (from_user_id = ? AND to_user_id = ?)
+                OR (from_user_id = ? AND to_user_id = ?)",
+            (
+                user1_id.to_string(),
+                user2_id.to_string(),
+                user2_id.to_string(),
+                user1_id.to_string(),
+            ),
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
     /// Get conversation summaries without loading full message histories.
     pub fn get_conversation_summaries(
         &self,

--- a/fido-server/src/db/repositories/membership_repository.rs
+++ b/fido-server/src/db/repositories/membership_repository.rs
@@ -106,6 +106,20 @@ impl MembershipRepository {
         Ok(memberships)
     }
 
+    /// Check whether two users share any community membership.
+    pub fn users_share_community(&self, user_one: &Uuid, user_two: &Uuid) -> Result<bool> {
+        let conn = self.pool.get()?;
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*)
+             FROM memberships m1
+             INNER JOIN memberships m2 ON m1.community_id = m2.community_id
+             WHERE m1.user_id = ? AND m2.user_id = ?",
+            (user_one.to_string(), user_two.to_string()),
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
     /// List admin memberships for a community
     pub fn list_admins(&self, community_id: &Uuid) -> Result<Vec<Membership>> {
         let conn = self.pool.get()?;

--- a/fido-server/src/events.rs
+++ b/fido-server/src/events.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use fido_types::{Message, Post};
+use fido_types::{DirectMessage, DmConversation, Message, Post};
 
 #[derive(Debug, Clone)]
 pub enum ServerEvent {
+    DmRequestCreated(DmConversation),
+    DmMessageCreated(DirectMessage),
     MessageCreated(Message),
     ThreadCreated(Post),
     ThreadPendingApproval(Post),
@@ -20,6 +22,12 @@ pub struct NoopEventBus;
 impl EventBus for NoopEventBus {
     fn emit(&self, event: ServerEvent) -> Result<()> {
         match event {
+            ServerEvent::DmRequestCreated(conversation) => {
+                let _ = conversation.initiator_id;
+            }
+            ServerEvent::DmMessageCreated(message) => {
+                let _ = message.id;
+            }
             ServerEvent::MessageCreated(message) => {
                 let _ = message.id;
             }

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -103,6 +103,15 @@ pub fn create_router(state: AppState) -> Router {
             "/dms/mark-read/:user_id",
             post(api::dms::mark_messages_read),
         )
+        .route("/dms/requests", get(api::dms::get_pending_requests))
+        .route(
+            "/dms/requests/:user_id/accept",
+            post(api::dms::accept_request),
+        )
+        .route(
+            "/dms/requests/:user_id/decline",
+            post(api::dms::decline_request),
+        )
         .route("/dms", post(api::dms::send_message))
         // Config routes
         .route("/config", get(api::config::get_config))

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -310,6 +310,15 @@ async fn main() {
             "/dms/mark-read/:user_id",
             post(api::dms::mark_messages_read),
         )
+        .route("/dms/requests", get(api::dms::get_pending_requests))
+        .route(
+            "/dms/requests/:user_id/accept",
+            post(api::dms::accept_request),
+        )
+        .route(
+            "/dms/requests/:user_id/decline",
+            post(api::dms::decline_request),
+        )
         .route("/dms", post(api::dms::send_message))
         // Config routes
         .route("/config", get(api::config::get_config))

--- a/fido-server/src/services/chat.rs
+++ b/fido-server/src/services/chat.rs
@@ -188,7 +188,10 @@ mod tests {
         assert_eq!(events.len(), 1);
         match &events[0] {
             ServerEvent::MessageCreated(created) => assert_eq!(created.id, message.id),
-            ServerEvent::ThreadCreated(_) | ServerEvent::ThreadPendingApproval(_) => {
+            ServerEvent::DmRequestCreated(_)
+            | ServerEvent::DmMessageCreated(_)
+            | ServerEvent::ThreadCreated(_)
+            | ServerEvent::ThreadPendingApproval(_) => {
                 panic!("expected message event")
             }
         }

--- a/fido-server/src/services/dms.rs
+++ b/fido-server/src/services/dms.rs
@@ -6,7 +6,8 @@ use chrono::Utc;
 
 use crate::api::{ApiError, ApiResult};
 use crate::db::repositories::Repositories;
-use fido_types::DirectMessage;
+use crate::events::{ServerEvent, SharedEventBus};
+use fido_types::{DirectMessage, DmConversationState};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -18,13 +19,21 @@ pub struct ConversationSummary {
     pub unread_count: usize,
 }
 
+#[derive(Debug, Serialize)]
+pub struct DmRequestSummary {
+    pub from_user_id: String,
+    pub from_username: String,
+    pub created_at: String,
+}
+
 pub struct DMService {
     repos: Repositories,
+    event_bus: SharedEventBus,
 }
 
 impl DMService {
-    pub fn new(repos: Repositories) -> Self {
-        Self { repos }
+    pub fn new(repos: Repositories, event_bus: SharedEventBus) -> Self {
+        Self { repos, event_bus }
     }
 
     pub fn get_conversations(&self, user_id: &Uuid) -> ApiResult<Vec<ConversationSummary>> {
@@ -89,6 +98,38 @@ impl DMService {
         Ok(())
     }
 
+    pub fn get_pending_requests(&self, user_id: &Uuid) -> ApiResult<Vec<DmRequestSummary>> {
+        let conversations = self
+            .repos
+            .dm_conversations
+            .list_pending_for_recipient(user_id)?;
+        let mut requests = Vec::with_capacity(conversations.len());
+
+        for conversation in conversations {
+            let from_user = self
+                .repos
+                .users
+                .get_by_id(&conversation.initiator_id)?
+                .ok_or_else(|| ApiError::NotFound("Request sender not found".to_string()))?;
+
+            requests.push(DmRequestSummary {
+                from_user_id: from_user.id.to_string(),
+                from_username: from_user.username,
+                created_at: conversation.created_at.to_rfc3339(),
+            });
+        }
+
+        Ok(requests)
+    }
+
+    pub fn accept_request(&self, recipient_id: &Uuid, requester_id: &Uuid) -> ApiResult<()> {
+        self.update_request_state(recipient_id, requester_id, DmConversationState::Accepted)
+    }
+
+    pub fn decline_request(&self, recipient_id: &Uuid, requester_id: &Uuid) -> ApiResult<()> {
+        self.update_request_state(recipient_id, requester_id, DmConversationState::Declined)
+    }
+
     pub fn send_message(
         &self,
         from_user_id: &Uuid,
@@ -119,6 +160,8 @@ impl DMService {
             .get_by_id(from_user_id)?
             .ok_or_else(|| ApiError::NotFound("Sender not found".to_string()))?;
 
+        let conversation_state = self.ensure_send_allowed(from_user_id, &to_user.id)?;
+
         let message = DirectMessage {
             id: Uuid::new_v4(),
             from_user_id: *from_user_id,
@@ -131,12 +174,287 @@ impl DMService {
         };
 
         self.repos.dms.create(&message)?;
+        if conversation_state == DmConversationState::Pending {
+            if let Some(conversation) =
+                self.repos.dm_conversations.get(from_user_id, &to_user.id)?
+            {
+                self.event_bus
+                    .emit(ServerEvent::DmRequestCreated(conversation))?;
+            }
+        }
+        self.event_bus
+            .emit(ServerEvent::DmMessageCreated(message.clone()))?;
 
         Ok(message)
     }
 
     pub fn delete_conversation(&self, user_id: &Uuid, other_user_id: &Uuid) -> ApiResult<()> {
         self.repos.dms.delete_conversation(user_id, other_user_id)?;
+        Ok(())
+    }
+
+    fn update_request_state(
+        &self,
+        recipient_id: &Uuid,
+        requester_id: &Uuid,
+        state: DmConversationState,
+    ) -> ApiResult<()> {
+        let conversation = self
+            .repos
+            .dm_conversations
+            .get(recipient_id, requester_id)?
+            .ok_or_else(|| ApiError::NotFound("DM request not found".to_string()))?;
+
+        if conversation.state != DmConversationState::Pending {
+            return Err(ApiError::BadRequest(
+                "DM request is not pending".to_string(),
+            ));
+        }
+
+        if conversation.initiator_id != *requester_id {
+            return Err(ApiError::Forbidden(
+                "Only the request recipient can update this DM request".to_string(),
+            ));
+        }
+
+        self.repos
+            .dm_conversations
+            .set_state(recipient_id, requester_id, state)?;
+        Ok(())
+    }
+
+    fn ensure_send_allowed(
+        &self,
+        from_user_id: &Uuid,
+        to_user_id: &Uuid,
+    ) -> ApiResult<DmConversationState> {
+        if let Some(conversation) = self.repos.dm_conversations.get(from_user_id, to_user_id)? {
+            return match conversation.state {
+                DmConversationState::Accepted => Ok(DmConversationState::Accepted),
+                DmConversationState::Declined => {
+                    Err(ApiError::Forbidden("DM request was declined".to_string()))
+                }
+                DmConversationState::Pending => {
+                    let existing_messages =
+                        self.repos.dms.count_between(from_user_id, to_user_id)?;
+                    if conversation.initiator_id == *from_user_id && existing_messages == 0 {
+                        Ok(DmConversationState::Pending)
+                    } else {
+                        Err(ApiError::Forbidden(
+                            "DM request is pending acceptance".to_string(),
+                        ))
+                    }
+                }
+            };
+        }
+
+        let state = if self.should_auto_accept(from_user_id, to_user_id)? {
+            DmConversationState::Accepted
+        } else {
+            DmConversationState::Pending
+        };
+        self.repos
+            .dm_conversations
+            .create(from_user_id, to_user_id, from_user_id, state)?;
+        Ok(state)
+    }
+
+    fn should_auto_accept(&self, from_user_id: &Uuid, to_user_id: &Uuid) -> ApiResult<bool> {
+        Ok(self
+            .repos
+            .friends
+            .are_mutual_friends(from_user_id, to_user_id)?
+            || self
+                .repos
+                .memberships
+                .users_share_community(from_user_id, to_user_id)?)
+    }
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use crate::{
+        db::Database,
+        events::{EventBus, ServerEvent},
+    };
+    use anyhow::Result;
+    use fido_types::{Community, Membership, MembershipRole, User};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct RecordingEventBus {
+        events: Mutex<Vec<ServerEvent>>,
+    }
+
+    impl EventBus for RecordingEventBus {
+        fn emit(&self, event: ServerEvent) -> Result<()> {
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    fn test_user(username: &str) -> User {
+        User {
+            id: Uuid::new_v4(),
+            username: username.to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        }
+    }
+
+    fn setup() -> Result<(Database, Repositories, Arc<RecordingEventBus>, User, User)> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repos = Repositories::new(db.pool.clone());
+        let sender = test_user("sender");
+        let recipient = test_user("recipient");
+        repos.users.create(&sender)?;
+        repos.users.create(&recipient)?;
+        let event_bus = Arc::new(RecordingEventBus::default());
+        Ok((db, repos, event_bus, sender, recipient))
+    }
+
+    #[test]
+    fn send_message_creates_pending_request_for_stranger() -> Result<()> {
+        let (_db, repos, event_bus, sender, recipient) = setup()?;
+        let service = DMService::new(repos.clone(), event_bus.clone());
+
+        service
+            .send_message(&sender.id, &recipient.username, "hello")
+            .expect("first stranger message creates request");
+
+        let conversation = repos
+            .dm_conversations
+            .get(&sender.id, &recipient.id)?
+            .expect("conversation exists");
+        assert_eq!(conversation.state, DmConversationState::Pending);
+        assert_eq!(conversation.initiator_id, sender.id);
+
+        let requests = service
+            .get_pending_requests(&recipient.id)
+            .expect("recipient can list pending request");
+        assert_eq!(requests.len(), 1);
+
+        let events = event_bus.events.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], ServerEvent::DmRequestCreated(_)));
+        assert!(matches!(events[1], ServerEvent::DmMessageCreated(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn send_message_rejects_second_pending_message() -> Result<()> {
+        let (_db, repos, event_bus, sender, recipient) = setup()?;
+        let service = DMService::new(repos, event_bus);
+
+        service
+            .send_message(&sender.id, &recipient.username, "hello")
+            .expect("first stranger message creates request");
+        let result = service.send_message(&sender.id, &recipient.username, "again");
+
+        assert!(matches!(result, Err(ApiError::Forbidden(_))));
+        Ok(())
+    }
+
+    #[test]
+    fn accept_request_allows_followup_messages() -> Result<()> {
+        let (_db, repos, event_bus, sender, recipient) = setup()?;
+        let service = DMService::new(repos.clone(), event_bus);
+
+        service
+            .send_message(&sender.id, &recipient.username, "hello")
+            .expect("first stranger message creates request");
+        service
+            .accept_request(&recipient.id, &sender.id)
+            .expect("recipient can accept request");
+        service
+            .send_message(&sender.id, &recipient.username, "thanks")
+            .expect("accepted request allows followup");
+
+        let conversation = repos
+            .dm_conversations
+            .get(&sender.id, &recipient.id)?
+            .expect("conversation exists");
+        assert_eq!(conversation.state, DmConversationState::Accepted);
+        assert_eq!(repos.dms.count_between(&sender.id, &recipient.id)?, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn decline_request_rejects_future_messages() -> Result<()> {
+        let (_db, repos, event_bus, sender, recipient) = setup()?;
+        let service = DMService::new(repos, event_bus);
+
+        service
+            .send_message(&sender.id, &recipient.username, "hello")
+            .expect("first stranger message creates request");
+        service
+            .decline_request(&recipient.id, &sender.id)
+            .expect("recipient can decline request");
+        let result = service.send_message(&sender.id, &recipient.username, "again");
+
+        assert!(matches!(result, Err(ApiError::Forbidden(_))));
+        Ok(())
+    }
+
+    #[test]
+    fn send_message_auto_accepts_mutual_follows() -> Result<()> {
+        let (_db, repos, event_bus, sender, recipient) = setup()?;
+        repos.friends.follow_user(&sender.id, &recipient.id)?;
+        repos.friends.follow_user(&recipient.id, &sender.id)?;
+        let service = DMService::new(repos.clone(), event_bus);
+
+        service
+            .send_message(&sender.id, &recipient.username, "hello")
+            .expect("mutual follows auto-accept dm");
+
+        let conversation = repos
+            .dm_conversations
+            .get(&sender.id, &recipient.id)?
+            .expect("conversation exists");
+        assert_eq!(conversation.state, DmConversationState::Accepted);
+        Ok(())
+    }
+
+    #[test]
+    fn send_message_auto_accepts_shared_community_members() -> Result<()> {
+        let (_db, repos, event_bus, sender, recipient) = setup()?;
+        let community = Community {
+            id: Uuid::new_v4(),
+            github_repo_id: 42,
+            owner: "octocat".to_string(),
+            name: "hello".to_string(),
+            claimed_by: None,
+            require_thread_approval: false,
+            created_at: Utc::now(),
+        };
+        repos.communities.create(&community)?;
+        repos.memberships.insert(&Membership {
+            community_id: community.id,
+            user_id: sender.id,
+            role: MembershipRole::Member,
+            created_at: Utc::now(),
+        })?;
+        repos.memberships.insert(&Membership {
+            community_id: community.id,
+            user_id: recipient.id,
+            role: MembershipRole::Member,
+            created_at: Utc::now(),
+        })?;
+        let service = DMService::new(repos.clone(), event_bus);
+
+        service
+            .send_message(&sender.id, &recipient.username, "hello")
+            .expect("shared community auto-accepts dm");
+
+        let conversation = repos
+            .dm_conversations
+            .get(&sender.id, &recipient.id)?
+            .expect("conversation exists");
+        assert_eq!(conversation.state, DmConversationState::Accepted);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- enforce server-side DM conversation states for pending, accepted, and declined requests
- add pending request list plus accept/decline DM endpoints
- emit DM request/message events and cover request behavior with SQLite-backed service tests

## Validation
- cargo test -p fido-server --features sqlite-tests services::dms
- cargo build
- cargo test
- cargo clippy -p fido-server --bins --lib --all-features -- -D warnings

## Note
- cargo clippy --all-targets --all-features -- -D warnings still fails on pre-existing placeholder assert!(true) calls in fido-server/tests/hashtag_integration_tests.rs.