### PR TITLE
feat: WebSocket event gateway (stint 0010)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -173,8 +174,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -243,6 +246,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -552,6 +561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +743,7 @@ dependencies = [
  "config",
  "dotenv",
  "fido-types",
+ "futures-util",
  "lazy_static",
  "once_cell",
  "r2d2",
@@ -739,6 +755,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -818,6 +835,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +865,8 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1812,12 +1842,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2187,6 +2238,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2584,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -2546,6 +2609,18 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2725,6 +2800,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,6 +2911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,7 +2936,7 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "rand",
+ "rand 0.9.2",
  "serde",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ anyhow = "1.0"
 rusqlite = { version = "0.37", features = ["bundled"] }
 
 # HTTP server and client
-axum = "0.7"
-tokio = { version = "1.35", features = ["macros", "rt-multi-thread", "time", "net"] }
+axum = { version = "0.7", features = ["ws"] }
+tokio = { version = "1.35", features = ["macros", "rt-multi-thread", "time", "net", "sync", "signal"] }
 tower-http = { version = "0.5", features = ["cors", "fs", "limit"] }
 reqwest = { version = "0.11", default-features = false, features = ["json", "native-tls"] }
 

--- a/fido-server/Cargo.toml
+++ b/fido-server/Cargo.toml
@@ -42,3 +42,7 @@ once_cell = "1.19"
 lazy_static = "1.4"
 base64.workspace = true
 aes-gcm-siv.workspace = true
+
+[dev-dependencies]
+tokio-tungstenite = "0.24"
+futures-util = "0.3"

--- a/fido-server/src/api/mod.rs
+++ b/fido-server/src/api/mod.rs
@@ -9,5 +9,6 @@ pub mod friends;
 pub mod notifications;
 pub mod posts;
 pub mod profile;
+pub mod ws;
 
 pub use error::{ApiError, ApiResult};

--- a/fido-server/src/api/ws.rs
+++ b/fido-server/src/api/ws.rs
@@ -1,0 +1,148 @@
+//! `GET /ws`: the authenticated WebSocket event gateway.
+//!
+//! Auth happens before the upgrade: the session token comes from
+//! `Authorization: Bearer <token>`, `X-Session-Token`, or a `?token=` query
+//! fallback; an invalid or missing token yields HTTP 401 with no upgrade.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Query, State};
+use axum::http::HeaderMap;
+use axum::response::Response;
+use serde::Deserialize;
+use tokio::sync::broadcast::error::RecvError;
+use uuid::Uuid;
+
+use crate::api::ApiError;
+use crate::realtime::RealtimeGateway;
+use crate::state::AppState;
+
+/// Interval between server pings.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+/// Number of consecutive unanswered pings before the connection is dropped.
+const MAX_MISSED_PONGS: u8 = 2;
+/// WebSocket close code for "going away" (RFC 6455 section 7.4.1).
+const CLOSE_GOING_AWAY: u16 = 1001;
+
+#[derive(Debug, Deserialize)]
+pub struct WsQuery {
+    #[serde(default)]
+    token: Option<String>,
+}
+
+pub async fn ws_handler(
+    State(state): State<AppState>,
+    Query(query): Query<WsQuery>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Result<Response, ApiError> {
+    let token = extract_token(&headers, &query)
+        .ok_or_else(|| ApiError::Unauthorized("Missing session token".to_string()))?;
+
+    let user_id = state
+        .get_authenticated_user_id_from_token(&token)
+        .ok_or_else(|| ApiError::Unauthorized("Invalid session token".to_string()))?;
+
+    let gateway = state.realtime.clone();
+    Ok(ws.on_upgrade(move |socket| handle_connection(socket, user_id, gateway)))
+}
+
+/// Extract the session token: Authorization Bearer, X-Session-Token, or ?token=.
+fn extract_token(headers: &HeaderMap, query: &WsQuery) -> Option<String> {
+    if let Some(bearer) = headers
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    {
+        return Some(bearer.trim().to_string());
+    }
+    if let Some(token) = headers.get("X-Session-Token").and_then(|v| v.to_str().ok()) {
+        return Some(token.to_string());
+    }
+    query.token.clone()
+}
+
+async fn handle_connection(mut socket: WebSocket, user_id: Uuid, gateway: Arc<RealtimeGateway>) {
+    let connections = gateway.registry().connect(user_id);
+    tracing::info!(%user_id, connections, "WebSocket connected");
+
+    let mut events = gateway.subscribe();
+    let mut shutdown = gateway.shutdown_signal();
+    let mut ping_interval =
+        tokio::time::interval_at(tokio::time::Instant::now() + PING_INTERVAL, PING_INTERVAL);
+    let mut missed_pongs: u8 = 0;
+
+    loop {
+        tokio::select! {
+            outbound = events.recv() => match outbound {
+                Ok(event) => {
+                    if !event.is_for(&user_id) {
+                        continue;
+                    }
+                    if let Err(e) = socket.send(Message::Text(event.json().to_string())).await {
+                        tracing::debug!(%user_id, error = %e, "WebSocket send failed");
+                        break;
+                    }
+                }
+                Err(RecvError::Lagged(skipped)) => {
+                    // Never silently skip events: close so the client falls
+                    // back to refetching (polling fallback contract).
+                    tracing::warn!(%user_id, skipped, "WebSocket consumer lagged; closing");
+                    send_close(&mut socket, "event stream lagged").await;
+                    break;
+                }
+                Err(RecvError::Closed) => {
+                    send_close(&mut socket, "server shutting down").await;
+                    break;
+                }
+            },
+            frame = socket.recv() => match frame {
+                Some(Ok(Message::Pong(_))) => {
+                    missed_pongs = 0;
+                }
+                Some(Ok(Message::Close(_))) | None => {
+                    break;
+                }
+                Some(Ok(_)) => {
+                    // Server -> client only in MVP; ignore other client frames.
+                    // Pings are answered automatically by the protocol layer.
+                }
+                Some(Err(e)) => {
+                    tracing::debug!(%user_id, error = %e, "WebSocket receive error");
+                    break;
+                }
+            },
+            _ = ping_interval.tick() => {
+                if missed_pongs >= MAX_MISSED_PONGS {
+                    tracing::info!(%user_id, "WebSocket missed {MAX_MISSED_PONGS} pongs; dropping");
+                    break;
+                }
+                missed_pongs += 1;
+                if let Err(e) = socket.send(Message::Ping(Vec::new())).await {
+                    tracing::debug!(%user_id, error = %e, "WebSocket ping failed");
+                    break;
+                }
+            },
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    send_close(&mut socket, "server shutting down").await;
+                    break;
+                }
+            },
+        }
+    }
+
+    let remaining = gateway.registry().disconnect(user_id);
+    tracing::info!(%user_id, connections = remaining, "WebSocket disconnected");
+}
+
+async fn send_close(socket: &mut WebSocket, reason: &'static str) {
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: CLOSE_GOING_AWAY,
+            reason: reason.into(),
+        })))
+        .await;
+}

--- a/fido-server/src/db/repositories/membership_repository.rs
+++ b/fido-server/src/db/repositories/membership_repository.rs
@@ -120,6 +120,19 @@ impl MembershipRepository {
         Ok(count > 0)
     }
 
+    /// List all memberships for a community
+    pub fn list_members(&self, community_id: &Uuid) -> Result<Vec<Membership>> {
+        let conn = self.pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT community_id, user_id, role, created_at FROM memberships
+             WHERE community_id = ? ORDER BY created_at ASC",
+        )?;
+        let memberships = stmt
+            .query_map([community_id.to_string()], map_membership_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(memberships)
+    }
+
     /// List admin memberships for a community
     pub fn list_admins(&self, community_id: &Uuid) -> Result<Vec<Membership>> {
         let conn = self.pool.get()?;
@@ -213,6 +226,7 @@ mod tests {
         assert_eq!(got.role, MembershipRole::Admin);
 
         assert_eq!(repo.list_for_user(&user_id)?.len(), 1);
+        assert_eq!(repo.list_members(&community_id)?.len(), 1);
         assert_eq!(repo.list_admins(&community_id)?.len(), 1);
 
         repo.delete(&community_id, &user_id)?;

--- a/fido-server/src/events.rs
+++ b/fido-server/src/events.rs
@@ -5,7 +5,10 @@ use fido_types::{DirectMessage, DmConversation, Message, Notification, Post};
 
 #[derive(Debug, Clone)]
 pub enum ServerEvent {
-    DmRequestCreated(DmConversation),
+    DmRequestCreated {
+        conversation: DmConversation,
+        message: DirectMessage,
+    },
     DmMessageCreated(DirectMessage),
     MessageCreated(Message),
     NotificationCreated(Notification),
@@ -15,32 +18,6 @@ pub enum ServerEvent {
 
 pub trait EventBus: Send + Sync {
     fn emit(&self, event: ServerEvent) -> Result<()>;
-}
-
-#[derive(Debug, Default)]
-pub struct NoopEventBus;
-
-impl EventBus for NoopEventBus {
-    fn emit(&self, event: ServerEvent) -> Result<()> {
-        match event {
-            ServerEvent::DmRequestCreated(conversation) => {
-                let _ = conversation.initiator_id;
-            }
-            ServerEvent::DmMessageCreated(message) => {
-                let _ = message.id;
-            }
-            ServerEvent::MessageCreated(message) => {
-                let _ = message.id;
-            }
-            ServerEvent::NotificationCreated(notification) => {
-                let _ = notification.id;
-            }
-            ServerEvent::ThreadCreated(post) | ServerEvent::ThreadPendingApproval(post) => {
-                let _ = post.id;
-            }
-        }
-        Ok(())
-    }
 }
 
 pub type SharedEventBus = Arc<dyn EventBus>;

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod http;
 pub mod mention;
 pub mod oauth;
 pub mod rate_limit;
+pub mod realtime;
 pub mod security;
 pub mod services;
 pub mod session;
@@ -46,6 +47,8 @@ pub fn create_router(state: AppState) -> Router {
     Router::new()
         // Health check
         .route("/health", get(health_check))
+        // Realtime WebSocket gateway
+        .route("/ws", get(api::ws::ws_handler))
         // Authentication routes
         .route("/users/test", get(api::auth::list_test_users))
         .route("/auth/login", post(api::auth::login))

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -6,6 +6,7 @@ mod http;
 mod mention;
 mod oauth;
 mod rate_limit;
+mod realtime;
 mod security;
 mod services;
 mod session;
@@ -253,6 +254,8 @@ async fn main() {
     let app = Router::new()
         // Health check
         .route("/health", get(health_check))
+        // Realtime WebSocket gateway
+        .route("/ws", get(api::ws::ws_handler))
         // Authentication routes
         .route("/users/test", get(api::auth::list_test_users))
         .route("/auth/login", post(api::auth::login))
@@ -380,7 +383,7 @@ async fn main() {
         .route("/social/mutual", get(api::friends::get_mutual_friends_list))
         .with_state(state.clone())
         .layer(middleware::from_fn_with_state(
-            state,
+            state.clone(),
             rate_limit::rate_limit_middleware,
         ))
         .layer(axum::Extension(rate_limiter))
@@ -424,7 +427,21 @@ async fn main() {
 
     tracing::info!("Server starting successfully on {}", addr);
 
-    if let Err(e) = axum::serve(listener, app).await {
+    // On ctrl-c, signal the realtime gateway first so WebSocket connections
+    // close with a going-away frame, then let axum drain gracefully.
+    let gateway = state.realtime.clone();
+    let shutdown = async move {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::error!("Failed to listen for shutdown signal: {}", e);
+        }
+        tracing::info!("Shutdown signal received, closing WebSocket connections");
+        gateway.shutdown();
+    };
+
+    if let Err(e) = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+    {
         tracing::error!("Server error: {}", e);
         eprintln!("FATAL: Server error: {}", e);
         std::process::exit(1);

--- a/fido-server/src/realtime.rs
+++ b/fido-server/src/realtime.rs
@@ -1,0 +1,331 @@
+//! Realtime WebSocket gateway: the in-process event bus backing `GET /ws`.
+//!
+//! API handlers publish [`ServerEvent`]s through the [`EventBus`] trait; the
+//! gateway resolves recipients at publish time (one DB lookup per event),
+//! serializes the wire envelope once, and fans the result out over a
+//! `tokio::sync::broadcast` channel. Each connection task only checks whether
+//! its own user id is in the recipient set.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use fido_types::{ChannelMessageEvent, DmRequestEvent, Event, EventEnvelope};
+use tokio::sync::{broadcast, watch};
+use uuid::Uuid;
+
+use crate::db::repositories::Repositories;
+use crate::events::{EventBus, ServerEvent};
+
+/// Broadcast channel capacity. A connection that lags this far behind is
+/// closed so its client falls back to refetching (polling fallback contract).
+const BROADCAST_CAPACITY: usize = 256;
+
+/// A serialized event plus the set of user ids that may receive it.
+#[derive(Debug, Clone)]
+pub struct OutboundEvent {
+    recipients: Arc<HashSet<Uuid>>,
+    json: Arc<str>,
+}
+
+impl OutboundEvent {
+    pub fn is_for(&self, user_id: &Uuid) -> bool {
+        self.recipients.contains(user_id)
+    }
+
+    pub fn json(&self) -> &str {
+        &self.json
+    }
+}
+
+/// Tracks how many live WebSocket connections each user holds.
+#[derive(Debug, Default)]
+pub struct ConnectionRegistry {
+    connections: Mutex<HashMap<Uuid, usize>>,
+}
+
+impl ConnectionRegistry {
+    /// Record a new connection; returns the user's connection count after it.
+    pub fn connect(&self, user_id: Uuid) -> usize {
+        let mut connections = self.connections.lock().unwrap_or_else(|e| e.into_inner());
+        let count = connections.entry(user_id).or_insert(0);
+        *count += 1;
+        *count
+    }
+
+    /// Record a closed connection; returns the user's remaining count.
+    pub fn disconnect(&self, user_id: Uuid) -> usize {
+        let mut connections = self.connections.lock().unwrap_or_else(|e| e.into_inner());
+        match connections.get_mut(&user_id) {
+            Some(count) if *count > 1 => {
+                *count -= 1;
+                *count
+            }
+            Some(_) => {
+                connections.remove(&user_id);
+                0
+            }
+            None => 0,
+        }
+    }
+}
+
+/// The realtime gateway: publish-time recipient resolution + broadcast fan-out.
+pub struct RealtimeGateway {
+    repos: Repositories,
+    sender: broadcast::Sender<OutboundEvent>,
+    registry: ConnectionRegistry,
+    shutdown: watch::Sender<bool>,
+}
+
+impl RealtimeGateway {
+    pub fn new(repos: Repositories) -> Self {
+        let (sender, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (shutdown, _) = watch::channel(false);
+        Self {
+            repos,
+            sender,
+            registry: ConnectionRegistry::default(),
+            shutdown,
+        }
+    }
+
+    /// Subscribe a new connection task to the event stream.
+    pub fn subscribe(&self) -> broadcast::Receiver<OutboundEvent> {
+        self.sender.subscribe()
+    }
+
+    /// Watch channel that flips to `true` when the server is shutting down.
+    pub fn shutdown_signal(&self) -> watch::Receiver<bool> {
+        self.shutdown.subscribe()
+    }
+
+    /// Signal all connection tasks to close with a going-away frame.
+    pub fn shutdown(&self) {
+        let _ = self.shutdown.send(true);
+    }
+
+    pub fn registry(&self) -> &ConnectionRegistry {
+        &self.registry
+    }
+
+    /// Resolve the recipient set for an event via a single repo lookup.
+    fn resolve_recipients(&self, event: &Event) -> Result<HashSet<Uuid>> {
+        let recipients = match event {
+            Event::MessageCreated(payload) => self
+                .repos
+                .memberships
+                .list_members(&payload.community_id)
+                .context("Failed to resolve MessageCreated recipients")?
+                .into_iter()
+                .map(|m| m.user_id)
+                .collect(),
+            Event::ThreadCreated(post) => self
+                .repos
+                .memberships
+                .list_members(&post.community_id)
+                .context("Failed to resolve ThreadCreated recipients")?
+                .into_iter()
+                .map(|m| m.user_id)
+                .collect(),
+            Event::ThreadPendingApproval(post) => self
+                .repos
+                .memberships
+                .list_admins(&post.community_id)
+                .context("Failed to resolve ThreadPendingApproval recipients")?
+                .into_iter()
+                .map(|m| m.user_id)
+                .collect(),
+            Event::DmRequestCreated(payload) => {
+                let conversation = &payload.conversation;
+                let recipient = if conversation.initiator_id == conversation.user_a {
+                    conversation.user_b
+                } else {
+                    conversation.user_a
+                };
+                HashSet::from([recipient])
+            }
+            Event::DmMessageCreated(message) => {
+                HashSet::from([message.from_user_id, message.to_user_id])
+            }
+            Event::NotificationCreated(notification) => HashSet::from([notification.user_id]),
+        };
+        Ok(recipients)
+    }
+}
+
+impl EventBus for RealtimeGateway {
+    fn emit(&self, event: ServerEvent) -> Result<()> {
+        let event = match event {
+            ServerEvent::MessageCreated(message) => {
+                let channel = self
+                    .repos
+                    .channels
+                    .get_by_id(&message.channel_id)
+                    .context("Failed to look up channel for MessageCreated event")?
+                    .with_context(|| {
+                        format!(
+                            "Channel {} not found for MessageCreated event",
+                            message.channel_id
+                        )
+                    })?;
+                Event::MessageCreated(ChannelMessageEvent {
+                    message,
+                    community_id: channel.community_id,
+                })
+            }
+            ServerEvent::ThreadCreated(post) => Event::ThreadCreated(post),
+            ServerEvent::ThreadPendingApproval(post) => Event::ThreadPendingApproval(post),
+            ServerEvent::DmRequestCreated {
+                conversation,
+                message,
+            } => Event::DmRequestCreated(DmRequestEvent {
+                conversation,
+                message,
+            }),
+            ServerEvent::DmMessageCreated(message) => Event::DmMessageCreated(message),
+            ServerEvent::NotificationCreated(notification) => {
+                Event::NotificationCreated(notification)
+            }
+        };
+
+        let recipients = self.resolve_recipients(&event)?;
+        let envelope = EventEnvelope {
+            event,
+            ts: Utc::now(),
+        };
+        let json =
+            serde_json::to_string(&envelope).context("Failed to serialize event envelope")?;
+
+        // Err means no live subscribers, which is fine: events are also
+        // observable via the REST endpoints (polling fallback contract).
+        let _ = self.sender.send(OutboundEvent {
+            recipients: Arc::new(recipients),
+            json: Arc::from(json),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use chrono::Utc;
+    use fido_types::{
+        Channel, Community, Membership, MembershipRole, Message, Notification, NotificationType,
+        User,
+    };
+
+    fn test_user(username: &str) -> User {
+        User {
+            id: Uuid::new_v4(),
+            username: username.to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        }
+    }
+
+    fn setup() -> Result<(Database, RealtimeGateway, Community, Channel, User, User)> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repos = Repositories::new(db.pool.clone());
+
+        let member = test_user("member");
+        let outsider = test_user("outsider");
+        repos.users.create(&member)?;
+        repos.users.create(&outsider)?;
+
+        let community = Community {
+            id: Uuid::new_v4(),
+            github_repo_id: 42,
+            owner: "octocat".to_string(),
+            name: "hello".to_string(),
+            claimed_by: None,
+            require_thread_approval: false,
+            created_at: Utc::now(),
+        };
+        repos.communities.create(&community)?;
+
+        let channel = Channel {
+            id: Uuid::new_v4(),
+            community_id: community.id,
+            name: "general".to_string(),
+            created_at: Utc::now(),
+        };
+        repos.channels.create(&channel)?;
+
+        repos.memberships.insert(&Membership {
+            community_id: community.id,
+            user_id: member.id,
+            role: MembershipRole::Member,
+            created_at: Utc::now(),
+        })?;
+
+        let gateway = RealtimeGateway::new(repos);
+        Ok((db, gateway, community, channel, member, outsider))
+    }
+
+    #[test]
+    fn message_created_routes_to_members_only() -> Result<()> {
+        let (_db, gateway, community, channel, member, outsider) = setup()?;
+        let mut rx = gateway.subscribe();
+
+        gateway.emit(ServerEvent::MessageCreated(Message {
+            id: Uuid::new_v4(),
+            channel_id: channel.id,
+            author_id: member.id,
+            content: "hello".to_string(),
+            created_at: Utc::now(),
+        }))?;
+
+        let outbound = rx.try_recv()?;
+        assert!(outbound.is_for(&member.id));
+        assert!(!outbound.is_for(&outsider.id));
+
+        let envelope: serde_json::Value = serde_json::from_str(outbound.json())?;
+        assert_eq!(envelope["type"], "MessageCreated");
+        assert_eq!(
+            envelope["payload"]["community_id"],
+            community.id.to_string()
+        );
+        assert!(envelope["ts"].is_string());
+        Ok(())
+    }
+
+    #[test]
+    fn notification_created_routes_to_recipient_only() -> Result<()> {
+        let (_db, gateway, _community, _channel, member, outsider) = setup()?;
+        let mut rx = gateway.subscribe();
+
+        gateway.emit(ServerEvent::NotificationCreated(Notification {
+            id: Uuid::new_v4(),
+            user_id: member.id,
+            notification_type: NotificationType::Mention,
+            actor_id: outsider.id,
+            subject_type: "post".to_string(),
+            subject_id: Uuid::new_v4().to_string(),
+            read: false,
+            created_at: Utc::now(),
+        }))?;
+
+        let outbound = rx.try_recv()?;
+        assert!(outbound.is_for(&member.id));
+        assert!(!outbound.is_for(&outsider.id));
+        Ok(())
+    }
+
+    #[test]
+    fn registry_tracks_multiple_connections_per_user() {
+        let registry = ConnectionRegistry::default();
+        let user = Uuid::new_v4();
+        assert_eq!(registry.connect(user), 1);
+        assert_eq!(registry.connect(user), 2);
+        assert_eq!(registry.disconnect(user), 1);
+        assert_eq!(registry.disconnect(user), 0);
+        assert_eq!(registry.disconnect(user), 0);
+    }
+}

--- a/fido-server/src/services/chat.rs
+++ b/fido-server/src/services/chat.rs
@@ -188,7 +188,7 @@ mod tests {
         assert_eq!(events.len(), 1);
         match &events[0] {
             ServerEvent::MessageCreated(created) => assert_eq!(created.id, message.id),
-            ServerEvent::DmRequestCreated(_)
+            ServerEvent::DmRequestCreated { .. }
             | ServerEvent::DmMessageCreated(_)
             | ServerEvent::NotificationCreated(_)
             | ServerEvent::ThreadCreated(_)

--- a/fido-server/src/services/dms.rs
+++ b/fido-server/src/services/dms.rs
@@ -186,8 +186,10 @@ impl DMService {
                     "dm_conversation",
                     dm_subject_id(from_user_id, &to_user.id),
                 )?;
-                self.event_bus
-                    .emit(ServerEvent::DmRequestCreated(conversation))?;
+                self.event_bus.emit(ServerEvent::DmRequestCreated {
+                    conversation,
+                    message: message.clone(),
+                })?;
             }
         }
         self.event_bus
@@ -355,7 +357,7 @@ mod tests {
         let events = event_bus.events.lock().unwrap();
         assert_eq!(events.len(), 3);
         assert!(matches!(events[0], ServerEvent::NotificationCreated(_)));
-        assert!(matches!(events[1], ServerEvent::DmRequestCreated(_)));
+        assert!(matches!(events[1], ServerEvent::DmRequestCreated { .. }));
         assert!(matches!(events[2], ServerEvent::DmMessageCreated(_)));
 
         let notifications = repos.notifications.list_for_user(&recipient.id, 10, 0)?;

--- a/fido-server/src/state.rs
+++ b/fido-server/src/state.rs
@@ -1,6 +1,7 @@
 use crate::db::repositories::Repositories;
 use crate::db::Database;
-use crate::events::{NoopEventBus, SharedEventBus};
+use crate::events::SharedEventBus;
+use crate::realtime::RealtimeGateway;
 use crate::security::AuditLogger;
 use crate::services::github::GithubService;
 use crate::session::SessionManager;
@@ -16,6 +17,7 @@ pub struct AppState {
     pub audit_logger: AuditLogger,
     pub github_service: GithubService,
     pub event_bus: SharedEventBus,
+    pub realtime: Arc<RealtimeGateway>,
 }
 
 impl AppState {
@@ -29,7 +31,8 @@ impl AppState {
         let session_manager = SessionManager::new(repos.sessions.clone());
         let audit_logger = AuditLogger::new(repos.audit.clone());
         let github_service = GithubService::from_env(repos.clone())?;
-        let event_bus = Arc::new(NoopEventBus);
+        let realtime = Arc::new(RealtimeGateway::new(repos.clone()));
+        let event_bus: SharedEventBus = realtime.clone();
         Ok(Self {
             db,
             repos,
@@ -37,6 +40,7 @@ impl AppState {
             audit_logger,
             github_service,
             event_bus,
+            realtime,
         })
     }
 

--- a/fido-server/tests/ws_integration_tests.rs
+++ b/fido-server/tests/ws_integration_tests.rs
@@ -1,0 +1,302 @@
+//! Integration tests for the `/ws` realtime event gateway.
+//!
+//! Spins the real router on an ephemeral listener, connects WebSocket clients
+//! with real session tokens, drives the HTTP API, and asserts event delivery
+//! and membership filtering.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::protocol::Message as WsMessage;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use uuid::Uuid;
+
+use fido_server::db::repositories::Repositories;
+use fido_server::db::Database;
+use fido_server::state::AppState;
+use fido_types::{Channel, Community, Membership, MembershipRole, User};
+
+/// Base64 of 32 zero bytes; GithubService requires FIDO_TOKEN_KEY at startup.
+const TEST_TOKEN_KEY: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+const RECV_TIMEOUT: Duration = Duration::from_secs(5);
+const SILENCE_TIMEOUT: Duration = Duration::from_millis(500);
+
+struct TestServer {
+    addr: SocketAddr,
+    state: AppState,
+    _db_guard: TempDb,
+}
+
+/// Deletes the temp SQLite file when the test finishes.
+struct TempDb(std::path::PathBuf);
+
+impl Drop for TempDb {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+async fn spawn_server() -> Result<TestServer> {
+    std::env::set_var("FIDO_TOKEN_KEY", TEST_TOKEN_KEY);
+
+    let db_path = std::env::temp_dir().join(format!("fido-ws-test-{}.sqlite", Uuid::new_v4()));
+    let db = Database::new(&db_path).context("Failed to create test database")?;
+    db.initialize().context("Failed to initialize schema")?;
+
+    let repos = Repositories::new(db.pool.clone());
+    let state = AppState::new_with_repos(db, repos).context("Failed to build app state")?;
+    let router = fido_server::create_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("Failed to bind ephemeral listener")?;
+    let addr = listener.local_addr()?;
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("test server crashed");
+    });
+
+    Ok(TestServer {
+        addr,
+        state,
+        _db_guard: TempDb(db_path),
+    })
+}
+
+fn create_user(repos: &Repositories, username: &str) -> Result<User> {
+    let user = User {
+        id: Uuid::new_v4(),
+        username: username.to_string(),
+        bio: None,
+        join_date: Utc::now(),
+        is_test_user: true,
+        is_admin: false,
+    };
+    repos.users.create(&user)?;
+    Ok(user)
+}
+
+fn create_community_with_channel(repos: &Repositories) -> Result<(Community, Channel)> {
+    let community = Community {
+        id: Uuid::new_v4(),
+        github_repo_id: 4242,
+        owner: "octocat".to_string(),
+        name: "hello-world".to_string(),
+        claimed_by: None,
+        require_thread_approval: false,
+        created_at: Utc::now(),
+    };
+    repos.communities.create(&community)?;
+
+    let channel = Channel {
+        id: Uuid::new_v4(),
+        community_id: community.id,
+        name: "general".to_string(),
+        created_at: Utc::now(),
+    };
+    repos.channels.create(&channel)?;
+    Ok((community, channel))
+}
+
+fn add_member(repos: &Repositories, community_id: Uuid, user_id: Uuid) -> Result<()> {
+    repos.memberships.insert(&Membership {
+        community_id,
+        user_id,
+        role: MembershipRole::Member,
+        created_at: Utc::now(),
+    })?;
+    Ok(())
+}
+
+type WsClient = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+async fn connect_ws(addr: SocketAddr, token: &str) -> Result<WsClient> {
+    let mut request = format!("ws://{addr}/ws").into_client_request()?;
+    request
+        .headers_mut()
+        .insert("X-Session-Token", token.parse()?);
+    let (socket, _response) = tokio::time::timeout(RECV_TIMEOUT, connect_async(request))
+        .await
+        .context("WebSocket connect timed out")??;
+    Ok(socket)
+}
+
+/// Read frames until a Text frame arrives (skipping pings/pongs), then parse it.
+async fn next_event(socket: &mut WsClient) -> Result<serde_json::Value> {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        let frame = tokio::time::timeout_at(deadline, socket.next())
+            .await
+            .context("Timed out waiting for event")?
+            .context("WebSocket closed while waiting for event")??;
+        match frame {
+            WsMessage::Text(text) => {
+                return serde_json::from_str(&text).context("Event was not valid JSON")
+            }
+            WsMessage::Ping(payload) => {
+                socket.send(WsMessage::Pong(payload)).await?;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Assert no Text frame arrives within `SILENCE_TIMEOUT`.
+async fn assert_silent(socket: &mut WsClient) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + SILENCE_TIMEOUT;
+    loop {
+        match tokio::time::timeout_at(deadline, socket.next()).await {
+            Err(_) => return Ok(()), // timed out with no events: success
+            Ok(Some(Ok(WsMessage::Text(text)))) => {
+                anyhow::bail!("Expected no events, but received: {text}")
+            }
+            Ok(Some(Ok(_))) => continue, // control frames are fine
+            Ok(Some(Err(e))) => return Err(e.into()),
+            Ok(None) => anyhow::bail!("WebSocket closed unexpectedly"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn message_created_is_delivered_to_members_and_filtered_for_non_members() -> Result<()> {
+    let server = spawn_server().await?;
+    let repos = &server.state.repos;
+
+    let (community, channel) = create_community_with_channel(repos)?;
+    let user_a = create_user(repos, "member-a")?;
+    let user_b = create_user(repos, "member-b")?;
+    let user_c = create_user(repos, "outsider-c")?;
+    add_member(repos, community.id, user_a.id)?;
+    add_member(repos, community.id, user_b.id)?;
+
+    let token_a = server.state.session_manager.create_session(user_a.id)?;
+    let token_b = server.state.session_manager.create_session(user_b.id)?;
+    let token_c = server.state.session_manager.create_session(user_c.id)?;
+
+    let mut ws_a = connect_ws(server.addr, &token_a).await?;
+    let mut ws_b = connect_ws(server.addr, &token_b).await?;
+    let mut ws_c = connect_ws(server.addr, &token_c).await?;
+
+    // Send a channel message as A through the full HTTP path.
+    let response = reqwest::Client::new()
+        .post(format!(
+            "http://{}/channels/{}/messages",
+            server.addr, channel.id
+        ))
+        .header("X-Session-Token", &token_a)
+        .json(&serde_json::json!({ "content": "hello realtime" }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200, "message POST should succeed");
+
+    // Both members receive the MessageCreated envelope.
+    for ws in [&mut ws_a, &mut ws_b] {
+        let envelope = next_event(ws).await?;
+        assert_eq!(envelope["type"], "MessageCreated");
+        assert_eq!(envelope["payload"]["message"]["content"], "hello realtime");
+        assert_eq!(
+            envelope["payload"]["message"]["author_id"],
+            user_a.id.to_string()
+        );
+        assert_eq!(
+            envelope["payload"]["message"]["channel_id"],
+            channel.id.to_string()
+        );
+        assert_eq!(
+            envelope["payload"]["community_id"],
+            community.id.to_string()
+        );
+        let ts = envelope["ts"].as_str().expect("ts is a string");
+        ts.parse::<chrono::DateTime<chrono::Utc>>()
+            .expect("ts is ISO-8601");
+    }
+
+    // The non-member receives nothing.
+    assert_silent(&mut ws_c).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn ws_handshake_without_token_is_rejected_with_401() -> Result<()> {
+    let server = spawn_server().await?;
+
+    let request = format!("ws://{}/ws", server.addr).into_client_request()?;
+    let result = tokio::time::timeout(RECV_TIMEOUT, connect_async(request)).await?;
+
+    match result {
+        Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+            assert_eq!(response.status(), 401);
+        }
+        Err(other) => panic!("expected HTTP 401 rejection, got error: {other}"),
+        Ok(_) => panic!("handshake without token must not succeed"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn ws_handshake_with_invalid_token_is_rejected_with_401() -> Result<()> {
+    let server = spawn_server().await?;
+
+    let mut request = format!("ws://{}/ws", server.addr).into_client_request()?;
+    request
+        .headers_mut()
+        .insert("Authorization", "Bearer not-a-real-token".parse()?);
+    let result = tokio::time::timeout(RECV_TIMEOUT, connect_async(request)).await?;
+
+    match result {
+        Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+            assert_eq!(response.status(), 401);
+        }
+        Err(other) => panic!("expected HTTP 401 rejection, got error: {other}"),
+        Ok(_) => panic!("handshake with invalid token must not succeed"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn ws_accepts_query_token_and_delivers_notifications_to_recipient_only() -> Result<()> {
+    let server = spawn_server().await?;
+    let repos = &server.state.repos;
+
+    let (community, _channel) = create_community_with_channel(repos)?;
+    let sender = create_user(repos, "dm-sender")?;
+    let recipient = create_user(repos, "dm-recipient")?;
+    // Shared community so the DM does not require a message request.
+    add_member(repos, community.id, sender.id)?;
+    add_member(repos, community.id, recipient.id)?;
+
+    let token_sender = server.state.session_manager.create_session(sender.id)?;
+    let token_recipient = server.state.session_manager.create_session(recipient.id)?;
+
+    // Connect the recipient via the ?token= query fallback.
+    let request =
+        format!("ws://{}/ws?token={}", server.addr, token_recipient).into_client_request()?;
+    let (mut ws_recipient, _) = tokio::time::timeout(RECV_TIMEOUT, connect_async(request))
+        .await
+        .context("WebSocket connect timed out")??;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/dms", server.addr))
+        .header("X-Session-Token", &token_sender)
+        .json(&serde_json::json!({
+            "to_username": recipient.username,
+            "content": "hi over realtime",
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200, "DM POST should succeed");
+
+    let envelope = next_event(&mut ws_recipient).await?;
+    assert_eq!(envelope["type"], "DmMessageCreated");
+    assert_eq!(envelope["payload"]["content"], "hi over realtime");
+    assert_eq!(envelope["payload"]["from_user_id"], sender.id.to_string());
+    assert_eq!(envelope["payload"]["to_user_id"], recipient.id.to_string());
+    Ok(())
+}

--- a/fido-types/src/events.rs
+++ b/fido-types/src/events.rs
@@ -1,0 +1,45 @@
+//! Realtime event envelope and payloads pushed over the `/ws` gateway.
+//!
+//! Wire format: `{ "type": "<EventType>", "payload": { ... }, "ts": "<ISO-8601>" }`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::datetime_format;
+use crate::models::{DirectMessage, DmConversation, Message, Notification, Post};
+
+/// A channel message together with the community it belongs to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelMessageEvent {
+    pub message: Message,
+    pub community_id: Uuid,
+}
+
+/// A newly created DM request: the pending conversation plus its first message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DmRequestEvent {
+    pub conversation: DmConversation,
+    pub message: DirectMessage,
+}
+
+/// Typed realtime event, tagged by `type` with its DTO under `payload`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload")]
+pub enum Event {
+    MessageCreated(ChannelMessageEvent),
+    ThreadCreated(Post),
+    ThreadPendingApproval(Post),
+    DmRequestCreated(DmRequestEvent),
+    DmMessageCreated(DirectMessage),
+    NotificationCreated(Notification),
+}
+
+/// Envelope pushed to clients: the tagged event flattened next to a timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventEnvelope {
+    #[serde(flatten)]
+    pub event: Event,
+    #[serde(with = "datetime_format")]
+    pub ts: DateTime<Utc>,
+}

--- a/fido-types/src/lib.rs
+++ b/fido-types/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod enums;
+pub mod events;
 pub mod models;
 
 pub use enums::*;
+pub use events::*;
 pub use models::*;

--- a/fido-types/src/models.rs
+++ b/fido-types/src/models.rs
@@ -7,7 +7,7 @@ use crate::enums::{
 };
 
 // Custom serde module for DateTime to ensure RFC3339 string format
-mod datetime_format {
+pub(crate) mod datetime_format {
     use chrono::{DateTime, Utc};
     use serde::{self, Deserialize, Deserializer, Serializer};
 


### PR DESCRIPTION
## Summary

Implements stint 0010: the single realtime transport. One authed WebSocket per client; the server pushes typed events (chat messages, notifications, DM activity). Replaces the no-op event bus stubs from stints 0006-0009 with real delivery.

- `GET /ws` axum WebSocket upgrade, authenticated before upgrade via session token (`Authorization: Bearer`, `X-Session-Token`, or `?token=` fallback); invalid token gets HTTP 401 with no upgrade
- `RealtimeGateway` implements the existing `EventBus` trait over a tokio broadcast channel; recipients are resolved at publish time (one repo lookup per event) per the design-doc routing catalog, and the envelope is serialized once per event
- Wire envelope `{type, payload, ts}` with serde types shared via `fido-types` (new `events.rs`)
- Lifecycle: 30s server pings with drop after 2 missed pongs, per-user connection registry, graceful shutdown sends going-away (1001) close frames; a lagged consumer is closed so the client falls back to polling
- `DmRequestCreated` now carries the first message alongside the conversation, matching the catalog payload
- `NoopEventBus` deleted (nothing references it once the real gateway is wired; service tests use their own recording buses)
- New `MembershipRepository::list_members` for community fan-out

## Testing

- New integration suite `ws_integration_tests.rs`: two members receive `MessageCreated` via the full HTTP path, a non-member connection receives nothing, missing/invalid tokens are rejected with 401, `?token=` fallback verified via DM delivery
- `cargo test --workspace`, `cargo test -p fido-server --features sqlite-tests` (145 passed), `cargo clippy --workspace --all-targets` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)