### PR TITLE
Harden prerelease startup and router paths

### DIFF
--- a/fido-server/src/api/admin.rs
+++ b/fido-server/src/api/admin.rs
@@ -237,6 +237,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn test_validate_config_does_not_expose_secrets() {
         let _guard = crate::test_utils::env_lock().lock().unwrap();
         // Set a test GitHub client ID to verify it's not exposed

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -34,6 +34,18 @@ pub fn create_router(state: AppState) -> Router {
     // Configure CORS using environment-aware configuration
     let security_config = security::SecurityConfig::from_env()
         .unwrap_or_else(|_| security::SecurityConfig::default());
+    create_router_with_security_config(state, &security_config)
+}
+
+/// Create the shared API router used by production startup and tests.
+///
+/// This intentionally excludes production-only static file fallback routing;
+/// callers that serve the web terminal can attach that fallback after the API
+/// router is built.
+pub fn create_router_with_security_config(
+    state: AppState,
+    security_config: &security::SecurityConfig,
+) -> Router {
     let cors_config = security::CorsConfig::new(
         security_config.environment,
         security_config.allowed_origins.clone(),
@@ -209,4 +221,77 @@ pub fn create_router(state: AppState) -> Router {
 
 async fn health_check() -> &'static str {
     "OK"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{Context, Result};
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use reqwest::StatusCode;
+
+    const TEST_TOKEN_KEY: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    fn test_state() -> Result<AppState> {
+        let db = db::Database::in_memory().context("create in-memory database")?;
+        db.initialize().context("initialize schema")?;
+        let repos = db::repositories::Repositories::new(db.pool.clone());
+
+        let _guard = test_utils::env_lock().lock().unwrap();
+        std::env::set_var("FIDO_TOKEN_KEY", TEST_TOKEN_KEY);
+        let state = AppState::new_with_repos(db, repos).context("build app state")?;
+        std::env::remove_var("FIDO_TOKEN_KEY");
+
+        Ok(state)
+    }
+
+    async fn status_for(config: security::SecurityConfig, path: &str) -> Result<StatusCode> {
+        let router = create_router_with_security_config(test_state()?, &config);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("bind test listener")?;
+        let addr = listener.local_addr().context("read listener addr")?;
+
+        tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("test server crashed");
+        });
+
+        let response = reqwest::get(format!("http://{addr}{path}"))
+            .await
+            .context("send test request")?;
+        Ok(response.status())
+    }
+
+    #[tokio::test]
+    async fn mounts_test_login_routes_in_development() -> Result<()> {
+        let config = security::SecurityConfig {
+            environment: security::Environment::Development,
+            ..Default::default()
+        };
+
+        assert_eq!(status_for(config, "/users/test").await?, StatusCode::OK);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn omits_test_login_routes_in_production() -> Result<()> {
+        let config = security::SecurityConfig {
+            environment: security::Environment::Production,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            status_for(config, "/users/test").await?,
+            StatusCode::NOT_FOUND
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn token_key_fixture_is_valid() -> Result<()> {
+        assert_eq!(STANDARD.decode(TEST_TOKEN_KEY)?.len(), 32);
+        Ok(())
+    }
 }

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -1,30 +1,11 @@
-mod api;
-mod config;
-mod db;
-mod events;
-mod http;
-mod mention;
-mod oauth;
-mod rate_limit;
-mod realtime;
-mod security;
-mod services;
-mod session;
-mod state;
-#[cfg(test)]
-mod test_utils;
-
-use axum::{
-    middleware,
-    routing::{delete, get, post, put},
-    Router,
-};
 use clap::Parser;
-use db::repositories::Repositories;
-use rate_limit::RateLimiter;
-use state::AppState;
+use fido_server::{
+    config, create_router_with_security_config,
+    db::{self, repositories::Repositories},
+    security, services,
+    state::AppState,
+};
 use std::net::SocketAddr;
-use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::services::ServeDir;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -250,184 +231,14 @@ async fn main() {
         }
     });
 
-    // Configure CORS using environment-aware configuration
-    let cors_config = security::CorsConfig::new(
-        security_config.environment,
-        security_config.allowed_origins.clone(),
-    );
     tracing::info!(
         "CORS configured for {} environment with origins: {:?}",
         security_config.environment,
-        cors_config.allowed_origins()
+        security_config.allowed_origins
     );
-    let cors = cors_config.to_cors_layer();
 
-    // Create global rate limiter: 100 requests per minute per user
-    let rate_limiter = RateLimiter::new(100, 60);
-
-    // Build router - API routes take precedence over static files
-    let mut app = Router::new()
-        // Health check
-        .route("/health", get(health_check))
-        // Public community badge SVG
-        .route("/badge/:owner/:repo_svg", get(api::badge::community_badge))
-        // Realtime WebSocket gateway
-        .route("/ws", get(api::ws::ws_handler));
-
-    // Passwordless test-only auth routes. These allow logging in as any test
-    // user with no credentials, so they MUST NEVER be mounted in production.
-    if !security_config.environment.is_production() {
-        app = app
-            .route("/users/test", get(api::auth::list_test_users))
-            .route("/auth/login", post(api::auth::login));
-    }
-
-    let app = app
-        // Authentication routes
-        .route("/auth/logout", post(api::auth::logout))
-        // Admin-only authentication routes (protected by require_admin middleware)
-        .merge(
-            Router::new()
-                .route("/auth/cleanup-sessions", post(api::auth::cleanup_sessions))
-                .route_layer(middleware::from_fn_with_state(
-                    state.clone(),
-                    security::admin::require_admin,
-                )),
-        )
-        // Admin-only configuration routes (protected by require_admin middleware)
-        .merge(
-            Router::new()
-                .route("/admin/config/validate", get(api::admin::validate_config))
-                .route_layer(middleware::from_fn_with_state(
-                    state.clone(),
-                    security::admin::require_admin,
-                )),
-        )
-        // GitHub Device Flow routes
-        .route("/auth/github/device", post(api::auth::github_device_flow))
-        .route(
-            "/auth/github/device/poll",
-            post(api::auth::github_device_poll),
-        )
-        .route("/auth/validate", get(api::auth::validate_session))
-        // Notification routes
-        .route(
-            "/notifications",
-            get(api::notifications::list_notifications),
-        )
-        .route(
-            "/notifications/unread-count",
-            get(api::notifications::unread_count),
-        )
-        .route(
-            "/notifications/mark-read",
-            post(api::notifications::mark_read),
-        )
-        // Post routes
-        .route("/posts", get(api::posts::get_posts))
-        .route("/posts", post(api::posts::create_post))
-        .route("/posts/:id/approve", post(api::posts::approve_post))
-        .route("/posts/:id/vote", post(api::posts::vote_on_post))
-        .route("/posts/:id/replies", get(api::posts::get_replies))
-        .route("/posts/:id/reply", post(api::posts::create_reply))
-        .route("/posts/:id/thread", get(api::posts::get_thread))
-        .route("/posts/:id", get(api::posts::get_post))
-        .route("/posts/:id", put(api::posts::update_post))
-        .route("/posts/:id", delete(api::posts::delete_post))
-        // Profile routes
-        .route("/users/:id/profile", get(api::profile::get_profile))
-        .route("/users/:id/profile", put(api::profile::update_profile))
-        // DM routes
-        .route("/dms/conversations", get(api::dms::get_conversations))
-        .route(
-            "/dms/conversations/:user_id",
-            get(api::dms::get_conversation),
-        )
-        .route(
-            "/dms/conversations/:user_id",
-            delete(api::dms::delete_conversation),
-        )
-        .route(
-            "/dms/mark-read/:user_id",
-            post(api::dms::mark_messages_read),
-        )
-        .route("/dms/requests", get(api::dms::get_pending_requests))
-        .route(
-            "/dms/requests/:user_id/accept",
-            post(api::dms::accept_request),
-        )
-        .route(
-            "/dms/requests/:user_id/decline",
-            post(api::dms::decline_request),
-        )
-        .route("/dms", post(api::dms::send_message))
-        // Config routes
-        .route("/config", get(api::config::get_config))
-        .route("/config", put(api::config::update_config))
-        // Community routes
-        .route(
-            "/communities/browse",
-            get(api::communities::browse_communities),
-        )
-        .route("/communities/join", post(api::communities::join_community))
-        .route("/communities", get(api::communities::list_communities))
-        .route("/communities/:id", get(api::communities::get_community))
-        .route(
-            "/communities/:id/channels",
-            get(api::chat::list_community_channels),
-        )
-        .route(
-            "/communities/:id/posts/pending",
-            get(api::posts::get_pending_posts),
-        )
-        .route(
-            "/communities/:id/claim",
-            post(api::communities::claim_community),
-        )
-        .route(
-            "/communities/:id/members",
-            get(api::communities::list_members),
-        )
-        .route(
-            "/communities/:id/activity",
-            get(api::communities::get_activity),
-        )
-        .route(
-            "/communities/:id/membership",
-            delete(api::communities::leave_community),
-        )
-        .route(
-            "/channels/:id/messages",
-            get(api::chat::get_channel_messages).post(api::chat::send_channel_message),
-        )
-        // User routes
-        .route("/users/search", get(api::friends::search_users))
-        .route(
-            "/users/:id/profile-view",
-            get(api::friends::get_user_profile),
-        )
-        .route(
-            "/users/:id/follow",
-            post(api::friends::follow_user).delete(api::friends::unfollow_user),
-        )
-        // Social routes
-        .route("/social/following", get(api::friends::get_following_list))
-        .route("/social/followers", get(api::friends::get_followers_list))
-        .route("/social/mutual", get(api::friends::get_mutual_friends_list))
-        .with_state(state.clone())
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            rate_limit::rate_limit_middleware,
-        ))
-        .layer(axum::Extension(rate_limiter))
-        .layer(cors)
-        // Security headers middleware - adds X-Content-Type-Options, X-Frame-Options, etc.
-        .layer(middleware::from_fn(
-            security::headers::create_security_headers_layer(security_config.environment),
-        ))
-        // Request body size limit: 1MB (1024 * 1024 bytes)
-        .layer(RequestBodyLimitLayer::new(1024 * 1024))
-        // Serve static files from web directory - only for unmatched routes
+    // API routes are shared with tests; production only adds the static web fallback.
+    let app = create_router_with_security_config(state.clone(), &security_config)
         .fallback_service(ServeDir::new("../web"));
 
     // Start server
@@ -479,8 +290,4 @@ async fn main() {
         eprintln!("FATAL: Server error: {}", e);
         std::process::exit(1);
     }
-}
-
-async fn health_check() -> &'static str {
-    "OK"
 }

--- a/fido-server/tests/hashtag_integration_tests.rs
+++ b/fido-server/tests/hashtag_integration_tests.rs
@@ -23,7 +23,6 @@ mod integration_tests {
         // - POST /posts with content containing #rust #programming
         // - GET /posts/:id to verify hashtags are included
         // - Verify database has hashtag entries
-        assert!(true, "Integration test placeholder");
     }
 
     /// Test Scenario: Follow/unfollow flow
@@ -38,7 +37,6 @@ mod integration_tests {
         // - GET /hashtags/followed to verify
         // - DELETE /hashtags/follow/:name
         // - GET /hashtags/followed to verify removal
-        assert!(true, "Integration test placeholder");
     }
 
     /// Test Scenario: Filtered post retrieval
@@ -53,7 +51,6 @@ mod integration_tests {
         // - GET /posts?hashtag=rust&sort=newest
         // - Verify filtered results
         // - Test with sort=top and sort=hot
-        assert!(true, "Integration test placeholder");
     }
 
     /// Test Scenario: Hashtag search
@@ -68,7 +65,6 @@ mod integration_tests {
         // - GET /hashtags/search?q=rust
         // - Verify results include rust, rustlang, etc.
         // - Verify sorting by post count
-        assert!(true, "Integration test placeholder");
     }
 
     /// Test Scenario: Activity tracking
@@ -84,7 +80,6 @@ mod integration_tests {
         // - GET /posts?hashtag=rust
         // - GET /users/:id/profile
         // - Verify recent_hashtags includes tracked hashtags
-        assert!(true, "Integration test placeholder");
     }
 
     /// Test Scenario: Sort preference persistence
@@ -97,7 +92,6 @@ mod integration_tests {
         // - PUT /config with sort_order
         // - GET /config to verify
         // - Restart session and verify persistence
-        assert!(true, "Integration test placeholder");
     }
 }
 

--- a/fido-tui/src/auth.rs
+++ b/fido-tui/src/auth.rs
@@ -4,10 +4,70 @@ use fido_types::User;
 use crate::api::{ApiClient, ApiError};
 use crate::session::SessionStore;
 
+pub struct RestoredSession {
+    pub user: User,
+    pub session_token: String,
+    pub api_client: ApiClient,
+}
+
+pub async fn restore_existing_session(
+    mut api_client: ApiClient,
+) -> Result<Option<RestoredSession>> {
+    let session_store = SessionStore::for_server(api_client.base_url())
+        .context("Failed to initialize server-scoped session store")?;
+
+    // Try to load session token from file
+    let token = match session_store.load()? {
+        Some(t) => t,
+        None => {
+            log::debug!("No existing session found");
+            return Ok(None);
+        }
+    };
+
+    log::info!("Found existing session token, validating with server");
+
+    // Set the session token in the API client
+    api_client.set_session_token(Some(token.clone()));
+
+    // Validate the session with the server
+    match api_client.validate_session().await {
+        Ok(response) if response.valid => {
+            log::info!("Session is valid for user: {}", response.user.username);
+            Ok(Some(RestoredSession {
+                user: response.user,
+                session_token: token,
+                api_client,
+            }))
+        }
+        Ok(_) => {
+            log::warn!("Session validation returned invalid");
+            // Clear invalid session
+            let _ = session_store.delete();
+            Ok(None)
+        }
+        Err(ApiError::Unauthorized(_))
+        | Err(ApiError::NotFound(_))
+        | Err(ApiError::BadRequest(_)) => {
+            log::warn!("Session token rejected by server, clearing local token");
+            let _ = session_store.delete();
+            Ok(None)
+        }
+        Err(e) => {
+            // Keep the local token on transient failures (network/server/rate-limit).
+            // This prevents unnecessary re-authentication after temporary outages.
+            log::warn!(
+                "Session validation failed due to transient error; keeping local token: {}",
+                e
+            );
+            Ok(None)
+        }
+    }
+}
+
 /// Manages the OAuth authentication flow for the TUI client.
 ///
 /// This struct handles:
-/// - Checking for existing sessions
 /// - Initiating GitHub OAuth flow
 /// - Opening the system browser
 /// - Polling for session completion
@@ -27,59 +87,6 @@ impl AuthFlow {
             api_client,
             session_store,
         })
-    }
-
-    /// Checks for an existing session and validates it with the server.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(Some(user))` if a valid session exists
-    /// - `Ok(None)` if no session exists or the session is invalid
-    /// - `Err(_)` if there's an error communicating with the server
-    pub async fn check_existing_session(&mut self) -> Result<Option<User>> {
-        // Try to load session token from file
-        let token = match self.session_store.load()? {
-            Some(t) => t,
-            None => {
-                log::debug!("No existing session found");
-                return Ok(None);
-            }
-        };
-
-        log::info!("Found existing session token, validating with server");
-
-        // Set the session token in the API client
-        self.api_client.set_session_token(Some(token.clone()));
-
-        // Validate the session with the server
-        match self.api_client.validate_session().await {
-            Ok(response) if response.valid => {
-                log::info!("Session is valid for user: {}", response.user.username);
-                Ok(Some(response.user))
-            }
-            Ok(_) => {
-                log::warn!("Session validation returned invalid");
-                // Clear invalid session
-                let _ = self.session_store.delete();
-                Ok(None)
-            }
-            Err(ApiError::Unauthorized(_))
-            | Err(ApiError::NotFound(_))
-            | Err(ApiError::BadRequest(_)) => {
-                log::warn!("Session token rejected by server, clearing local token");
-                let _ = self.session_store.delete();
-                Ok(None)
-            }
-            Err(e) => {
-                // Keep the local token on transient failures (network/server/rate-limit).
-                // This prevents unnecessary re-authentication after temporary outages.
-                log::warn!(
-                    "Session validation failed due to transient error; keeping local token: {}",
-                    e
-                );
-                Ok(None)
-            }
-        }
     }
 
     /// Initiates the GitHub Device Flow by requesting a device code from the server.

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -1,9 +1,10 @@
 use crate::app::{App, DMSelection, FilterTab, InputMode, PostFilter, Screen, Tab};
-use crate::auth::AuthFlow;
+use crate::auth::{self, AuthFlow, RestoredSession};
 use crate::{log_key_event, ui};
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use std::time::Duration;
+use tokio::task::JoinHandle;
 
 pub struct EventLoop {
     modal_tracker: ModalStateTracker,
@@ -11,16 +12,26 @@ pub struct EventLoop {
     last_dm_selection: DMSelection,
     last_terminal_size: (u16, u16),
     last_device_poll: std::time::Instant,
+    startup_started: bool,
+    startup_data_load_pending: bool,
+    session_restore_task: Option<JoinHandle<Result<Option<RestoredSession>, String>>>,
+    update_check_task: Option<JoinHandle<Option<String>>>,
+    is_web_mode: bool,
 }
 
 impl EventLoop {
-    pub fn new() -> Self {
+    pub fn new(is_web_mode: bool) -> Self {
         Self {
             modal_tracker: ModalStateTracker::new(),
             last_tab: Tab::Posts, // Default starting tab
             last_dm_selection: DMSelection::NewConversation,
             last_terminal_size: (0, 0),
             last_device_poll: std::time::Instant::now(),
+            startup_started: false,
+            startup_data_load_pending: false,
+            session_restore_task: None,
+            update_check_task: None,
+            is_web_mode,
         }
     }
 
@@ -43,6 +54,9 @@ impl EventLoop {
             // Process events
             self.process_events(app, auth_flow).await?;
 
+            // Start and drain startup network work only after at least one frame.
+            self.handle_startup_tasks(app, auth_flow).await?;
+
             // Handle pending loads
             self.handle_pending_loads(app).await?;
             app.flush_finished_vote_tasks().await;
@@ -55,6 +69,91 @@ impl EventLoop {
 
             // Handle DM conversation changes
             self.handle_dm_conversation_changes(app).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn handle_startup_tasks(
+        &mut self,
+        app: &mut App,
+        auth_flow: &mut AuthFlow,
+    ) -> Result<()> {
+        if !self.startup_started {
+            self.startup_started = true;
+
+            let api_client = app.api_client.clone();
+            self.session_restore_task = Some(tokio::spawn(async move {
+                auth::restore_existing_session(api_client)
+                    .await
+                    .map_err(|e| e.to_string())
+            }));
+
+            if !self.is_web_mode {
+                self.update_check_task = Some(tokio::spawn(crate::check_for_updates()));
+            }
+        }
+
+        if self
+            .update_check_task
+            .as_ref()
+            .map(|task| task.is_finished())
+            .unwrap_or(false)
+        {
+            let handle = self.update_check_task.take().unwrap();
+            if let Ok(Some(latest_version)) = handle.await {
+                app.update_available = Some(latest_version);
+            }
+        }
+
+        if self
+            .session_restore_task
+            .as_ref()
+            .map(|task| task.is_finished())
+            .unwrap_or(false)
+        {
+            let handle = self.session_restore_task.take().unwrap();
+            match handle.await {
+                Ok(Ok(Some(restored))) if app.current_screen == Screen::Auth => {
+                    log::info!("Restored session for user: {}", restored.user.username);
+                    auth_flow
+                        .api_client_mut()
+                        .set_session_token(Some(restored.session_token.clone()));
+                    app.api_client = restored.api_client;
+                    app.auth_state.current_user = Some(restored.user);
+                    app.auth_state.loading = false;
+                    app.auth_state.error = None;
+                    app.current_screen = Screen::Main;
+                    self.startup_data_load_pending = true;
+                    return Ok(());
+                }
+                Ok(Ok(Some(restored))) => {
+                    log::debug!(
+                        "Ignoring restored startup session for {} after screen changed",
+                        restored.user.username
+                    );
+                }
+                Ok(Ok(None)) => {
+                    log::info!("No valid session found, showing authentication screen");
+                    app.auth_state.loading = false;
+                }
+                Ok(Err(e)) => {
+                    log::warn!("Startup session restore failed: {}", e);
+                    app.auth_state.loading = false;
+                }
+                Err(e) => {
+                    log::warn!("Startup session restore task failed: {}", e);
+                    app.auth_state.loading = false;
+                }
+            }
+        }
+
+        if self.startup_data_load_pending && app.current_screen == Screen::Main {
+            self.startup_data_load_pending = false;
+            let _ = app.load_settings().await;
+            app.load_filter_preference();
+            let _ = app.init_community_context().await;
+            let _ = app.load_posts().await;
         }
 
         Ok(())
@@ -305,11 +404,12 @@ impl EventLoop {
 
         // Handle the async key events that were previously in main.rs
         match key.code {
-            KeyCode::Char('l') if app.current_screen == Screen::Auth => {
+            KeyCode::Char('l') if app.current_screen == Screen::Auth && !app.auth_state.loading => {
                 app.load_test_users().await?;
             }
             KeyCode::Char('g') | KeyCode::Char('G')
                 if app.current_screen == Screen::Auth
+                    && !app.auth_state.loading
                     && !app.auth_state.github_auth_in_progress
                     && app.auth_state.show_github_option =>
             {
@@ -336,6 +436,7 @@ impl EventLoop {
             }
             KeyCode::Enter
                 if app.current_screen == Screen::Auth
+                    && !app.auth_state.loading
                     && !app.auth_state.github_auth_in_progress =>
             {
                 app.login_selected_user().await?;

--- a/fido-tui/src/main.rs
+++ b/fido-tui/src/main.rs
@@ -86,7 +86,7 @@ async fn fetch_latest_version() -> Result<String> {
 }
 
 /// Check crates.io for the latest version of fido
-async fn check_for_updates() -> Option<String> {
+pub(crate) async fn check_for_updates() -> Option<String> {
     let latest = fetch_latest_version().await.ok()?;
 
     // Simple version comparison (works for semver)
@@ -227,34 +227,11 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Check for updates (quick, non-blocking with 3s timeout, skip in web mode)
-    if !is_web_mode {
-        if let Some(latest_version) = check_for_updates().await {
-            app.update_available = Some(latest_version);
-        }
-    }
-
-    // Check for existing session on startup
     let mut auth_flow = auth::AuthFlow::new(app.api_client.clone())?;
-    if let Ok(Some(user)) = auth_flow.check_existing_session().await {
-        log::info!("Restored session for user: {}", user.username);
-        app.auth_state.current_user = Some(user);
-        app.current_screen = app::Screen::Main;
-
-        // Update API client with session token
-        app.api_client = auth_flow.api_client().clone();
-
-        // Load initial data
-        let _ = app.load_settings().await;
-        app.load_filter_preference();
-        let _ = app.init_community_context().await;
-        let _ = app.load_posts().await;
-    } else {
-        log::info!("No valid session found, showing authentication screen");
-    }
+    app.auth_state.loading = true;
 
     // Main event loop
-    let mut event_loop = event_loop::EventLoop::new();
+    let mut event_loop = event_loop::EventLoop::new(is_web_mode);
 
     event_loop.run(&mut app, &mut auth_flow, &mut tui).await?;
 

--- a/justfile
+++ b/justfile
@@ -61,6 +61,11 @@ e2e-tui:
     chmod +x ./scripts/e2e_tui.sh
     ./scripts/e2e_tui.sh
 
+# Focused startup smoke: first frame must render before network startup work
+e2e-tui-startup:
+    chmod +x ./scripts/e2e_tui_startup_smoke.sh
+    ./scripts/e2e_tui_startup_smoke.sh
+
 # Deploy to Railway (triggers rebuild from current branch)
 deploy:
     railway up

--- a/scripts/e2e_tui_startup_smoke.sh
+++ b/scripts/e2e_tui_startup_smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Focused startup smoke for first-frame regressions.
+#
+# Launches the real TUI with an isolated HOME and unreachable server. The
+# first frame should render before any update check or session validation can
+# block on network IO.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIDO_BIN="$ROOT/target/debug/fido"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/fido-startup-smoke.XXXXXX")"
+SESSION="fido-startup-smoke-$$"
+
+cleanup() {
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $1"
+    echo "--- pane ---"
+    tmux capture-pane -p -t "$SESSION" 2>/dev/null || echo "(no pane)"
+    exit 1
+}
+
+command -v tmux >/dev/null || { echo "FAIL: tmux is required"; exit 1; }
+
+cd "$ROOT"
+echo "==> building fido TUI"
+cargo build --quiet --bin fido
+
+mkdir -p "$WORK/home" "$WORK/cwd"
+
+echo "==> launching startup smoke"
+tmux new-session -d -s "$SESSION" -x 100 -y 30 -c "$WORK/cwd" \
+    "env HOME='$WORK/home' FIDO_SERVER_URL='http://127.0.0.1:9' '$FIDO_BIN'"
+
+for ((i = 0; i < 20; i++)); do
+    pane="$(tmux capture-pane -p -t "$SESSION" 2>/dev/null || true)"
+    if printf '%s\n' "$pane" | grep -Eq "Fido - Terminal|Authentication|Loading|Choose authentication"; then
+        echo "PASS: TUI rendered first frame before startup network work"
+        exit 0
+    fi
+    sleep 0.1
+done
+
+fail "timed out waiting for first meaningful frame"


### PR DESCRIPTION
Implements P1 stints 0019, 0020, and 0022 in one PR.

Summary:
- Share the server API router between production startup and tests, with production test-login route coverage.
- Move crates.io update checks and session validation behind the first TUI render.
- Add just e2e-tui-startup for a focused first-frame tmux smoke.
- Clean up clippy-blocking placeholder test assertions.

Validation:
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo test -p fido-server --features sqlite-tests
- just e2e-tui-startup
- just e2e-tui