### PR TITLE
Directory-scoped communities: repo-mode board, Home list, community modal, TUI e2e harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,8 +367,14 @@ mod tests {
 ```
 
 ### Integration Testing
-- **Server**: Test API endpoints with in-memory SQLite database
-- **End-to-End**: Test full stack with Docker containers
+- **Server**: Test API endpoints with in-memory SQLite database (`cargo test -p fido-server --features sqlite-tests`); `fido-server/tests/e2e_community_rewrite.rs` spins a real server plus a GitHub API fixture server via `GITHUB_API_BASE`.
+- **TUI End-to-End**: `just e2e-tui` (`scripts/e2e_tui.sh`) builds the real binaries, starts `fido-server` with a temp DB and a stubbed GitHub API (`scripts/github_stub.py`), then drives the TUI inside a detached tmux session with `send-keys`, asserting on `capture-pane` output, the SQLite database, and log files. Covers: test-user login, directory-scoped community join (launching inside a git repo with a GitHub origin), posting, the community settings modal, and Home mode outside a repo. On failure it dumps the pane, server log tail, and keeps artifacts in the temp workdir. Use this harness to verify TUI changes for real — don't stop at unit tests.
+
+### Directory-Scoped Communities
+The launch directory decides the community (see `docs/superpowers/specs/2026-07-02-directory-scoped-communities-design.md`):
+- Inside a git repo with a GitHub `origin`: the TUI joins that repo's community (lazily created server-side) and opens its board. Detection in `fido-tui/src/repo_context.rs`.
+- Anywhere else: Home mode — the Posts tab lists joined communities (Enter opens, Esc returns).
+- `i` on a board opens the community settings modal (role, member count, claim admin via GitHub permission check).
 
 ## Performance Characteristics
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,11 @@ Fido is a blazing-fast, keyboard-driven terminal social platform for developers,
 The project uses a `justfile` for common development tasks. Environment variables are automatically loaded from `.env` if present.
 
 ```bash
-# Run the server
+# Run the server (writes logs/fido-server.log by default)
 just server
+
+# Run the server with fresh database (also writes logs/fido-server.log)
+just server-reset
 
 # Run the TUI client
 just tui
@@ -235,6 +238,32 @@ The TUI uses a configurable logging system with feature-specific macros:
 Configuration via `LogConfig` in `fido-tui/src/logging.rs`. See `LOGGING.md` for details.
 
 ## Debugging & Logging
+
+### Local Server Logs
+
+`just server` and `just server-reset` write startup and runtime output to `logs/fido-server.log` by default while still echoing to the terminal. The recipes cap the active log at 10 MiB by default and rotate one previous file to `logs/fido-server.log.1`.
+
+```bash
+just server
+just server-reset
+```
+
+Tail the current local server log with:
+
+```bash
+just server-log
+# or
+tail -f logs/fido-server.log
+```
+
+Override log path or size only when needed:
+
+```bash
+FIDO_SERVER_LOG=/tmp/fido-server.log just server-reset
+FIDO_SERVER_LOG_MAX_BYTES=20971520 just server
+```
+
+If a server is already running from an older direct command and `lsof -p <pid>` shows stdout/stderr attached to `/dev/tty*`, past startup logs are only in that terminal's scrollback. Restart with `just server` or `just server-reset` before debugging startup behavior.
 
 ### Cohesive Logging System
 Fido uses a unified logging system built on Rust's `log` and `simplelog` crates with configurable features.

--- a/docs/superpowers/specs/2026-07-02-directory-scoped-communities-design.md
+++ b/docs/superpowers/specs/2026-07-02-directory-scoped-communities-design.md
@@ -1,0 +1,86 @@
+# Directory-Scoped Communities: TUI Reimagining
+
+Date: 2026-07-02
+Status: approved (Ian, in-session)
+
+## Decision
+
+The directory you launch `fido` from decides the community. No picker, no
+persistent community rail.
+
+- Launched inside a git repo with a GitHub `origin` remote: the TUI opens
+  directly to that repo's community board, auto-joining (which lazily creates
+  the community server-side on first visit).
+- Launched anywhere else: the TUI opens to a Home view listing the user's
+  joined communities (Enter opens one) plus DMs/Profile/Settings as today.
+  Empty state tells the user to launch fido inside a repo.
+
+This supersedes the persistent-left-rail layout in `.stint/tasks/0012` and
+replaces the hardcoded default-community bootstrap in the current WIP.
+
+## Scope
+
+1. **Repo context detection (TUI)** — new `fido-tui/src/repo_context.rs`.
+   At startup: `git -C <cwd> rev-parse --show-toplevel` (git walks up to the
+   nearest repo itself), then `git -C <top> remote get-url origin`, parse
+   `owner/name` from GitHub https/ssh remote forms. No repo, no origin, or a
+   non-GitHub remote all yield `None` (Home mode) — detection, not config, so
+   absence is a valid state, logged at info.
+
+2. **Join by owner/name (server)** — `POST /communities/join` request becomes
+   `{ owner, name }`; `github_repo_id` is removed from the request. The server
+   resolves the repo via GitHub `GET /repos/{owner}/{name}` — with the caller's
+   stored token when present, otherwise unauthenticated (public repos) — and
+   uses the canonical id/owner/name from the response. Unresolvable repo → 404
+   naming the repo. New `GithubService::get_repo`.
+
+3. **Community context state (TUI)** — replace
+   `current_community_id`/`current_community_label` with
+   `community: Option<CommunityContext>` carrying id, owner/name, the user's
+   `MembershipRole`, member_count, claimed flag, and
+   `require_thread_approval`. Populated from the join/get response after
+   login and after session restore.
+
+4. **UI**
+   - Posts tab is the Board. Repo mode: title `owner/name · role · N members`.
+   - Role badge renders admin/contributor/member from membership.
+   - Claim: `C` on the board when the community is unclaimed; server verifies
+     GitHub admin/maintain. Success updates the badge; Forbidden shows the
+     server's message inline.
+   - Home mode: Posts tab renders the joined-communities list; Enter loads
+     that community's board (`GET /communities/:id`), Esc returns to the list.
+   - DMs/Profile/Settings tabs unchanged. Hashtag-follow UI untouched this
+     pass (dies with stint 0014).
+
+5. **E2E TUI harness** — `just e2e-tui` → `scripts/e2e_tui.sh`:
+   - Starts a GitHub API stub (fixture responses for `/repos/...`,
+     `/repos/.../contributors`) and `fido-server` with a temp DB and
+     `GITHUB_API_BASE` pointed at the stub.
+   - Creates a temp git repo with a fake GitHub origin, launches the real TUI
+     binary inside it under tmux, logs in as a seeded test user, and asserts
+     via `tmux capture-pane` + server API + TUI log file: board title shows
+     the repo community, posting works, and launching outside a repo lands on
+     Home.
+
+## Non-Scope
+
+- Chat channels and WebSocket-driven state (stints 0011/0013).
+- Admin approval queue, member management UI (stint 0014).
+- Starred-repo browsing UI (`/communities/browse` stays server-only for now;
+  discovery on Home can come later).
+- Leave-community UI (endpoint exists; no keybind this pass).
+
+## Error Handling
+
+- Join failure in repo mode (server down, repo 404, private repo without
+  token): board pane shows the categorized error with a retry keybind; the
+  app stays usable (DMs/Profile/Settings still work).
+- No silent fallback from repo mode to Home mode: if the directory names a
+  repo, the app is that repo's community or an explicit error.
+
+## Testing
+
+- Unit: remote-URL parsing table (https, ssh, `.git` suffix, non-GitHub).
+- Server e2e (`e2e_community_rewrite.rs`): update join tests for the new
+  request shape; add resolve-failure case.
+- TUI e2e: harness above, run in CI-able script form.

--- a/fido-server/src/api/communities.rs
+++ b/fido-server/src/api/communities.rs
@@ -62,7 +62,6 @@ pub struct CommunityViewResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct JoinCommunityRequest {
-    pub github_repo_id: i64,
     pub owner: String,
     pub name: String,
 }
@@ -90,14 +89,7 @@ pub async fn join_community(
     validate_repo_name(&request.name, "name")?;
 
     let service = CommunityService::new(state.repos.clone(), state.github_service.clone());
-    let view = service
-        .join(
-            user_id,
-            request.github_repo_id,
-            &request.owner,
-            &request.name,
-        )
-        .await?;
+    let view = service.join(user_id, &request.owner, &request.name).await?;
 
     Ok(Json(map_community_view(view)))
 }

--- a/fido-server/src/db/connection.rs
+++ b/fido-server/src/db/connection.rs
@@ -42,11 +42,11 @@ impl Database {
             return Ok(());
         }
 
-        let conn = rusqlite::Connection::open_with_flags(
-            path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-        )
-        .with_context(|| format!("Failed to open existing database at {}", path.display()))?;
+        let conn =
+            rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .with_context(|| {
+                    format!("Failed to open existing database at {}", path.display())
+                })?;
 
         let version: i32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
@@ -92,16 +92,16 @@ impl Database {
             path.display(),
             backup.display()
         );
-        std::fs::rename(path, &backup)
-            .with_context(|| format!("Failed to archive legacy database to {}", backup.display()))?;
+        std::fs::rename(path, &backup).with_context(|| {
+            format!("Failed to archive legacy database to {}", backup.display())
+        })?;
         for suffix in ["-wal", "-shm"] {
             let sidecar = std::path::PathBuf::from(format!("{}{}", path.display(), suffix));
             if sidecar.exists() {
                 let sidecar_backup =
                     std::path::PathBuf::from(format!("{}{}", backup.display(), suffix));
-                std::fs::rename(&sidecar, &sidecar_backup).with_context(|| {
-                    format!("Failed to archive sidecar {}", sidecar.display())
-                })?;
+                std::fs::rename(&sidecar, &sidecar_backup)
+                    .with_context(|| format!("Failed to archive sidecar {}", sidecar.display()))?;
             }
         }
         Ok(())

--- a/fido-server/src/services/communities.rs
+++ b/fido-server/src/services/communities.rs
@@ -45,20 +45,18 @@ impl CommunityService {
             .collect()
     }
 
-    pub async fn join(
-        &self,
-        user_id: Uuid,
-        github_repo_id: i64,
-        owner: &str,
-        name: &str,
-    ) -> ApiResult<CommunityView> {
-        let community = match self
-            .repos
-            .communities
-            .get_by_github_repo_id(github_repo_id)?
-        {
+    pub async fn join(&self, user_id: Uuid, owner: &str, name: &str) -> ApiResult<CommunityView> {
+        let repo = self
+            .github
+            .get_repo(user_id, owner, name)
+            .await?
+            .ok_or_else(|| {
+                ApiError::NotFound(format!("GitHub repo {}/{} not found", owner, name))
+            })?;
+
+        let community = match self.repos.communities.get_by_github_repo_id(repo.id)? {
             Some(community) => community,
-            None => self.create_community(github_repo_id, owner, name)?,
+            None => self.create_community(repo.id, &repo.owner.login, &repo.name)?,
         };
 
         let role = if self
@@ -329,7 +327,7 @@ mod tests {
         assert!(browse[0].membership.is_none());
 
         let joined = service
-            .join(user_id, 1296269, "octocat", "Hello-World")
+            .join(user_id, "octocat", "Hello-World")
             .await
             .expect("join");
         assert_eq!(joined.community.github_repo_id, 1296269);

--- a/fido-server/src/services/github.rs
+++ b/fido-server/src/services/github.rs
@@ -118,6 +118,57 @@ impl GithubService {
         result
     }
 
+    /// Resolve a repo by owner/name. Uses the caller's stored token when present
+    /// (required for private repos), otherwise queries unauthenticated.
+    /// Returns Ok(None) when GitHub reports the repo does not exist (404).
+    pub async fn get_repo(
+        &self,
+        user_id: Uuid,
+        owner: &str,
+        name: &str,
+    ) -> Result<Option<GithubRepo>> {
+        let url = format!("{}/repos/{}/{}", self.api_base, owner, name);
+        let token = self.load_token(user_id)?;
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("User-Agent", GITHUB_USER_AGENT)
+            .header("Accept", GITHUB_API_ACCEPT);
+        if let Some(token) = token.as_deref() {
+            request = request.header("Authorization", format!("Bearer {}", token));
+        }
+
+        let result = async {
+            let response = request
+                .send()
+                .await
+                .with_context(|| format!("GitHub get_repo request failed for {}/{}", owner, name))?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            let repo = response
+                .error_for_status()
+                .with_context(|| {
+                    format!(
+                        "GitHub get_repo returned non-success status for {}/{}",
+                        owner, name
+                    )
+                })?
+                .json::<GithubRepo>()
+                .await
+                .with_context(|| {
+                    format!("Failed to parse GitHub repo response for {}/{}", owner, name)
+                })?;
+            Ok(Some(repo))
+        }
+        .await;
+
+        let op = format!("GET /repos/{}/{}", owner, name);
+        self.log_result("get_repo", user_id, Some(&op), &result);
+        result
+    }
+
     pub async fn repo_permission(
         &self,
         user_id: Uuid,

--- a/fido-server/src/services/github.rs
+++ b/fido-server/src/services/github.rs
@@ -140,10 +140,9 @@ impl GithubService {
         }
 
         let result = async {
-            let response = request
-                .send()
-                .await
-                .with_context(|| format!("GitHub get_repo request failed for {}/{}", owner, name))?;
+            let response = request.send().await.with_context(|| {
+                format!("GitHub get_repo request failed for {}/{}", owner, name)
+            })?;
             if response.status() == StatusCode::NOT_FOUND {
                 return Ok(None);
             }
@@ -158,7 +157,10 @@ impl GithubService {
                 .json::<GithubRepo>()
                 .await
                 .with_context(|| {
-                    format!("Failed to parse GitHub repo response for {}/{}", owner, name)
+                    format!(
+                        "Failed to parse GitHub repo response for {}/{}",
+                        owner, name
+                    )
                 })?;
             Ok(Some(repo))
         }

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -161,7 +161,10 @@ async fn github_fixture_server() -> Result<String> {
         .route("/repos/octocat/Hello-World", get(repo))
         .route("/repos/octocat/Hello-World/contributors", get(contributors))
         .route("/repos/:owner/:name", get(dynamic_repo))
-        .route("/repos/:owner/:name/contributors", get(dynamic_contributors));
+        .route(
+            "/repos/:owner/:name/contributors",
+            get(dynamic_contributors),
+        );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
     tokio::spawn(async move {
@@ -336,10 +339,7 @@ async fn communities_join_list_detail_leave_e2e() -> Result<()> {
 
     // Invalid repo names are rejected.
     let response = alice_client
-        .post(
-            "/communities/join",
-            &json!({ "owner": "a/b", "name": "x" }),
-        )
+        .post("/communities/join", &json!({ "owner": "a/b", "name": "x" }))
         .await?;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
@@ -607,7 +607,10 @@ async fn threads_board_scoped_and_approval_e2e() -> Result<()> {
     assert_eq!(response.status(), StatusCode::OK);
 
     let response = replier_client
-        .post(&format!("/posts/{}/vote", post_id), &json!({ "direction": "up" }))
+        .post(
+            &format!("/posts/{}/vote", post_id),
+            &json!({ "direction": "up" }),
+        )
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
 

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -79,9 +79,28 @@ async fn spawn_server(github_api_base: Option<&str>) -> Result<TestServer> {
     })
 }
 
+/// Deterministic fixture repo id so parallel joins of the same owner/name agree.
+fn fixture_repo_id(owner: &str, name: &str) -> i64 {
+    let mut hash: i64 = 7;
+    for byte in owner.bytes().chain([b'/']).chain(name.bytes()) {
+        hash = hash.wrapping_mul(31).wrapping_add(byte as i64);
+    }
+    hash.abs().max(2)
+}
+
 /// Local stand-in for api.github.com using recorded response shapes.
+///
+/// Serves the recorded octocat/Hello-World fixtures exactly, resolves any
+/// other /repos/:owner/:name with a deterministic id, and 404s owner "ghost"
+/// to exercise the unresolvable-repo path.
 async fn github_fixture_server() -> Result<String> {
-    use axum::{routing::get, Json, Router};
+    use axum::{
+        extract::Path,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        routing::get,
+        Json, Router,
+    };
 
     async fn starred() -> Json<Value> {
         Json(json!([
@@ -119,10 +138,30 @@ async fn github_fixture_server() -> Result<String> {
         ]))
     }
 
+    async fn dynamic_repo(Path((owner, name)): Path<(String, String)>) -> Response {
+        if owner == "ghost" {
+            return StatusCode::NOT_FOUND.into_response();
+        }
+        Json(json!({
+            "id": fixture_repo_id(&owner, &name),
+            "name": name,
+            "full_name": format!("{}/{}", owner, name),
+            "private": false,
+            "owner": { "login": owner }
+        }))
+        .into_response()
+    }
+
+    async fn dynamic_contributors() -> Json<Value> {
+        Json(json!([]))
+    }
+
     let app = Router::new()
         .route("/user/starred", get(starred))
         .route("/repos/octocat/Hello-World", get(repo))
-        .route("/repos/octocat/Hello-World/contributors", get(contributors));
+        .route("/repos/octocat/Hello-World/contributors", get(contributors))
+        .route("/repos/:owner/:name", get(dynamic_repo))
+        .route("/repos/:owner/:name/contributors", get(dynamic_contributors));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
     tokio::spawn(async move {
@@ -248,7 +287,8 @@ async fn json_body(response: reqwest::Response) -> Result<Value> {
 
 #[tokio::test]
 async fn communities_join_list_detail_leave_e2e() -> Result<()> {
-    let server = spawn_server(None).await?;
+    let fixture_base = github_fixture_server().await?;
+    let server = spawn_server(Some(&fixture_base)).await?;
     let repos = &server.state.repos;
 
     let alice = create_user(repos, "e2e-alice")?;
@@ -263,10 +303,9 @@ async fn communities_join_list_detail_leave_e2e() -> Result<()> {
         .await?;
     assert_eq!(anon.status(), StatusCode::UNAUTHORIZED);
 
-    // Join lazily creates the community with a default general channel.
-    let repo_id = rand_repo_id();
+    // Join resolves the repo via GitHub and lazily creates the community
+    // with a default general channel.
     let join_body = json!({
-        "github_repo_id": repo_id,
         "owner": "octocat",
         "name": "lazy-created-repo",
     });
@@ -274,7 +313,10 @@ async fn communities_join_list_detail_leave_e2e() -> Result<()> {
     assert_eq!(response.status(), StatusCode::OK, "join should succeed");
     let view = json_body(response).await?;
     let community_id = view["community"]["id"].as_str().unwrap().to_string();
-    assert_eq!(view["community"]["github_repo_id"], repo_id);
+    assert_eq!(
+        view["community"]["github_repo_id"],
+        fixture_repo_id("octocat", "lazy-created-repo")
+    );
     assert_eq!(view["membership"]["role"], "member");
     assert_eq!(view["member_count"], 1);
     assert_eq!(view["channels"][0]["name"], "general");
@@ -296,10 +338,19 @@ async fn communities_join_list_detail_leave_e2e() -> Result<()> {
     let response = alice_client
         .post(
             "/communities/join",
-            &json!({ "github_repo_id": rand_repo_id(), "owner": "a/b", "name": "x" }),
+            &json!({ "owner": "a/b", "name": "x" }),
         )
         .await?;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // A repo GitHub can't resolve is a 404, not a lazily created community.
+    let response = alice_client
+        .post(
+            "/communities/join",
+            &json!({ "owner": "ghost", "name": "no-such-repo" }),
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // List shows the joined community.
     let listed = json_body(alice_client.get("/communities").await?).await?;
@@ -350,7 +401,7 @@ async fn communities_browse_and_claim_e2e() -> Result<()> {
     let response = client
         .post(
             "/communities/join",
-            &json!({ "github_repo_id": 1296269, "owner": "octocat", "name": "Hello-World" }),
+            &json!({ "owner": "octocat", "name": "Hello-World" }),
         )
         .await?;
     assert_eq!(response.status(), StatusCode::OK);

--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -200,12 +200,14 @@ impl ApiClient {
     /// Get posts with optional limit, sort order, and filters
     pub async fn get_posts(
         &self,
+        community_id: Uuid,
         limit: Option<i32>,
         sort: Option<String>,
         hashtag: Option<String>,
         username: Option<String>,
     ) -> ApiResult<Vec<Post>> {
         let mut params = Vec::new();
+        params.push(("community_id", community_id.to_string()));
 
         if let Some(l) = limit {
             params.push(("limit", l.to_string()));
@@ -224,6 +226,47 @@ impl ApiClient {
         let url = self.build_url_with_params("/posts", &params_ref);
 
         let req = self.add_auth_header(self.client.get(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// List communities joined by the authenticated user
+    pub async fn list_communities(&self) -> ApiResult<Vec<CommunityViewResponse>> {
+        let url = self.build_url("/communities");
+        let req = self.add_auth_header(self.client.get(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Join a repo community; the server resolves the repo via GitHub and
+    /// lazily creates the community on first join.
+    pub async fn join_community(
+        &self,
+        owner: &str,
+        name: &str,
+    ) -> ApiResult<CommunityViewResponse> {
+        let url = self.build_url("/communities/join");
+        let request = JoinCommunityRequest {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        };
+        let req = self.add_auth_header(self.client.post(&url).json(&request));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Get a community view by id (includes the caller's membership)
+    pub async fn get_community(&self, community_id: Uuid) -> ApiResult<CommunityViewResponse> {
+        let url = self.build_url(&format!("/communities/{}", community_id));
+        let req = self.add_auth_header(self.client.get(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Claim admin of a community (server verifies GitHub admin/maintain permission)
+    pub async fn claim_community(&self, community_id: Uuid) -> ApiResult<CommunityViewResponse> {
+        let url = self.build_url(&format!("/communities/{}/claim", community_id));
+        let req = self.add_auth_header(self.client.post(&url).json(&serde_json::json!({})));
         let response = req.send().await?;
         self.handle_response(response).await
     }
@@ -513,4 +556,30 @@ pub struct DevicePollRequest {
 pub struct ValidateSessionResponse {
     pub user: fido_types::User,
     pub valid: bool,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct CommunityViewResponse {
+    pub community: CommunityResponse,
+    pub membership: Option<MembershipResponse>,
+    pub member_count: i64,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct CommunityResponse {
+    pub id: Uuid,
+    pub owner: String,
+    pub name: String,
+    pub claimed_by: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct MembershipResponse {
+    pub role: fido_types::MembershipRole,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct JoinCommunityRequest {
+    owner: String,
+    name: String,
 }

--- a/fido-tui/src/api/mod.rs
+++ b/fido-tui/src/api/mod.rs
@@ -1,5 +1,5 @@
 mod client;
 mod error;
 
-pub use client::{ApiClient, SocialUserInfo, VoteDirection};
+pub use client::{ApiClient, CommunityViewResponse, SocialUserInfo, VoteDirection};
 pub use error::{ApiError, ApiResult};

--- a/fido-tui/src/app/auth.rs
+++ b/fido-tui/src/app/auth.rs
@@ -37,10 +37,15 @@ impl App {
         self.auth_state.current_user = None;
         self.current_screen = Screen::Auth;
         self.posts_state.posts.clear();
+        self.posts_state.message = None;
         self.profile_state.profile = None;
         self.dms_state.conversations.clear();
         self.dms_state.conversations_loaded = false;
         self.dms_state.messages.clear();
+        self.community = None;
+        self.community_error = None;
+        self.show_community_modal = false;
+        self.home_state = super::state::HomeState::new();
 
         // Reset GitHub Device Flow state
         self.auth_state.github_auth_in_progress = false;
@@ -125,6 +130,8 @@ impl App {
 
                 // Load filter preference
                 self.load_filter_preference();
+
+                let _ = self.init_community_context().await;
 
                 // Load posts after successful login (will use loaded settings and filter)
                 let _ = self.load_posts().await;

--- a/fido-tui/src/app/build.rs
+++ b/fido-tui/src/app/build.rs
@@ -162,7 +162,11 @@ impl App {
             log_config: crate::logging::LogConfig::default(),
             pending_vote_tasks: Vec::new(),
             update_available: None,
-            current_community_id: None,
+            launch_repo: None,
+            community: None,
+            community_error: None,
+            home_state: HomeState::new(),
+            show_community_modal: false,
         }
     }
 }

--- a/fido-tui/src/app/communities.rs
+++ b/fido-tui/src/app/communities.rs
@@ -1,0 +1,169 @@
+//! Community context: the launch directory decides the community.
+//!
+//! Repo mode (launched inside a GitHub repo): join that repo's community and
+//! scope the board to it. Home mode (anywhere else): list joined communities
+//! and let the user open one.
+
+use anyhow::Result;
+
+use crate::api::CommunityViewResponse;
+
+use super::{categorize_error, App};
+
+impl App {
+    /// Entry point after login or session restore.
+    pub async fn init_community_context(&mut self) -> Result<()> {
+        self.community = None;
+        self.community_error = None;
+
+        if let Some(repo) = self.launch_repo.clone() {
+            self.enter_repo_community(&repo.owner, &repo.name).await;
+        } else {
+            self.load_home_communities().await;
+        }
+        Ok(())
+    }
+
+    /// Repo mode: join (lazily creating) the launch repo's community.
+    async fn enter_repo_community(&mut self, owner: &str, name: &str) {
+        match self.api_client.join_community(owner, name).await {
+            Ok(view) => {
+                self.apply_community_view(view);
+            }
+            Err(e) => {
+                log::error!("Failed to join community {}/{}: {}", owner, name, e);
+                self.community_error = Some(format!(
+                    "Could not open the {}/{} community: {}",
+                    owner,
+                    name,
+                    categorize_error(&e.to_string())
+                ));
+            }
+        }
+    }
+
+    /// Home mode: load the joined-communities list.
+    pub async fn load_home_communities(&mut self) {
+        self.home_state.loading = true;
+        self.home_state.error = None;
+
+        match self.api_client.list_communities().await {
+            Ok(communities) => {
+                self.home_state.communities = communities;
+                self.home_state.loaded = true;
+                if self.home_state.communities.is_empty() {
+                    self.home_state.list_state.select(None);
+                } else {
+                    self.home_state.list_state.select(Some(0));
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to list joined communities: {}", e);
+                self.home_state.error = Some(categorize_error(&e.to_string()));
+            }
+        }
+
+        self.home_state.loading = false;
+    }
+
+    /// Home mode: whether the joined-communities list is the active Posts view.
+    pub fn is_home_list_active(&self) -> bool {
+        self.launch_repo.is_none() && self.community.is_none()
+    }
+
+    /// Home mode: open the selected community's board.
+    pub async fn open_home_selection(&mut self) -> Result<()> {
+        let Some(selected) = self.home_state.selected() else {
+            return Ok(());
+        };
+        let community_id = selected.community.id;
+
+        match self.api_client.get_community(community_id).await {
+            Ok(view) => {
+                self.apply_community_view(view);
+                self.load_posts().await?;
+            }
+            Err(e) => {
+                log::error!("Failed to open community {}: {}", community_id, e);
+                self.home_state.error = Some(categorize_error(&e.to_string()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Home mode: leave the open board and return to the communities list.
+    pub fn close_community(&mut self) {
+        self.community = None;
+        self.show_community_modal = false;
+        self.posts_state.posts.clear();
+        self.posts_state.list_state.select(None);
+        self.posts_state.error = None;
+    }
+
+    /// Repo mode: retry after a failed join (server down, repo unresolvable).
+    pub async fn retry_community(&mut self) -> Result<()> {
+        self.init_community_context().await?;
+        if self.community.is_some() {
+            self.load_posts().await?;
+        }
+        Ok(())
+    }
+
+    /// Claim admin of the current community; the server verifies GitHub
+    /// admin/maintain permission on the repo.
+    pub async fn claim_current_community(&mut self) -> Result<()> {
+        let Some(community_id) = self.community.as_ref().map(|c| c.id) else {
+            return Ok(());
+        };
+
+        match self.api_client.claim_community(community_id).await {
+            Ok(view) => {
+                self.apply_community_view(view);
+                self.posts_state.message = Some((
+                    "Community claimed - you are now admin".to_string(),
+                    std::time::Instant::now(),
+                ));
+            }
+            Err(e) => {
+                log::error!("Failed to claim community {}: {}", community_id, e);
+                self.posts_state.message = Some((
+                    format!("Claim failed: {}", categorize_error(&e.to_string())),
+                    std::time::Instant::now(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_community_view(&mut self, view: CommunityViewResponse) {
+        self.community = Some(crate::app::state::CommunityContext {
+            id: view.community.id,
+            owner: view.community.owner,
+            name: view.community.name,
+            role: view.membership.map(|m| m.role),
+            member_count: view.member_count,
+            claimed: view.community.claimed_by.is_some(),
+        });
+        self.community_error = None;
+    }
+
+    /// Home list navigation
+    pub fn next_home_community(&mut self) {
+        move_home_selection(&mut self.home_state, 1);
+    }
+
+    pub fn previous_home_community(&mut self) {
+        move_home_selection(&mut self.home_state, -1);
+    }
+}
+
+fn move_home_selection(home: &mut crate::app::state::HomeState, delta: i64) {
+    let len = home.communities.len();
+    if len == 0 {
+        home.list_state.select(None);
+        return;
+    }
+    let current = home.list_state.selected().unwrap_or(0) as i64;
+    let next = (current + delta).rem_euclid(len as i64) as usize;
+    home.list_state.select(Some(next));
+}

--- a/fido-tui/src/app/composer.rs
+++ b/fido-tui/src/app/composer.rs
@@ -173,7 +173,7 @@ impl App {
         match &self.composer_state.mode {
             Some(ComposerMode::NewPost) => {
                 self.posts_state.error = None;
-                let Some(community_id) = self.current_community_id else {
+                let Some(community_id) = self.community.as_ref().map(|c| c.id) else {
                     self.posts_state.error = Some("No community selected".to_string());
                     return Ok(());
                 };

--- a/fido-tui/src/app/handlers/mod.rs
+++ b/fido-tui/src/app/handlers/mod.rs
@@ -115,6 +115,18 @@ fn handle_global_keys(app: &mut App, key: KeyEvent) -> Result<bool> {
             app.toggle_help();
             Ok(true)
         }
+        // Esc from a board opened off the Home list returns to the list
+        // (repo mode has no list to return to, so Esc falls through to quit).
+        KeyCode::Esc
+            if app.input_mode == InputMode::Navigation
+                && app.current_screen == Screen::Main
+                && app.current_tab == Tab::Posts
+                && app.launch_repo.is_none()
+                && app.community.is_some() =>
+        {
+            app.close_community();
+            Ok(true)
+        }
         KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc
             if app.input_mode == InputMode::Navigation =>
         {

--- a/fido-tui/src/app/handlers/modals.rs
+++ b/fido-tui/src/app/handlers/modals.rs
@@ -4,6 +4,17 @@ use crossterm::event::{KeyCode, KeyEvent};
 
 /// Handle modal key events, returning Some(()) if a modal consumed the event
 pub fn handle_modal_keys(app: &mut App, key: KeyEvent) -> Result<Option<()>> {
+    // Community settings modal ('c' claim is async and handled by the event loop)
+    if app.show_community_modal {
+        if matches!(
+            key.code,
+            KeyCode::Esc | KeyCode::Char('i') | KeyCode::Char('I')
+        ) {
+            app.show_community_modal = false;
+        }
+        return Ok(Some(()));
+    }
+
     // Priority 3: Filter modal
     if app.posts_state.show_filter_modal {
         if matches!(key.code, KeyCode::Esc) {

--- a/fido-tui/src/app/handlers/posts.rs
+++ b/fido-tui/src/app/handlers/posts.rs
@@ -12,6 +12,20 @@ pub fn handle_posts_keys(app: &mut App, key: KeyEvent) -> Result<()> {
         return handle_post_detail_keys(app, key);
     }
 
+    // Home mode: the Posts tab shows the joined-communities list.
+    if app.is_home_list_active() {
+        match key.code {
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => {
+                app.next_home_community();
+            }
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => {
+                app.previous_home_community();
+            }
+            _ => {}
+        }
+        return Ok(());
+    }
+
     match key.code {
         KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => {
             app.next_post();
@@ -29,6 +43,11 @@ pub fn handle_posts_keys(app: &mut App, key: KeyEvent) -> Result<()> {
         }
         KeyCode::Char('s') | KeyCode::Char('S') => {
             app.open_user_search_modal();
+        }
+        KeyCode::Char('i') | KeyCode::Char('I') => {
+            if app.community.is_some() {
+                app.show_community_modal = true;
+            }
         }
         KeyCode::Char('p') | KeyCode::Char('P') => {}
         KeyCode::Enter => {}

--- a/fido-tui/src/app/mod.rs
+++ b/fido-tui/src/app/mod.rs
@@ -5,6 +5,7 @@ pub mod handlers;
 pub(crate) use error::categorize_error;
 mod auth;
 mod build;
+mod communities;
 mod composer;
 mod dms;
 mod friends;

--- a/fido-tui/src/app/posts.rs
+++ b/fido-tui/src/app/posts.rs
@@ -61,16 +61,32 @@ impl App {
             .map(|c| c.max_posts_display)
             .unwrap_or(25);
 
+        let Some(community_id) = self.community.as_ref().map(|c| c.id) else {
+            self.posts_state.posts.clear();
+            self.posts_state.list_state.select(None);
+            self.posts_state.loading = false;
+            return Ok(());
+        };
+
+        self.posts_state.message = None;
+
         // Apply current filter
         let result = match &self.posts_state.current_filter {
             PostFilter::All => {
                 self.api_client
-                    .get_posts(Some(max_posts), Some(sort_order.clone()), None, None)
+                    .get_posts(
+                        community_id,
+                        Some(max_posts),
+                        Some(sort_order.clone()),
+                        None,
+                        None,
+                    )
                     .await
             }
             PostFilter::Hashtag(tag) => {
                 self.api_client
                     .get_posts(
+                        community_id,
                         Some(max_posts),
                         Some(sort_order.clone()),
                         Some(tag.clone()),
@@ -81,6 +97,7 @@ impl App {
             PostFilter::User(user) => {
                 self.api_client
                     .get_posts(
+                        community_id,
                         Some(max_posts),
                         Some(sort_order.clone()),
                         None,
@@ -97,6 +114,7 @@ impl App {
                     if let Ok(posts) = self
                         .api_client
                         .get_posts(
+                            community_id,
                             Some(max_posts),
                             Some(sort_order.clone()),
                             Some(hashtag.clone()),
@@ -113,6 +131,7 @@ impl App {
                     if let Ok(posts) = self
                         .api_client
                         .get_posts(
+                            community_id,
                             Some(max_posts),
                             Some(sort_order.clone()),
                             None,

--- a/fido-tui/src/app/profile.rs
+++ b/fido-tui/src/app/profile.rs
@@ -25,29 +25,35 @@ impl App {
             }
 
             // Load user's posts
-            match self
-                .api_client
-                .get_posts(
-                    Some(100),
-                    Some("Newest".to_string()),
-                    None,
-                    Some(user.username.clone()),
-                )
-                .await
-            {
-                Ok(posts) => {
-                    self.profile_state.user_posts = posts;
-                    if !self.profile_state.user_posts.is_empty() {
-                        self.profile_state.list_state.select(Some(0));
-                    } else {
-                        self.profile_state.list_state.select(None);
+            if let Some(community_id) = self.community.as_ref().map(|c| c.id) {
+                match self
+                    .api_client
+                    .get_posts(
+                        community_id,
+                        Some(100),
+                        Some("Newest".to_string()),
+                        None,
+                        Some(user.username.clone()),
+                    )
+                    .await
+                {
+                    Ok(posts) => {
+                        self.profile_state.user_posts = posts;
+                        if !self.profile_state.user_posts.is_empty() {
+                            self.profile_state.list_state.select(Some(0));
+                        } else {
+                            self.profile_state.list_state.select(None);
+                        }
+                    }
+                    Err(e) => {
+                        let error_msg = categorize_error(&e.to_string());
+                        self.profile_state.error =
+                            Some(format!("{} (Switch tabs to retry)", error_msg));
                     }
                 }
-                Err(e) => {
-                    let error_msg = categorize_error(&e.to_string());
-                    self.profile_state.error =
-                        Some(format!("{} (Switch tabs to retry)", error_msg));
-                }
+            } else {
+                self.profile_state.user_posts.clear();
+                self.profile_state.list_state.select(None);
             }
 
             self.profile_state.loading = false;

--- a/fido-tui/src/app/state.rs
+++ b/fido-tui/src/app/state.rs
@@ -161,8 +161,60 @@ pub struct App {
         Vec<tokio::task::JoinHandle<(uuid::Uuid, crate::api::ApiResult<serde_json::Value>)>>,
     /// Latest version available on crates.io (if newer than current)
     pub update_available: Option<String>,
-    /// Community whose board the composer posts to (wired by task 0011)
-    pub current_community_id: Option<Uuid>,
+    /// GitHub repo detected from the launch directory; decides the community
+    pub launch_repo: Option<crate::repo_context::RepoRef>,
+    /// The community whose board is currently shown
+    pub community: Option<CommunityContext>,
+    /// Why the launch repo's community could not be entered (repo mode only)
+    pub community_error: Option<String>,
+    /// Joined-communities list shown when launched outside a repo
+    pub home_state: HomeState,
+    /// Community settings modal (role, member count, claim)
+    pub show_community_modal: bool,
+}
+
+/// The community the board is scoped to, with the caller's standing in it
+#[derive(Debug, Clone)]
+pub struct CommunityContext {
+    pub id: Uuid,
+    pub owner: String,
+    pub name: String,
+    pub role: Option<fido_types::MembershipRole>,
+    pub member_count: i64,
+    pub claimed: bool,
+}
+
+impl CommunityContext {
+    pub fn full_name(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+}
+
+/// Home mode state: the joined-communities list (launched outside a repo)
+pub struct HomeState {
+    pub communities: Vec<crate::api::CommunityViewResponse>,
+    pub list_state: ListState,
+    pub loading: bool,
+    pub loaded: bool,
+    pub error: Option<String>,
+}
+
+impl HomeState {
+    pub fn new() -> Self {
+        Self {
+            communities: Vec::new(),
+            list_state: ListState::default(),
+            loading: false,
+            loaded: false,
+            error: None,
+        }
+    }
+
+    pub fn selected(&self) -> Option<&crate::api::CommunityViewResponse> {
+        self.list_state
+            .selected()
+            .and_then(|i| self.communities.get(i))
+    }
 }
 
 /// Settings tab state

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -2,6 +2,18 @@ use super::*;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use fido_types::Post;
 
+/// Put the app on a community board (the launch-repo path in production).
+fn set_test_community(app: &mut App) {
+    app.community = Some(crate::app::state::CommunityContext {
+        id: uuid::Uuid::new_v4(),
+        owner: "testowner".to_string(),
+        name: "testrepo".to_string(),
+        role: Some(fido_types::MembershipRole::Member),
+        member_count: 1,
+        claimed: false,
+    });
+}
+
 /// Helper to create a KeyEvent
 fn key_event(code: KeyCode) -> KeyEvent {
     let mut event = KeyEvent::new(code, KeyModifiers::empty());
@@ -129,6 +141,76 @@ fn test_escape_exits_app_when_no_modals() {
     app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
 
     assert!(!app.running, "App should stop running");
+}
+
+#[test]
+fn test_escape_returns_to_home_list_from_opened_community() {
+    let mut app = App::new();
+    app.current_screen = Screen::Main;
+    app.current_tab = Tab::Posts;
+    app.running = true;
+    // Home mode (no launch repo) with a community opened from the list
+    app.launch_repo = None;
+    set_test_community(&mut app);
+
+    app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
+
+    assert!(app.community.is_none(), "Board should close back to Home");
+    assert!(app.running, "App should still be running");
+
+    // Second Escape from the Home list quits
+    app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
+    assert!(!app.running, "App should stop running from Home");
+}
+
+#[test]
+fn test_escape_quits_in_repo_mode() {
+    let mut app = App::new();
+    app.current_screen = Screen::Main;
+    app.current_tab = Tab::Posts;
+    app.running = true;
+    // Repo mode: launch repo decides the community; there is no list to return to
+    app.launch_repo = Some(crate::repo_context::RepoRef {
+        owner: "testowner".to_string(),
+        name: "testrepo".to_string(),
+    });
+    set_test_community(&mut app);
+
+    app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
+    assert!(!app.running, "Esc quits directly in repo mode");
+}
+
+#[test]
+fn test_i_opens_community_modal_and_escape_closes_it() {
+    let mut app = App::new();
+    app.current_screen = Screen::Main;
+    app.current_tab = Tab::Posts;
+    app.input_mode = InputMode::Navigation;
+    set_test_community(&mut app);
+
+    app.handle_key_event(key_event(KeyCode::Char('i'))).unwrap();
+    assert!(app.show_community_modal, "'i' opens the community modal");
+
+    app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
+    assert!(!app.show_community_modal, "Esc closes the community modal");
+    assert!(app.community.is_some(), "Board stays open behind the modal");
+}
+
+#[test]
+fn test_home_list_navigation_keys() {
+    let mut app = App::new();
+    app.current_screen = Screen::Main;
+    app.current_tab = Tab::Posts;
+    app.input_mode = InputMode::Navigation;
+    // Home mode with no community selected
+    assert!(app.is_home_list_active());
+
+    // 'n' must not open the composer while the home list is active
+    app.handle_key_event(key_event(KeyCode::Char('n'))).unwrap();
+    assert!(
+        app.composer_state.mode.is_none(),
+        "Composer must not open from the Home list"
+    );
 }
 
 #[test]
@@ -384,6 +466,7 @@ fn test_n_shows_new_post_modal_on_posts_tab() {
     app.current_screen = Screen::Main;
     app.current_tab = Tab::Posts;
     app.input_mode = InputMode::Navigation;
+    set_test_community(&mut app);
 
     // Press 'n'
     let key = key_event(KeyCode::Char('n'));
@@ -508,6 +591,7 @@ fn test_navigation_mode_allows_shortcuts() {
     app.current_screen = Screen::Main;
     app.current_tab = Tab::Posts;
     app.input_mode = InputMode::Navigation;
+    set_test_community(&mut app);
 
     // Add some posts
     app.posts_state.posts = vec![Post {

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -144,6 +144,7 @@ impl EventLoop {
         // Load initial data
         let _ = app.load_settings().await;
         app.load_filter_preference();
+        let _ = app.init_community_context().await;
         let _ = app.load_posts().await;
 
         Ok(())
@@ -348,7 +349,27 @@ impl EventLoop {
                     && !app.composer_state.is_open()
                     && !app.posts_state.show_filter_modal =>
             {
-                self.handle_post_selection(app).await?;
+                if app.is_home_list_active() {
+                    app.open_home_selection().await?;
+                } else {
+                    self.handle_post_selection(app).await?;
+                }
+            }
+            KeyCode::Char('c') | KeyCode::Char('C')
+                if app.show_community_modal
+                    && app.community.as_ref().map(|c| !c.claimed).unwrap_or(false) =>
+            {
+                app.claim_current_community().await?;
+            }
+            KeyCode::Char('r') | KeyCode::Char('R')
+                if app.current_screen == Screen::Main
+                    && app.current_tab == Tab::Posts
+                    && !app.viewing_post_detail
+                    && !app.composer_state.is_open()
+                    && (app.community_error.is_some()
+                        || (app.is_home_list_active() && app.home_state.error.is_some())) =>
+            {
+                app.retry_community().await?;
             }
             KeyCode::Enter
                 if app.current_tab == Tab::DMs

--- a/fido-tui/src/main.rs
+++ b/fido-tui/src/main.rs
@@ -6,6 +6,7 @@ mod emoji;
 mod event_loop;
 #[macro_use]
 mod logging;
+mod repo_context;
 mod session;
 mod terminal;
 mod text_wrapper;
@@ -214,6 +215,12 @@ async fn main() -> Result<()> {
 
     app.log_config = log_config;
 
+    // The launch directory decides the community: inside a GitHub repo the
+    // board opens on that repo's community, elsewhere the Home list shows.
+    if let Ok(cwd) = std::env::current_dir() {
+        app.launch_repo = repo_context::detect_repo_context(&cwd);
+    }
+
     // Check for updates (quick, non-blocking with 3s timeout, skip in web mode)
     if !is_web_mode {
         if let Some(latest_version) = check_for_updates().await {
@@ -234,6 +241,7 @@ async fn main() -> Result<()> {
         // Load initial data
         let _ = app.load_settings().await;
         app.load_filter_preference();
+        let _ = app.init_community_context().await;
         let _ = app.load_posts().await;
     } else {
         log::info!("No valid session found, showing authentication screen");

--- a/fido-tui/src/repo_context.rs
+++ b/fido-tui/src/repo_context.rs
@@ -1,0 +1,193 @@
+//! Detects the GitHub repo the TUI was launched inside.
+//!
+//! The launch directory decides the community: if the working directory is
+//! inside a git repo whose `origin` remote points at GitHub, the TUI opens
+//! straight onto that repo's community. Anything else (no repo, no origin,
+//! non-GitHub remote) is Home mode — a valid state, not an error.
+
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoRef {
+    pub owner: String,
+    pub name: String,
+}
+
+impl RepoRef {
+    pub fn full_name(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+}
+
+/// Resolve the GitHub repo for `cwd`, walking up to the nearest git repo.
+pub fn detect_repo_context(cwd: &Path) -> Option<RepoRef> {
+    let toplevel = git_stdout(cwd, &["rev-parse", "--show-toplevel"])?;
+    let origin_url = git_stdout(Path::new(&toplevel), &["remote", "get-url", "origin"])?;
+
+    match parse_github_remote(&origin_url) {
+        Some(repo) => {
+            log::info!(
+                "Launch context: {} (from origin remote in {})",
+                repo.full_name(),
+                toplevel
+            );
+            Some(repo)
+        }
+        None => {
+            log::info!(
+                "Launch context: origin remote '{}' is not a GitHub repo; using Home mode",
+                origin_url
+            );
+            None
+        }
+    }
+}
+
+fn git_stdout(dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map_err(|e| log::info!("git {:?} failed to spawn: {}; using Home mode", args, e))
+        .ok()?;
+
+    if !output.status.success() {
+        log::info!(
+            "git {:?} exited {} in {}; using Home mode",
+            args,
+            output.status,
+            dir.display()
+        );
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        return None;
+    }
+    Some(stdout)
+}
+
+/// Parse `owner/name` out of a GitHub remote URL.
+///
+/// Handles the forms git actually produces:
+/// - `https://github.com/owner/name(.git)`
+/// - `git@github.com:owner/name(.git)`
+/// - `ssh://git@github.com/owner/name(.git)`
+/// - `git://github.com/owner/name(.git)`
+pub fn parse_github_remote(url: &str) -> Option<RepoRef> {
+    let url = url.trim();
+
+    let path = if let Some(rest) = url.strip_prefix("git@github.com:") {
+        rest
+    } else {
+        let after_scheme = url.split_once("://").map(|(_, rest)| rest)?;
+        let after_scheme = after_scheme.strip_prefix("git@").unwrap_or(after_scheme);
+        after_scheme.strip_prefix("github.com/")?
+    };
+
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let path = path.strip_suffix('/').unwrap_or(path);
+
+    let (owner, name) = path.split_once('/')?;
+    if owner.is_empty() || name.is_empty() || name.contains('/') {
+        return None;
+    }
+
+    Some(RepoRef {
+        owner: owner.to_string(),
+        name: name.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo(owner: &str, name: &str) -> Option<RepoRef> {
+        Some(RepoRef {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        })
+    }
+
+    #[test]
+    fn parses_github_remote_url_forms() {
+        let cases = [
+            (
+                "https://github.com/ianjamesburke/fido.git",
+                repo("ianjamesburke", "fido"),
+            ),
+            (
+                "https://github.com/ianjamesburke/fido",
+                repo("ianjamesburke", "fido"),
+            ),
+            (
+                "https://github.com/rust-lang/rust/",
+                repo("rust-lang", "rust"),
+            ),
+            (
+                "git@github.com:octocat/Hello-World.git",
+                repo("octocat", "Hello-World"),
+            ),
+            (
+                "git@github.com:octocat/Hello-World",
+                repo("octocat", "Hello-World"),
+            ),
+            ("ssh://git@github.com/owner/name.git", repo("owner", "name")),
+            ("git://github.com/owner/name.git", repo("owner", "name")),
+            (
+                "  https://github.com/owner/name.git\n",
+                repo("owner", "name"),
+            ),
+            // Not GitHub / not parseable
+            ("https://gitlab.com/owner/name.git", None),
+            ("git@gitlab.com:owner/name.git", None),
+            ("https://github.com/owner", None),
+            ("https://github.com/", None),
+            ("not-a-url", None),
+            ("", None),
+        ];
+
+        for (url, expected) in cases {
+            assert_eq!(parse_github_remote(url), expected, "url: {:?}", url);
+        }
+    }
+
+    #[test]
+    fn detects_none_outside_a_repo() {
+        let dir = std::env::temp_dir().join(format!("fido-no-repo-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(detect_repo_context(&dir), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn detects_repo_from_nested_directory() {
+        let dir = std::env::temp_dir().join(format!("fido-repo-{}", uuid::Uuid::new_v4()));
+        let nested = dir.join("a/b");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let run = |args: &[&str]| {
+            let status = Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .args(args)
+                .status()
+                .unwrap();
+            assert!(status.success(), "git {:?}", args);
+        };
+        run(&["init", "-q"]);
+        run(&[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:testowner/testrepo.git",
+        ]);
+
+        assert_eq!(detect_repo_context(&nested), repo("testowner", "testrepo"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/fido-tui/src/ui/components/action_bar.rs
+++ b/fido-tui/src/ui/components/action_bar.rs
@@ -13,7 +13,19 @@ pub fn action_bar_text(app: &App) -> &'static str {
 
     match app.current_tab {
         crate::app::Tab::Posts => {
-            "u/d: Vote | n: Post | f: Filter | s: Search | Space: View | p: Profile"
+            if app.show_community_modal {
+                if app.community.as_ref().map(|c| !c.claimed).unwrap_or(false) {
+                    "c: Claim admin | Esc: Close"
+                } else {
+                    "Esc: Close"
+                }
+            } else if app.community_error.is_some() {
+                "r: Retry"
+            } else if app.is_home_list_active() {
+                "↑/↓/j/k: Navigate | Enter: Open community"
+            } else {
+                "u/d: Vote | n: Post | i: Community | f: Filter | s: Search | Space: View"
+            }
         }
         crate::app::Tab::DMs => {
             let has_active_conversation = app.dms_state.selection.conversation_index().is_some();

--- a/fido-tui/src/ui/modals/community.rs
+++ b/fido-tui/src/ui/modals/community.rs
@@ -1,0 +1,78 @@
+use ratatui::{
+    layout::{Alignment, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::super::components::modal::{render_modal_container, ModalConfig};
+use super::super::theme::get_theme_colors;
+use crate::app::App;
+
+/// Community settings modal: the caller's standing in the community and the
+/// tucked-away actions (claiming admin; future moderation settings).
+pub fn render_community_modal(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = get_theme_colors(app);
+
+    let Some(community) = app.community.clone() else {
+        return;
+    };
+
+    let config = ModalConfig::new(" Community ").with_size(50, 45);
+    let inner = render_modal_container(frame, area, &config, &theme);
+
+    let role = community
+        .role
+        .map(|r| r.as_str().to_string())
+        .unwrap_or_else(|| "not a member".to_string());
+    let claimed_status = if community.claimed {
+        "claimed"
+    } else {
+        "unclaimed"
+    };
+
+    let label_style = Style::default().fg(theme.text_dim);
+    let value_style = Style::default().fg(theme.text).add_modifier(Modifier::BOLD);
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            community.full_name(),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Your role:  ", label_style),
+            Span::styled(role, value_style),
+        ]),
+        Line::from(vec![
+            Span::styled("Members:    ", label_style),
+            Span::styled(community.member_count.to_string(), value_style),
+        ]),
+        Line::from(vec![
+            Span::styled("Admin:      ", label_style),
+            Span::styled(claimed_status.to_string(), value_style),
+        ]),
+        Line::from(""),
+    ];
+
+    if !community.claimed {
+        lines.push(Line::from(Span::styled(
+            "c: Claim admin (requires GitHub admin/maintain on the repo)",
+            Style::default().fg(theme.success),
+        )));
+    }
+    lines.push(Line::from(Span::styled(
+        "Esc: Close",
+        Style::default().fg(theme.text_dim),
+    )));
+
+    let content = Paragraph::new(lines)
+        .alignment(Alignment::Center)
+        .style(Style::default().fg(theme.text))
+        .wrap(ratatui::widgets::Wrap { trim: false });
+    frame.render_widget(content, inner);
+}

--- a/fido-tui/src/ui/modals/help.rs
+++ b/fido-tui/src/ui/modals/help.rs
@@ -245,8 +245,20 @@ pub fn add_posts_feed_shortcuts(
     app: &mut App,
     shortcuts: &mut Vec<(&'static str, Vec<(&'static str, &'static str)>)>,
 ) {
+    if app.is_home_list_active() {
+        shortcuts.push((
+            "Home",
+            vec![
+                ("↓/j", "Next community"),
+                ("↑/k", "Previous community"),
+                ("Enter", "Open community board"),
+            ],
+        ));
+        return;
+    }
+
     shortcuts.push((
-        "Posts Tab",
+        "Board",
         vec![
             ("↓/j", "Next post"),
             ("↑/k", "Previous post"),
@@ -254,6 +266,7 @@ pub fn add_posts_feed_shortcuts(
             ("u", "Upvote selected post"),
             ("d", "Downvote selected post"),
             ("n", "New post"),
+            ("i", "Community info & settings"),
             ("f", "Filter posts"),
             ("s", "Search users"),
             ("p", "View author profile"),

--- a/fido-tui/src/ui/modals/mod.rs
+++ b/fido-tui/src/ui/modals/mod.rs
@@ -1,4 +1,5 @@
 // Modal rendering modules
+mod community;
 mod composer;
 mod filters;
 mod help;
@@ -7,6 +8,7 @@ mod social;
 mod social_components;
 
 // Re-export all public functions
+pub use community::*;
 pub use composer::*;
 pub use filters::*;
 pub use help::*;

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
     Frame,
 };
 
@@ -385,6 +385,11 @@ pub fn render_main_screen(frame: &mut Frame, app: &mut App) {
         render_user_profile_view(frame, app, area);
     }
 
+    // Render community settings modal
+    if app.show_community_modal {
+        render_community_modal(frame, app, area);
+    }
+
     // Render help modal (highest priority - render last)
     if app.show_help {
         render_help_modal(frame, app, area);
@@ -398,7 +403,12 @@ pub fn render_tab_header(frame: &mut Frame, app: &mut App, area: Rect) {
     // Calculate total unread count for DMs
     let total_unread: usize = app.dms_state.unread_counts.values().sum();
 
-    let tabs = ["Posts", "DMs", "Profile", "Settings"];
+    let board_label = if app.is_home_list_active() {
+        "Home"
+    } else {
+        "Board"
+    };
+    let tabs = [board_label, "DMs", "Profile", "Settings"];
     let current_index = match app.current_tab {
         crate::app::Tab::Posts => 0,
         crate::app::Tab::DMs => 1,
@@ -472,6 +482,151 @@ pub fn render_global_footer(frame: &mut Frame, app: &mut App, area: Rect) {
     );
 }
 
+/// Board title: repo community plus the caller's standing in it.
+fn community_board_title(app: &App) -> String {
+    match &app.community {
+        Some(c) => {
+            let role = c
+                .role
+                .map(|r| r.as_str().to_string())
+                .unwrap_or_else(|| "not a member".to_string());
+            let members = if c.member_count == 1 {
+                "1 member".to_string()
+            } else {
+                format!("{} members", c.member_count)
+            };
+            let mut title = format!(" {} · {} · {} ", c.full_name(), role, members);
+            if !c.claimed {
+                title.push_str("· unclaimed ");
+            }
+            title
+        }
+        None => "Board".to_string(),
+    }
+}
+
+/// Repo mode: the launch repo's community could not be opened.
+fn render_community_error(frame: &mut Frame, app: &mut App, area: Rect, error: &str) {
+    let theme = get_theme_colors(app);
+    let widget = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            error.to_string(),
+            Style::default()
+                .fg(theme.error)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Press 'r' to retry.",
+            Style::default().fg(theme.text_dim),
+        )),
+    ])
+    .alignment(Alignment::Center)
+    .wrap(Wrap { trim: true })
+    .block(Block::default().borders(Borders::ALL).title(" Community "));
+    frame.render_widget(widget, area);
+}
+
+/// Home mode: joined-communities list (launched outside a GitHub repo).
+fn render_home_list(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = get_theme_colors(app);
+    let title = " Your Communities ";
+
+    if app.home_state.loading && app.home_state.communities.is_empty() {
+        render_panel_lines(
+            frame,
+            area,
+            title,
+            create_loading_display("Loading communities...", &theme),
+            &theme,
+        );
+        return;
+    }
+
+    if let Some(error) = &app.home_state.error {
+        let widget = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                error.clone(),
+                Style::default()
+                    .fg(theme.error)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Press 'r' to retry.",
+                Style::default().fg(theme.text_dim),
+            )),
+        ])
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true })
+        .block(Block::default().borders(Borders::ALL).title(title));
+        frame.render_widget(widget, area);
+        return;
+    }
+
+    if app.home_state.communities.is_empty() {
+        let widget = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "No communities yet",
+                Style::default()
+                    .fg(theme.warning)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Launch fido inside a GitHub repo directory to join its community.",
+                Style::default().fg(theme.text_dim),
+            )),
+        ])
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true })
+        .block(Block::default().borders(Borders::ALL).title(title));
+        frame.render_widget(widget, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = app
+        .home_state
+        .communities
+        .iter()
+        .map(|view| {
+            let role = view
+                .membership
+                .as_ref()
+                .map(|m| m.role.as_str())
+                .unwrap_or("member");
+            let members = if view.member_count == 1 {
+                "1 member".to_string()
+            } else {
+                format!("{} members", view.member_count)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{}/{}", view.community.owner, view.community.name),
+                    Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("  {} · {}", role, members),
+                    Style::default().fg(theme.text_dim),
+                ),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .highlight_style(
+            Style::default()
+                .fg(theme.success)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(list, area, &mut app.home_state.list_state);
+}
+
 /// Render Posts tab with global feed
 pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) {
     // Log at start of render
@@ -506,12 +661,26 @@ pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) 
     // Main posts area (no inline compose box - use 'n' to open modal)
     let posts_area = layout.content;
 
+    // Repo mode: joining the launch repo's community failed.
+    if let Some(error) = app.community_error.clone() {
+        render_community_error(frame, app, posts_area, &error);
+        return;
+    }
+
+    // Home mode: show the joined-communities list instead of a board.
+    if app.is_home_list_active() {
+        render_home_list(frame, app, posts_area);
+        return;
+    }
+
+    let community_title = community_board_title(app);
+
     // Only show full-page loading on initial load (when there are no posts yet)
     if app.posts_state.loading && app.posts_state.posts.is_empty() {
         render_panel_lines(
             frame,
             posts_area,
-            "Global Feed",
+            &community_title,
             create_loading_display("Loading posts...", &theme),
             &theme,
         );
@@ -535,12 +704,16 @@ pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) 
             )),
             Line::from(""),
             Line::from(Span::styled(
-                "Press 'n' to create the first post!",
+                "Press 'n' to create the first post.",
                 Style::default().fg(theme.text_dim),
             )),
         ])
         .alignment(Alignment::Center)
-        .block(Block::default().borders(Borders::ALL).title("Global Feed"));
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(community_title.as_str()),
+        );
         frame.render_widget(empty, posts_area);
 
         // Render filter modal if open (even when no posts)
@@ -670,12 +843,12 @@ pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) 
 
     // Build title with current filter
     let title = match &app.posts_state.current_filter {
-        crate::app::PostFilter::All => "Global Feed".to_string(),
-        crate::app::PostFilter::Hashtag(tag) => format!("#{}", tag),
-        crate::app::PostFilter::User(username) => format!("@{}", username),
+        crate::app::PostFilter::All => community_title,
+        crate::app::PostFilter::Hashtag(tag) => format!("{} / #{}", community_title, tag),
+        crate::app::PostFilter::User(username) => format!("{} / @{}", community_title, username),
         crate::app::PostFilter::Multi { hashtags, users } => {
             let total = hashtags.len() + users.len();
-            format!("Filtered ({} items)", total)
+            format!("{} / Filtered ({} items)", community_title, total)
         }
     };
 

--- a/justfile
+++ b/justfile
@@ -2,11 +2,43 @@ set dotenv-load
 
 # Start the Fido server locally with SQLite
 server:
-    cargo run --bin fido-server
+    #!/usr/bin/env bash
+    set -euo pipefail
+    log="${FIDO_SERVER_LOG:-logs/fido-server.log}"
+    max_bytes="${FIDO_SERVER_LOG_MAX_BYTES:-10485760}"
+    mkdir -p "$(dirname "$log")"
+    : > "$log"
+    cargo run --bin fido-server 2>&1 | while IFS= read -r line; do
+        printf '%s\n' "$line"
+        printf '%s\n' "$line" >> "$log"
+        if [ "$(wc -c < "$log")" -ge "$max_bytes" ]; then
+            mv "$log" "$log.1"
+            : > "$log"
+        fi
+    done
 
 # Start the Fido server with fresh database (deletes and recreates)
 server-reset:
-    cargo run --bin fido-server -- --reset-db
+    #!/usr/bin/env bash
+    set -euo pipefail
+    log="${FIDO_SERVER_LOG:-logs/fido-server.log}"
+    max_bytes="${FIDO_SERVER_LOG_MAX_BYTES:-10485760}"
+    mkdir -p "$(dirname "$log")"
+    : > "$log"
+    cargo run --bin fido-server -- --reset-db 2>&1 | while IFS= read -r line; do
+        printf '%s\n' "$line"
+        printf '%s\n' "$line" >> "$log"
+        if [ "$(wc -c < "$log")" -ge "$max_bytes" ]; then
+            mv "$log" "$log.1"
+            : > "$log"
+        fi
+    done
+
+# Tail the local Fido server log written by `just server` / `just server-reset`
+server-log:
+    mkdir -p logs
+    touch logs/fido-server.log
+    tail -f logs/fido-server.log
 
 # Start the Fido TUI client
 tui:

--- a/justfile
+++ b/justfile
@@ -56,6 +56,11 @@ web:
 test:
     cargo test --workspace
 
+# End-to-end test: drive the real TUI in tmux against a real local server
+e2e-tui:
+    chmod +x ./scripts/e2e_tui.sh
+    ./scripts/e2e_tui.sh
+
 # Deploy to Railway (triggers rebuild from current branch)
 deploy:
     railway up

--- a/scripts/e2e_tui.sh
+++ b/scripts/e2e_tui.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# End-to-end test of the real TUI binary against a real local server.
+#
+# Drives the TUI in a detached tmux pane and asserts on captured frames,
+# the SQLite database, and log files. GitHub is stubbed via GITHUB_API_BASE.
+#
+# Covers: test-user login, directory-scoped community join (repo mode),
+# board title with role, posting, community modal, Home mode outside a repo,
+# opening a community from the Home list.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+command -v tmux >/dev/null || { echo "FAIL: tmux is required"; exit 1; }
+command -v sqlite3 >/dev/null || { echo "FAIL: sqlite3 is required"; exit 1; }
+
+PORT="${E2E_PORT:-34567}"
+STUB_PORT=$((PORT + 1))
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/fido-e2e.XXXXXX")"
+SESSION="fido-e2e-$$"
+FIDO_BIN="$ROOT/target/debug/fido"
+SERVER_BIN="$ROOT/target/debug/fido-server"
+
+SERVER_PID=""
+STUB_PID=""
+
+cleanup() {
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null || true
+    [[ -n "$STUB_PID" ]] && kill "$STUB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $1"
+    echo "--- pane ---"
+    tmux capture-pane -p -t "$SESSION" 2>/dev/null || echo "(no pane)"
+    echo "--- server log tail ---"
+    tail -n 30 "$WORK/server.log" 2>/dev/null || true
+    echo "--- stub log tail ---"
+    tail -n 10 "$WORK/stub.log" 2>/dev/null || true
+    echo "--- artifacts kept in $WORK ---"
+    trap - EXIT
+    cleanup
+    exit 1
+}
+
+pane() { tmux capture-pane -p -t "$SESSION"; }
+
+# wait_for <pattern> <description> [tries]
+wait_for() {
+    local pattern="$1" what="$2" tries="${3:-75}"
+    for ((i = 0; i < tries; i++)); do
+        if pane 2>/dev/null | grep -qF "$pattern"; then
+            return 0
+        fi
+        sleep 0.2
+    done
+    fail "timed out waiting for: $what (pattern: $pattern)"
+}
+
+keys() { tmux send-keys -t "$SESSION" "$@"; sleep 0.3; }
+
+echo "==> building binaries"
+cargo build --quiet --bin fido --bin fido-server
+
+echo "==> starting github stub on :$STUB_PORT"
+python3 "$ROOT/scripts/github_stub.py" "$STUB_PORT" >"$WORK/stub.log" 2>&1 &
+STUB_PID=$!
+
+echo "==> starting fido-server on :$PORT (db: $WORK/fido.db)"
+PORT="$PORT" \
+    DATABASE_PATH="$WORK/fido.db" \
+    GITHUB_API_BASE="http://127.0.0.1:$STUB_PORT" \
+    FIDO_TOKEN_KEY="$(head -c 32 /dev/urandom | base64)" \
+    "$SERVER_BIN" --reset-db >"$WORK/server.log" 2>&1 &
+SERVER_PID=$!
+
+for ((i = 0; i < 50; i++)); do
+    curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break
+    kill -0 "$SERVER_PID" 2>/dev/null || fail "server exited during startup"
+    sleep 0.2
+done
+curl -sf "http://127.0.0.1:$PORT/health" >/dev/null || fail "server never became healthy"
+
+echo "==> creating temp git repo with GitHub origin"
+REPO="$WORK/testrepo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" remote add origin https://github.com/testowner/testrepo.git
+
+E2E_HOME="$WORK/home"
+mkdir -p "$E2E_HOME"
+NON_REPO="$WORK/non-repo"
+mkdir -p "$NON_REPO"
+
+launch_tui() { # $1 = working directory
+    tmux new-session -d -s "$SESSION" -x 140 -y 40 -c "$1" \
+        "env HOME='$E2E_HOME' '$FIDO_BIN' --server http://127.0.0.1:$PORT --verbose"
+}
+
+# --- Scenario 1: repo mode — launch inside a repo, land on its board -------
+echo "==> scenario 1: repo mode join + post"
+launch_tui "$REPO"
+wait_for "Authentication" "auth screen"
+keys 'l'
+wait_for "alice" "test users list"
+keys Enter
+wait_for "testowner/testrepo" "repo community board title"
+pane | grep -qF "member" || fail "board title should show the caller's role"
+pane | grep -qF "unclaimed" || fail "board title should show unclaimed state"
+
+keys 'n'
+wait_for "New Post" "composer modal" 25
+tmux send-keys -t "$SESSION" -l "hello from the e2e harness"
+sleep 0.3
+keys Enter
+wait_for "hello from the e2e harness" "posted thread on board"
+
+# Database-level assertion: the post landed in the repo's community.
+POST_COUNT=$(sqlite3 "$WORK/fido.db" \
+    "SELECT count(*) FROM posts p JOIN communities c ON p.community_id = c.id
+     WHERE c.owner = 'testowner' AND c.name = 'testrepo'
+       AND p.content = 'hello from the e2e harness';")
+[[ "$POST_COUNT" == "1" ]] || fail "post not found in testowner/testrepo community (count=$POST_COUNT)"
+
+# --- Scenario 2: community modal ---------------------------------------------
+echo "==> scenario 2: community settings modal"
+keys 'i'
+wait_for "Your role" "community modal"
+pane | grep -qF "Claim admin" || fail "modal should offer claim on an unclaimed community"
+keys Escape
+sleep 0.3
+pane | grep -qF "Your role" && fail "community modal should close on Esc"
+
+tmux kill-session -t "$SESSION"
+
+# --- Scenario 3: Home mode — launch outside a repo ---------------------------
+echo "==> scenario 3: home mode lists joined communities"
+launch_tui "$NON_REPO"
+wait_for "Your Communities" "home list (session restored)"
+pane | grep -qF "testowner/testrepo" || fail "home list should show the joined community"
+pane | grep -qF "Home" || fail "tab bar should read Home outside a repo"
+
+keys Enter
+wait_for "hello from the e2e harness" "board opened from home list"
+keys Escape
+wait_for "Your Communities" "Esc returns to home list"
+
+tmux kill-session -t "$SESSION"
+
+echo "PASS: all TUI e2e scenarios"
+rm -rf "$WORK"

--- a/scripts/github_stub.py
+++ b/scripts/github_stub.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Local stand-in for api.github.com used by the TUI e2e harness.
+
+Resolves any /repos/:owner/:name with a deterministic id, returns an empty
+contributors list, and 404s owner "ghost" to exercise the unresolvable-repo
+path. Mirrors the fixture server in fido-server/tests/e2e_community_rewrite.rs.
+"""
+
+import json
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+REPO_RE = re.compile(r"^/repos/([^/]+)/([^/]+)$")
+CONTRIBUTORS_RE = re.compile(r"^/repos/([^/]+)/([^/]+)/contributors$")
+
+
+def repo_id(owner: str, name: str) -> int:
+    h = 7
+    for b in f"{owner}/{name}".encode():
+        h = (h * 31 + b) % (2**63)
+    return max(h, 2)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if CONTRIBUTORS_RE.fullmatch(path):
+            return self._reply(200, [])
+
+        repo = REPO_RE.fullmatch(path)
+        if repo:
+            owner, name = repo.groups()
+            if owner == "ghost":
+                return self._reply(404, {"message": "Not Found"})
+            return self._reply(
+                200,
+                {
+                    "id": repo_id(owner, name),
+                    "name": name,
+                    "full_name": f"{owner}/{name}",
+                    "private": False,
+                    "owner": {"login": owner},
+                },
+            )
+
+        return self._reply(404, {"message": "Not Found"})
+
+    def _reply(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        sys.stderr.write("stub: %s\n" % (format % args))
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: github_stub.py <port>")
+    port = int(sys.argv[1])
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The launch directory now decides the community — no picker, no rail.

- **Repo mode**: launching `fido` inside a git repo with a GitHub `origin` joins that repo's community (lazily created server-side) and opens its board. Detection walks to the nearest repo via `git rev-parse --show-toplevel` and parses the origin remote (`fido-tui/src/repo_context.rs`).
- **Home mode**: launching anywhere else lists joined communities; Enter opens a board, Esc returns to the list.
- **Community settings modal** (`i` on a board): your role, member count, claim state; `c` claims admin (server verifies GitHub admin/maintain). Keeps claim off the board surface.
- **Server**: `POST /communities/join` now takes `{owner, name}` and resolves the canonical repo id via GitHub (stored token when present, unauthenticated otherwise). Unresolvable repos 404 instead of creating communities from client-supplied ids.
- Removes the hardcoded `ianjamesburke/fido` default-community bootstrap; board title shows `owner/name · role · N members`.

## Testing

- `just e2e-tui`: new tmux-driven harness runs the real TUI against a real server (temp DB, GitHub stubbed via `GITHUB_API_BASE`), asserting on captured frames, SQLite, and logs — covers login, repo-mode join, posting, the community modal, and Home mode. Passing.
- `cargo test --workspace --features fido-server/sqlite-tests`: all green (146 server unit, 8 community e2e, WS, TUI nav tests incl. new Esc/home/modal coverage).

Design spec: `docs/superpowers/specs/2026-07-02-directory-scoped-communities-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)