### PR TITLE
Notifications model and API

### DIFF
--- a/fido-server/src/api/mod.rs
+++ b/fido-server/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod dms;
 pub mod error;
 pub mod friends;
+pub mod notifications;
 pub mod posts;
 pub mod profile;
 

--- a/fido-server/src/api/notifications.rs
+++ b/fido-server/src/api/notifications.rs
@@ -1,0 +1,173 @@
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use fido_types::{MarkNotificationsReadRequest, Notification, NotificationUnreadCount};
+use serde::Deserialize;
+
+use crate::{
+    api::{ApiError, ApiResult},
+    http::AuthenticatedUser,
+    services::notifications::NotificationService,
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct NotificationsQuery {
+    #[serde(default = "default_limit")]
+    limit: i32,
+    #[serde(default)]
+    offset: i32,
+}
+
+fn default_limit() -> i32 {
+    25
+}
+
+pub async fn list_notifications(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Query(query): Query<NotificationsQuery>,
+) -> ApiResult<Json<Vec<Notification>>> {
+    if query.limit <= 0 || query.limit > 100 {
+        return Err(ApiError::BadRequest(
+            "limit must be between 1 and 100".to_string(),
+        ));
+    }
+    if query.offset < 0 {
+        return Err(ApiError::BadRequest(
+            "offset must be non-negative".to_string(),
+        ));
+    }
+
+    let service = NotificationService::new(state.repos.clone(), state.event_bus.clone());
+    Ok(Json(service.list_for_user(
+        &user_id,
+        query.limit,
+        query.offset,
+    )?))
+}
+
+pub async fn unread_count(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+) -> ApiResult<Json<Vec<NotificationUnreadCount>>> {
+    let service = NotificationService::new(state.repos.clone(), state.event_bus.clone());
+    Ok(Json(service.unread_counts(&user_id)?))
+}
+
+pub async fn mark_read(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Json(payload): Json<MarkNotificationsReadRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    if payload.all && payload.notification_id.is_some() {
+        return Err(ApiError::BadRequest(
+            "Use either notification_id or all, not both".to_string(),
+        ));
+    }
+    if !payload.all && payload.notification_id.is_none() {
+        return Err(ApiError::BadRequest(
+            "notification_id is required unless all is true".to_string(),
+        ));
+    }
+
+    let service = NotificationService::new(state.repos.clone(), state.event_bus.clone());
+    service.mark_read(&user_id, payload.notification_id)?;
+    Ok(Json(serde_json::json!({ "success": true })))
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use chrono::Utc;
+    use fido_types::{NotificationType, User};
+    use uuid::Uuid;
+
+    use crate::{db::repositories::Repositories, db::Database};
+
+    fn setup_state() -> anyhow::Result<(AppState, Uuid, Uuid)> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repos = Repositories::new(db.pool.clone());
+        let recipient = User {
+            id: Uuid::new_v4(),
+            username: "recipient".to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        };
+        let actor = User {
+            id: Uuid::new_v4(),
+            username: "actor".to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        };
+        repos.users.create(&recipient)?;
+        repos.users.create(&actor)?;
+
+        let state = {
+            let _guard = crate::test_utils::env_lock().lock().unwrap();
+            std::env::set_var("FIDO_TOKEN_KEY", STANDARD.encode([9u8; 32]));
+            AppState::new_with_repos(db, repos)?
+        };
+        Ok((state, recipient.id, actor.id))
+    }
+
+    #[tokio::test]
+    async fn lists_counts_and_marks_notifications_read() -> anyhow::Result<()> {
+        let (state, recipient_id, actor_id) = setup_state()?;
+        let service = NotificationService::new(state.repos.clone(), state.event_bus.clone());
+        let notification = service
+            .create(
+                recipient_id,
+                NotificationType::Mention,
+                actor_id,
+                "community",
+                Uuid::new_v4().to_string(),
+            )
+            .expect("notification creates")
+            .expect("not self notification");
+
+        let listed = list_notifications(
+            State(state.clone()),
+            AuthenticatedUser(recipient_id),
+            Query(NotificationsQuery {
+                limit: 25,
+                offset: 0,
+            }),
+        )
+        .await
+        .expect("notifications list succeeds")
+        .0;
+        assert_eq!(listed.len(), 1);
+
+        let counts = unread_count(State(state.clone()), AuthenticatedUser(recipient_id))
+            .await
+            .expect("unread count succeeds")
+            .0;
+        assert_eq!(counts.len(), 1);
+        assert_eq!(counts[0].count, 1);
+
+        let _ = mark_read(
+            State(state.clone()),
+            AuthenticatedUser(recipient_id),
+            Json(MarkNotificationsReadRequest {
+                notification_id: Some(notification.id),
+                all: false,
+            }),
+        )
+        .await
+        .expect("mark read succeeds");
+        assert!(unread_count(State(state), AuthenticatedUser(recipient_id))
+            .await
+            .expect("unread count succeeds")
+            .0
+            .is_empty());
+        Ok(())
+    }
+}

--- a/fido-server/src/db/repositories/notification_repository.rs
+++ b/fido-server/src/db/repositories/notification_repository.rs
@@ -5,7 +5,7 @@ use rusqlite::params;
 use rusqlite::types::Type;
 use uuid::Uuid;
 
-use fido_types::{Notification, NotificationType};
+use fido_types::{Notification, NotificationType, NotificationUnreadCount};
 
 use crate::db::{row, DbPool};
 
@@ -73,28 +73,32 @@ impl NotificationRepository {
         Ok(count)
     }
 
-    /// Unread notification counts grouped by subject_type (for rail badges)
-    pub fn unread_counts_by_subject_type(&self, user_id: &Uuid) -> Result<Vec<(String, i64)>> {
+    /// Unread notification counts grouped by subject (for rail badges)
+    pub fn unread_counts_by_subject(&self, user_id: &Uuid) -> Result<Vec<NotificationUnreadCount>> {
         let conn = self.pool.get()?;
         let mut stmt = conn.prepare(
-            "SELECT subject_type, COUNT(*) FROM notifications
+            "SELECT subject_type, subject_id, COUNT(*) FROM notifications
              WHERE user_id = ? AND read = 0
-             GROUP BY subject_type",
+             GROUP BY subject_type, subject_id",
         )?;
         let counts = stmt
             .query_map([user_id.to_string()], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                Ok(NotificationUnreadCount {
+                    subject_type: row.get(0)?,
+                    subject_id: row.get(1)?,
+                    count: row.get(2)?,
+                })
             })?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(counts)
     }
 
-    /// Mark a single notification as read
-    pub fn mark_read(&self, notification_id: &Uuid) -> Result<()> {
+    /// Mark a single notification as read for its owner.
+    pub fn mark_read_for_user(&self, user_id: &Uuid, notification_id: &Uuid) -> Result<()> {
         let conn = self.pool.get()?;
         conn.execute(
-            "UPDATE notifications SET read = 1 WHERE id = ?",
-            [notification_id.to_string()],
+            "UPDATE notifications SET read = 1 WHERE id = ? AND user_id = ?",
+            (notification_id.to_string(), user_id.to_string()),
         )
         .context("Failed to mark notification as read")?;
         Ok(())
@@ -169,13 +173,22 @@ mod tests {
     }
 
     fn notification(user_id: Uuid, actor_id: Uuid, subject_type: &str) -> Notification {
+        notification_with_subject_id(user_id, actor_id, subject_type, Uuid::new_v4().to_string())
+    }
+
+    fn notification_with_subject_id(
+        user_id: Uuid,
+        actor_id: Uuid,
+        subject_type: &str,
+        subject_id: String,
+    ) -> Notification {
         Notification {
             id: Uuid::new_v4(),
             user_id,
             notification_type: NotificationType::Reply,
             actor_id,
             subject_type: subject_type.to_string(),
-            subject_id: Uuid::new_v4().to_string(),
+            subject_id,
             read: false,
             created_at: Utc::now(),
         }
@@ -185,17 +198,32 @@ mod tests {
     fn test_create_list_and_counts() -> Result<()> {
         let (db, recipient, actor) = setup()?;
         let repo = NotificationRepository::new(db.pool.clone());
+        let post_subject_id = Uuid::new_v4().to_string();
 
-        repo.create(&notification(recipient, actor, "post"))?;
-        repo.create(&notification(recipient, actor, "post"))?;
+        repo.create(&notification_with_subject_id(
+            recipient,
+            actor,
+            "post",
+            post_subject_id.clone(),
+        ))?;
+        repo.create(&notification_with_subject_id(
+            recipient,
+            actor,
+            "post",
+            post_subject_id,
+        ))?;
         repo.create(&notification(recipient, actor, "dm_conversation"))?;
 
         let listed = repo.list_for_user(&recipient, 10, 0)?;
         assert_eq!(listed.len(), 3);
         assert_eq!(repo.unread_count(&recipient)?, 3);
 
-        let grouped = repo.unread_counts_by_subject_type(&recipient)?;
+        let grouped = repo.unread_counts_by_subject(&recipient)?;
         assert_eq!(grouped.len(), 2);
+        assert!(grouped.iter().any(|count| count.subject_type == "post"));
+        assert!(grouped
+            .iter()
+            .any(|count| count.subject_type == "dm_conversation"));
         Ok(())
     }
 
@@ -209,7 +237,7 @@ mod tests {
         repo.create(&notification(recipient, actor, "post"))?;
         assert_eq!(repo.unread_count(&recipient)?, 2);
 
-        repo.mark_read(&n.id)?;
+        repo.mark_read_for_user(&recipient, &n.id)?;
         assert_eq!(repo.unread_count(&recipient)?, 1);
 
         repo.mark_all_read(&recipient)?;

--- a/fido-server/src/events.rs
+++ b/fido-server/src/events.rs
@@ -1,13 +1,14 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use fido_types::{DirectMessage, DmConversation, Message, Post};
+use fido_types::{DirectMessage, DmConversation, Message, Notification, Post};
 
 #[derive(Debug, Clone)]
 pub enum ServerEvent {
     DmRequestCreated(DmConversation),
     DmMessageCreated(DirectMessage),
     MessageCreated(Message),
+    NotificationCreated(Notification),
     ThreadCreated(Post),
     ThreadPendingApproval(Post),
 }
@@ -30,6 +31,9 @@ impl EventBus for NoopEventBus {
             }
             ServerEvent::MessageCreated(message) => {
                 let _ = message.id;
+            }
+            ServerEvent::NotificationCreated(notification) => {
+                let _ = notification.id;
             }
             ServerEvent::ThreadCreated(post) | ServerEvent::ThreadPendingApproval(post) => {
                 let _ = post.id;

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -75,6 +75,19 @@ pub fn create_router(state: AppState) -> Router {
             post(api::auth::github_device_poll),
         )
         .route("/auth/validate", get(api::auth::validate_session))
+        // Notification routes
+        .route(
+            "/notifications",
+            get(api::notifications::list_notifications),
+        )
+        .route(
+            "/notifications/unread-count",
+            get(api::notifications::unread_count),
+        )
+        .route(
+            "/notifications/mark-read",
+            post(api::notifications::mark_read),
+        )
         // Post routes
         .route("/posts", get(api::posts::get_posts))
         .route("/posts", post(api::posts::create_post))

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -282,6 +282,19 @@ async fn main() {
             post(api::auth::github_device_poll),
         )
         .route("/auth/validate", get(api::auth::validate_session))
+        // Notification routes
+        .route(
+            "/notifications",
+            get(api::notifications::list_notifications),
+        )
+        .route(
+            "/notifications/unread-count",
+            get(api::notifications::unread_count),
+        )
+        .route(
+            "/notifications/mark-read",
+            post(api::notifications::mark_read),
+        )
         // Post routes
         .route("/posts", get(api::posts::get_posts))
         .route("/posts", post(api::posts::create_post))

--- a/fido-server/src/services/chat.rs
+++ b/fido-server/src/services/chat.rs
@@ -190,6 +190,7 @@ mod tests {
             ServerEvent::MessageCreated(created) => assert_eq!(created.id, message.id),
             ServerEvent::DmRequestCreated(_)
             | ServerEvent::DmMessageCreated(_)
+            | ServerEvent::NotificationCreated(_)
             | ServerEvent::ThreadCreated(_)
             | ServerEvent::ThreadPendingApproval(_) => {
                 panic!("expected message event")

--- a/fido-server/src/services/dms.rs
+++ b/fido-server/src/services/dms.rs
@@ -7,7 +7,8 @@ use chrono::Utc;
 use crate::api::{ApiError, ApiResult};
 use crate::db::repositories::Repositories;
 use crate::events::{ServerEvent, SharedEventBus};
-use fido_types::{DirectMessage, DmConversationState};
+use crate::services::notifications::NotificationService;
+use fido_types::{DirectMessage, DmConversationState, NotificationType};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -178,6 +179,13 @@ impl DMService {
             if let Some(conversation) =
                 self.repos.dm_conversations.get(from_user_id, &to_user.id)?
             {
+                NotificationService::new(self.repos.clone(), self.event_bus.clone()).create(
+                    to_user.id,
+                    NotificationType::DmRequest,
+                    *from_user_id,
+                    "dm_conversation",
+                    dm_subject_id(from_user_id, &to_user.id),
+                )?;
                 self.event_bus
                     .emit(ServerEvent::DmRequestCreated(conversation))?;
             }
@@ -271,6 +279,12 @@ impl DMService {
     }
 }
 
+fn dm_subject_id(user_a: &Uuid, user_b: &Uuid) -> String {
+    let mut ids = [user_a.to_string(), user_b.to_string()];
+    ids.sort();
+    ids.join(":")
+}
+
 #[cfg(all(test, feature = "sqlite-tests"))]
 mod tests {
     use super::*;
@@ -339,9 +353,17 @@ mod tests {
         assert_eq!(requests.len(), 1);
 
         let events = event_bus.events.lock().unwrap();
-        assert_eq!(events.len(), 2);
-        assert!(matches!(events[0], ServerEvent::DmRequestCreated(_)));
-        assert!(matches!(events[1], ServerEvent::DmMessageCreated(_)));
+        assert_eq!(events.len(), 3);
+        assert!(matches!(events[0], ServerEvent::NotificationCreated(_)));
+        assert!(matches!(events[1], ServerEvent::DmRequestCreated(_)));
+        assert!(matches!(events[2], ServerEvent::DmMessageCreated(_)));
+
+        let notifications = repos.notifications.list_for_user(&recipient.id, 10, 0)?;
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(
+            notifications[0].notification_type,
+            NotificationType::DmRequest
+        );
         Ok(())
     }
 

--- a/fido-server/src/services/mod.rs
+++ b/fido-server/src/services/mod.rs
@@ -5,5 +5,6 @@ pub mod communities;
 pub mod dms;
 pub mod friends;
 pub mod github;
+pub mod notifications;
 pub mod posts;
 pub mod profile;

--- a/fido-server/src/services/notifications.rs
+++ b/fido-server/src/services/notifications.rs
@@ -1,0 +1,78 @@
+//! Notification creation and read-state business logic.
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::{
+    api::ApiResult,
+    db::repositories::Repositories,
+    events::{ServerEvent, SharedEventBus},
+};
+use fido_types::{Notification, NotificationType, NotificationUnreadCount};
+
+pub struct NotificationService {
+    repos: Repositories,
+    event_bus: SharedEventBus,
+}
+
+impl NotificationService {
+    pub fn new(repos: Repositories, event_bus: SharedEventBus) -> Self {
+        Self { repos, event_bus }
+    }
+
+    pub fn create(
+        &self,
+        user_id: Uuid,
+        notification_type: NotificationType,
+        actor_id: Uuid,
+        subject_type: impl Into<String>,
+        subject_id: impl Into<String>,
+    ) -> ApiResult<Option<Notification>> {
+        if user_id == actor_id {
+            return Ok(None);
+        }
+
+        let notification = Notification {
+            id: Uuid::new_v4(),
+            user_id,
+            notification_type,
+            actor_id,
+            subject_type: subject_type.into(),
+            subject_id: subject_id.into(),
+            read: false,
+            created_at: Utc::now(),
+        };
+
+        self.repos.notifications.create(&notification)?;
+        self.event_bus
+            .emit(ServerEvent::NotificationCreated(notification.clone()))?;
+        Ok(Some(notification))
+    }
+
+    pub fn list_for_user(
+        &self,
+        user_id: &Uuid,
+        limit: i32,
+        offset: i32,
+    ) -> ApiResult<Vec<Notification>> {
+        Ok(self
+            .repos
+            .notifications
+            .list_for_user(user_id, limit, offset)?)
+    }
+
+    pub fn unread_counts(&self, user_id: &Uuid) -> ApiResult<Vec<NotificationUnreadCount>> {
+        Ok(self.repos.notifications.unread_counts_by_subject(user_id)?)
+    }
+
+    pub fn mark_read(&self, user_id: &Uuid, notification_id: Option<Uuid>) -> ApiResult<()> {
+        if let Some(notification_id) = notification_id {
+            self.repos
+                .notifications
+                .mark_read_for_user(user_id, &notification_id)?;
+        } else {
+            self.repos.notifications.mark_all_read(user_id)?;
+        }
+        Ok(())
+    }
+}

--- a/fido-server/src/services/posts.rs
+++ b/fido-server/src/services/posts.rs
@@ -6,12 +6,189 @@ use crate::{
     api::{ApiError, ApiResult},
     db::repositories::Repositories,
     events::{ServerEvent, SharedEventBus},
+    mention::extract_mentions,
+    services::notifications::NotificationService,
 };
-use fido_types::{MembershipRole, Post, SortOrder, User, VoteDirection};
+use fido_types::{MembershipRole, NotificationType, Post, SortOrder, User, VoteDirection};
 
 pub struct PostService {
     repos: Repositories,
     event_bus: SharedEventBus,
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use crate::{
+        db::Database,
+        events::{EventBus, ServerEvent},
+    };
+    use anyhow::Result;
+    use chrono::Utc;
+    use fido_types::{Community, Membership};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct RecordingEventBus {
+        events: Mutex<Vec<ServerEvent>>,
+    }
+
+    impl EventBus for RecordingEventBus {
+        fn emit(&self, event: ServerEvent) -> Result<()> {
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    fn test_user(username: &str) -> User {
+        User {
+            id: Uuid::new_v4(),
+            username: username.to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        }
+    }
+
+    fn setup() -> Result<(
+        Repositories,
+        Arc<RecordingEventBus>,
+        Community,
+        User,
+        User,
+        User,
+    )> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repos = Repositories::new(db.pool.clone());
+        let admin = test_user("admin");
+        let author = test_user("author");
+        let mentioned = test_user("mentioned");
+        repos.users.create(&admin)?;
+        repos.users.create(&author)?;
+        repos.users.create(&mentioned)?;
+
+        let community = Community {
+            id: Uuid::new_v4(),
+            github_repo_id: 9009,
+            owner: "octocat".to_string(),
+            name: "notifications".to_string(),
+            claimed_by: Some(admin.id),
+            require_thread_approval: false,
+            created_at: Utc::now(),
+        };
+        repos.communities.create(&community)?;
+        for (user, role) in [
+            (&admin, MembershipRole::Admin),
+            (&author, MembershipRole::Member),
+            (&mentioned, MembershipRole::Member),
+        ] {
+            repos.memberships.insert(&Membership {
+                community_id: community.id,
+                user_id: user.id,
+                role,
+                created_at: Utc::now(),
+            })?;
+        }
+        Ok((
+            repos,
+            Arc::new(RecordingEventBus::default()),
+            community,
+            admin,
+            author,
+            mentioned,
+        ))
+    }
+
+    fn post(author: &User, community_id: Uuid, content: &str) -> Post {
+        Post {
+            id: Uuid::new_v4(),
+            author_id: author.id,
+            author_username: author.username.clone(),
+            community_id,
+            content: content.to_string(),
+            created_at: Utc::now(),
+            upvotes: 0,
+            downvotes: 0,
+            approved: true,
+            hashtags: Vec::new(),
+            user_vote: None,
+            parent_post_id: None,
+            reply_count: 0,
+            reply_to_user_id: None,
+            reply_to_username: None,
+        }
+    }
+
+    #[test]
+    fn create_reply_notifies_parent_author_and_mentions() -> Result<()> {
+        let (repos, event_bus, community, _admin, author, mentioned) = setup()?;
+        let service = PostService::new(repos.clone(), event_bus.clone());
+        let root = post(&author, community.id, "root");
+        service.create_post(&root).expect("root creates");
+
+        let reply_author = mentioned.clone();
+        let reply = Post {
+            id: Uuid::new_v4(),
+            author_id: reply_author.id,
+            author_username: reply_author.username,
+            community_id: community.id,
+            content: "@author @mentioned hi".to_string(),
+            created_at: Utc::now(),
+            upvotes: 0,
+            downvotes: 0,
+            approved: true,
+            hashtags: Vec::new(),
+            user_vote: None,
+            parent_post_id: Some(root.id),
+            reply_count: 0,
+            reply_to_user_id: Some(root.author_id),
+            reply_to_username: Some(root.author_username),
+        };
+        service.create_post(&reply).expect("reply creates");
+
+        let author_notifications = repos.notifications.list_for_user(&author.id, 10, 0)?;
+        assert_eq!(author_notifications.len(), 2);
+        assert!(author_notifications
+            .iter()
+            .any(|n| n.notification_type == NotificationType::Reply));
+        assert!(author_notifications
+            .iter()
+            .any(|n| n.notification_type == NotificationType::Mention));
+
+        let self_notifications = repos.notifications.list_for_user(&mentioned.id, 10, 0)?;
+        assert!(self_notifications.is_empty());
+        assert!(event_bus
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|event| matches!(event, ServerEvent::NotificationCreated(_))));
+        Ok(())
+    }
+
+    #[test]
+    fn approving_thread_notifies_author() -> Result<()> {
+        let (repos, _event_bus, community, admin, author, _mentioned) = setup()?;
+        let service = PostService::new(repos.clone(), Arc::new(RecordingEventBus::default()));
+        let pending = Post {
+            approved: false,
+            ..post(&author, community.id, "pending")
+        };
+        service.create_post(&pending).expect("pending creates");
+        service
+            .approve_post(admin.id, &pending.id)
+            .expect("admin approves");
+
+        let notifications = repos.notifications.list_for_user(&author.id, 10, 0)?;
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(
+            notifications[0].notification_type,
+            NotificationType::ThreadApproved
+        );
+        Ok(())
+    }
 }
 
 impl PostService {
@@ -116,7 +293,10 @@ impl PostService {
                 ServerEvent::ThreadPendingApproval(post.clone())
             };
             self.event_bus.emit(event)?;
+        } else {
+            self.notify_reply_targets(post)?;
         }
+        self.notify_mentions(post)?;
         Ok(())
     }
 
@@ -163,6 +343,13 @@ impl PostService {
         self.require_admin(user_id, post.community_id)?;
         self.repos.posts.approve(post_id)?;
         post.approved = true;
+        NotificationService::new(self.repos.clone(), self.event_bus.clone()).create(
+            post.author_id,
+            NotificationType::ThreadApproved,
+            user_id,
+            "community",
+            post.community_id.to_string(),
+        )?;
         self.populate_post(&mut post, Some(user_id))?;
         Ok(post)
     }
@@ -226,6 +413,37 @@ impl PostService {
             return Err(ApiError::Forbidden(
                 "Community admin role required".to_string(),
             ));
+        }
+        Ok(())
+    }
+
+    fn notify_reply_targets(&self, post: &Post) -> ApiResult<()> {
+        let Some(reply_to_user_id) = post.reply_to_user_id else {
+            return Ok(());
+        };
+
+        NotificationService::new(self.repos.clone(), self.event_bus.clone()).create(
+            reply_to_user_id,
+            NotificationType::Reply,
+            post.author_id,
+            "community",
+            post.community_id.to_string(),
+        )?;
+        Ok(())
+    }
+
+    fn notify_mentions(&self, post: &Post) -> ApiResult<()> {
+        let notifications = NotificationService::new(self.repos.clone(), self.event_bus.clone());
+        for username in extract_mentions(&post.content) {
+            if let Some(user) = self.repos.users.get_by_username(&username)? {
+                notifications.create(
+                    user.id,
+                    NotificationType::Mention,
+                    post.author_id,
+                    "community",
+                    post.community_id.to_string(),
+                )?;
+            }
         }
         Ok(())
     }

--- a/fido-types/src/models.rs
+++ b/fido-types/src/models.rs
@@ -206,6 +206,21 @@ pub struct Notification {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationUnreadCount {
+    pub subject_type: String,
+    pub subject_id: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkNotificationsReadRequest {
+    #[serde(default)]
+    pub notification_id: Option<Uuid>,
+    #[serde(default)]
+    pub all: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DmConversation {
     pub user_a: Uuid,
     pub user_b: Uuid,


### PR DESCRIPTION
## Summary
- add notification DTOs, service, and authenticated notifications API routes
- fan out notifications for mentions, replies, DM requests, and thread approval
- emit NotificationCreated events on the existing no-op event bus

## Validation
- cargo test -p fido-server --features sqlite-tests
- cargo test
- cargo clippy -p fido-server --lib --bins --all-features -- -D warnings

Note: cargo clippy --all-targets --all-features -- -D warnings is blocked by existing assert!(true) placeholders in fido-server/tests/hashtag_integration_tests.rs.