### PR TITLE
Prerelease P2 stress hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ Manual deploy:
 railway up
 ```
 
+Crates release preflight:
+
+```bash
+just prerelease-check
+```
+
+`just deploy-cargo-dry` runs the same publish preflight without publishing. It fails on a dirty worktree unless `FIDO_ALLOW_DIRTY_PUBLISH=1` is set, checks exact `fido-types@<version>` and `fido@<version>` registry state, and refuses to report success if the `fido` publish dry-run was skipped. `just deploy-cargo` publishes `fido-types` first, waits for crates.io indexing, then publishes `fido`. `fido-server` is deployed infrastructure and is not published to crates.io.
+
 Required Railway variables:
 
 - `GITHUB_CLIENT_ID`

--- a/fido-server/src/api/communities.rs
+++ b/fido-server/src/api/communities.rs
@@ -97,6 +97,9 @@ pub async fn join_community(
 
     let service = CommunityService::new(state.repos.clone(), state.github_service.clone());
     let view = service.join(user_id, &request.owner, &request.name).await?;
+    state
+        .realtime
+        .invalidate_community_recipients(&view.community.id);
 
     Ok(Json(map_community_view(view)))
 }
@@ -133,9 +136,11 @@ pub async fn claim_community(
     Path(community_id): Path<Uuid>,
 ) -> ApiResult<Json<CommunityViewResponse>> {
     let service = CommunityService::new(state.repos.clone(), state.github_service.clone());
-    Ok(Json(map_community_view(
-        service.claim(user_id, community_id).await?,
-    )))
+    let view = service.claim(user_id, community_id).await?;
+    state
+        .realtime
+        .invalidate_community_recipients(&view.community.id);
+    Ok(Json(map_community_view(view)))
 }
 
 /// GET /communities/:id/members - List a community's members, admins first
@@ -183,6 +188,9 @@ pub async fn leave_community(
 ) -> ApiResult<StatusCode> {
     let service = CommunityService::new(state.repos.clone(), state.github_service.clone());
     service.leave(user_id, community_id)?;
+    state
+        .realtime
+        .invalidate_community_recipients(&community_id);
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/fido-server/src/db/connection.rs
+++ b/fido-server/src/db/connection.rs
@@ -164,11 +164,8 @@ impl Database {
             [],
         );
 
-        // Create index on parent_post_id for efficient reply queries
-        let _ = conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_posts_parent_id ON posts(parent_post_id)",
-            [],
-        );
+        // Remove a legacy duplicate; SCHEMA creates idx_posts_parent_post_id.
+        let _ = conn.execute("DROP INDEX IF EXISTS idx_posts_parent_id", []);
 
         // Add sessions table for authentication
         let _ = conn.execute_batch(

--- a/fido-server/src/db/repositories/activity_repository.rs
+++ b/fido-server/src/db/repositories/activity_repository.rs
@@ -39,7 +39,12 @@ impl ActivityRepository {
         }
     }
 
-    pub fn upsert(&self, community_id: Uuid, payload: &str, fetched_at: DateTime<Utc>) -> Result<()> {
+    pub fn upsert(
+        &self,
+        community_id: Uuid,
+        payload: &str,
+        fetched_at: DateTime<Utc>,
+    ) -> Result<()> {
         let conn = self.pool.get()?;
         conn.execute(
             "INSERT INTO community_activity (community_id, payload, fetched_at)

--- a/fido-server/src/db/repositories/post_repository.rs
+++ b/fido-server/src/db/repositories/post_repository.rs
@@ -6,6 +6,23 @@ use fido_types::{Post, SortOrder};
 
 use crate::db::{row, DbPool};
 
+const POST_SELECT_WITH_REPLY_COUNT: &str = "SELECT p.id, p.author_id, u.username, p.content, p.created_at, p.upvotes, p.downvotes, p.parent_post_id,
+                    (SELECT COUNT(*) FROM posts WHERE parent_post_id = p.id) as reply_count,
+                    p.reply_to_user_id, u2.username as reply_to_username, p.community_id, p.approved
+             FROM posts p
+             JOIN users u ON p.author_id = u.id
+             LEFT JOIN users u2 ON p.reply_to_user_id = u2.id";
+
+const PENDING_POSTS_QUERY: &str = "SELECT p.id, p.author_id, u.username, p.content, p.created_at, p.upvotes, p.downvotes, p.parent_post_id,
+                    (SELECT COUNT(*) FROM posts WHERE parent_post_id = p.id) as reply_count,
+                    p.reply_to_user_id, u2.username as reply_to_username, p.community_id, p.approved
+             FROM posts p
+             JOIN users u ON p.author_id = u.id
+             LEFT JOIN users u2 ON p.reply_to_user_id = u2.id
+             WHERE p.community_id = ? AND p.parent_post_id IS NULL AND p.approved = 0
+             ORDER BY p.created_at ASC
+             LIMIT ?";
+
 #[derive(Clone)]
 pub struct PostRepository {
     pool: DbPool,
@@ -74,27 +91,7 @@ impl PostRepository {
     ) -> Result<Vec<Post>> {
         let conn = self.pool.get()?;
 
-        // Safe: order_clause is built from whitelisted enum values only
-        let order_clause = match sort_order {
-            SortOrder::Newest => "ORDER BY p.created_at DESC",
-            SortOrder::Popular => "ORDER BY p.upvotes DESC, p.created_at DESC",
-            SortOrder::Controversial => {
-                "ORDER BY ABS(p.upvotes - p.downvotes) ASC, p.created_at DESC"
-            }
-        };
-
-        let query = format!(
-            "SELECT p.id, p.author_id, u.username, p.content, p.created_at, p.upvotes, p.downvotes, p.parent_post_id,
-                    (SELECT COUNT(*) FROM posts WHERE parent_post_id = p.id) as reply_count,
-                    p.reply_to_user_id, u2.username as reply_to_username, p.community_id, p.approved
-             FROM posts p
-             JOIN users u ON p.author_id = u.id
-             LEFT JOIN users u2 ON p.reply_to_user_id = u2.id
-             WHERE p.community_id = ? AND p.parent_post_id IS NULL AND p.approved = 1
-             {}
-             LIMIT ?",
-            order_clause
-        );
+        let query = feed_posts_query(sort_order);
 
         let mut stmt = conn.prepare(&query)?;
 
@@ -108,17 +105,7 @@ impl PostRepository {
     /// Get pending top-level posts for admin approval.
     pub fn get_pending_posts(&self, community_id: &Uuid, limit: i32) -> Result<Vec<Post>> {
         let conn = self.pool.get()?;
-        let mut stmt = conn.prepare(
-            "SELECT p.id, p.author_id, u.username, p.content, p.created_at, p.upvotes, p.downvotes, p.parent_post_id,
-                    (SELECT COUNT(*) FROM posts WHERE parent_post_id = p.id) as reply_count,
-                    p.reply_to_user_id, u2.username as reply_to_username, p.community_id, p.approved
-             FROM posts p
-             JOIN users u ON p.author_id = u.id
-             LEFT JOIN users u2 ON p.reply_to_user_id = u2.id
-             WHERE p.community_id = ? AND p.parent_post_id IS NULL AND p.approved = 0
-             ORDER BY p.created_at ASC
-             LIMIT ?",
-        )?;
+        let mut stmt = conn.prepare(PENDING_POSTS_QUERY)?;
 
         let posts = stmt
             .query_map(params![community_id.to_string(), limit], map_post_row)?
@@ -315,6 +302,22 @@ impl PostRepository {
     }
 }
 
+fn feed_posts_query(sort_order: SortOrder) -> String {
+    // Safe: order_clause is built from whitelisted enum values only.
+    let order_clause = match sort_order {
+        SortOrder::Newest => "ORDER BY p.created_at DESC",
+        SortOrder::Popular => "ORDER BY p.upvotes DESC, p.created_at DESC",
+        SortOrder::Controversial => "ORDER BY ABS(p.upvotes - p.downvotes) ASC, p.created_at DESC",
+    };
+
+    format!(
+        "{POST_SELECT_WITH_REPLY_COUNT}
+             WHERE p.community_id = ? AND p.parent_post_id IS NULL AND p.approved = 1
+             {order_clause}
+             LIMIT ?"
+    )
+}
+
 fn map_post_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Post> {
     let id_str: String = row.get(0)?;
     let author_id_str: String = row.get(1)?;
@@ -340,4 +343,156 @@ fn map_post_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Post> {
         reply_to_user_id: row::parse_optional_uuid(reply_to_user_id_str.as_deref(), 9)?,
         reply_to_username: row.get(10)?,
     })
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use chrono::{Duration, Utc};
+    use std::time::Instant;
+
+    const PERF_THREAD_COUNT: usize = 5_000;
+
+    fn setup_large_feed() -> Result<(Database, PostRepository, Uuid)> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let conn = db.connection()?;
+
+        let user_id = Uuid::new_v4();
+        let community_id = Uuid::new_v4();
+        conn.execute(
+            "INSERT INTO users (id, username, join_date, is_test_user)
+             VALUES (?, 'feed-user', ?, 1)",
+            (user_id.to_string(), Utc::now().to_rfc3339()),
+        )?;
+        conn.execute(
+            "INSERT INTO communities (id, github_repo_id, owner, name, require_thread_approval, created_at)
+             VALUES (?, 4242, 'octocat', 'feed', 0, ?)",
+            (community_id.to_string(), Utc::now().to_rfc3339()),
+        )?;
+
+        let tx = conn.unchecked_transaction()?;
+        {
+            let mut post_stmt = tx.prepare(
+                "INSERT INTO posts (id, author_id, community_id, content, created_at, upvotes, downvotes, approved, parent_post_id, reply_to_user_id)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)",
+            )?;
+            let mut reply_stmt = tx.prepare(
+                "INSERT INTO posts (id, author_id, community_id, content, created_at, upvotes, downvotes, approved, parent_post_id, reply_to_user_id)
+                 VALUES (?, ?, ?, ?, ?, 0, 0, 1, ?, ?)",
+            )?;
+
+            for i in 0..PERF_THREAD_COUNT {
+                let post_id = Uuid::new_v4();
+                let created_at = Utc::now() - Duration::seconds(i as i64);
+                let approved = if i % 17 == 0 { 0 } else { 1 };
+                post_stmt.execute((
+                    post_id.to_string(),
+                    user_id.to_string(),
+                    community_id.to_string(),
+                    format!("thread {i}"),
+                    created_at.to_rfc3339(),
+                    (i % 500) as i32,
+                    (i % 11) as i32,
+                    approved,
+                ))?;
+
+                if i % 20 == 0 {
+                    reply_stmt.execute((
+                        Uuid::new_v4().to_string(),
+                        user_id.to_string(),
+                        community_id.to_string(),
+                        format!("reply {i}"),
+                        (created_at + Duration::milliseconds(1)).to_rfc3339(),
+                        post_id.to_string(),
+                        user_id.to_string(),
+                    ))?;
+                }
+            }
+        }
+        tx.commit()?;
+        drop(conn);
+
+        Ok((
+            db.clone(),
+            PostRepository::new(db.pool.clone()),
+            community_id,
+        ))
+    }
+
+    fn explain_query_plan(
+        conn: &rusqlite::Connection,
+        query: &str,
+        community_id: &Uuid,
+    ) -> Result<Vec<String>> {
+        let explain = format!("EXPLAIN QUERY PLAN {query}");
+        let mut stmt = conn.prepare(&explain)?;
+        let rows = stmt
+            .query_map(params![community_id.to_string(), 50], |row| row.get(3))?
+            .collect::<rusqlite::Result<Vec<String>>>()?;
+        Ok(rows)
+    }
+
+    fn assert_plan_uses(plan: &[String], index_name: &str) {
+        assert!(
+            plan.iter().any(|row| row.contains(index_name)),
+            "expected plan to use {index_name}; plan:\n{}",
+            plan.join("\n")
+        );
+    }
+
+    fn assert_no_temp_sort(plan: &[String]) {
+        assert!(
+            plan.iter().all(|row| !row.contains("USE TEMP B-TREE")),
+            "expected index-backed ordering; plan:\n{}",
+            plan.join("\n")
+        );
+    }
+
+    #[test]
+    fn large_feed_queries_use_release_indexes() -> Result<()> {
+        let (db, repo, community_id) = setup_large_feed()?;
+        let conn = db.connection()?;
+
+        for (sort, expected_index) in [
+            (SortOrder::Newest, "idx_posts_feed_newest"),
+            (SortOrder::Popular, "idx_posts_feed_popular"),
+            (SortOrder::Controversial, "idx_posts_feed_controversial"),
+        ] {
+            let started = Instant::now();
+            let posts = repo.get_posts(&community_id, sort, 50)?;
+            let elapsed = started.elapsed();
+            eprintln!(
+                "feed query {:?}: {} rows from {} threads in {:?}",
+                sort,
+                posts.len(),
+                PERF_THREAD_COUNT,
+                elapsed
+            );
+            assert_eq!(posts.len(), 50);
+
+            let plan = explain_query_plan(&conn, &feed_posts_query(sort), &community_id)?;
+            assert_plan_uses(&plan, expected_index);
+            assert_plan_uses(&plan, "idx_posts_parent_post_id");
+            assert_no_temp_sort(&plan);
+        }
+
+        let started = Instant::now();
+        let pending = repo.get_pending_posts(&community_id, 50)?;
+        eprintln!(
+            "pending feed query: {} rows from {} threads in {:?}",
+            pending.len(),
+            PERF_THREAD_COUNT,
+            started.elapsed()
+        );
+        assert!(!pending.is_empty());
+
+        let pending_plan = explain_query_plan(&conn, PENDING_POSTS_QUERY, &community_id)?;
+        assert_plan_uses(&pending_plan, "idx_posts_feed_newest");
+        assert_plan_uses(&pending_plan, "idx_posts_parent_post_id");
+        assert_no_temp_sort(&pending_plan);
+
+        Ok(())
+    }
 }

--- a/fido-server/src/db/schema.rs
+++ b/fido-server/src/db/schema.rs
@@ -74,6 +74,17 @@ CREATE INDEX IF NOT EXISTS idx_posts_parent_post_id ON posts(parent_post_id);
 -- Create index on community_id for efficient community-scoped lookups
 CREATE INDEX IF NOT EXISTS idx_posts_community_id ON posts(community_id);
 
+-- Composite feed indexes match the release-critical board query:
+-- community + top-level + approval filter, then the selected sort key.
+CREATE INDEX IF NOT EXISTS idx_posts_feed_newest
+ON posts(community_id, parent_post_id, approved, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_posts_feed_popular
+ON posts(community_id, parent_post_id, approved, upvotes DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_posts_feed_controversial
+ON posts(community_id, parent_post_id, approved, ABS(upvotes - downvotes), created_at DESC);
+
 -- Memberships table (community membership with role)
 CREATE TABLE IF NOT EXISTS memberships (
     community_id TEXT NOT NULL,

--- a/fido-server/src/realtime.rs
+++ b/fido-server/src/realtime.rs
@@ -1,10 +1,10 @@
 //! Realtime WebSocket gateway: the in-process event bus backing `GET /ws`.
 //!
 //! API handlers publish [`ServerEvent`]s through the [`EventBus`] trait; the
-//! gateway resolves recipients at publish time (one DB lookup per event),
-//! serializes the wire envelope once, and fans the result out over a
-//! `tokio::sync::broadcast` channel. Each connection task only checks whether
-//! its own user id is in the recipient set.
+//! gateway resolves recipients at publish time, caches community recipient sets
+//! until membership changes, serializes the wire envelope once, and fans the
+//! result out over a `tokio::sync::broadcast` channel. Each connection task
+//! only checks whether its own user id is in the recipient set.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -71,11 +71,85 @@ impl ConnectionRegistry {
     }
 }
 
+#[derive(Debug, Default)]
+struct RecipientCache {
+    members: Mutex<HashMap<Uuid, Arc<HashSet<Uuid>>>>,
+    admins: Mutex<HashMap<Uuid, Arc<HashSet<Uuid>>>>,
+}
+
+impl RecipientCache {
+    fn members(&self, repos: &Repositories, community_id: &Uuid) -> Result<Arc<HashSet<Uuid>>> {
+        if let Some(cached) = self
+            .members
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(community_id)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+
+        let loaded: Arc<HashSet<Uuid>> = Arc::new(
+            repos
+                .memberships
+                .list_members(community_id)
+                .context("Failed to resolve community members")?
+                .into_iter()
+                .map(|m| m.user_id)
+                .collect(),
+        );
+        let mut cache = self.members.lock().unwrap_or_else(|e| e.into_inner());
+        Ok(cache
+            .entry(*community_id)
+            .or_insert_with(|| loaded.clone())
+            .clone())
+    }
+
+    fn admins(&self, repos: &Repositories, community_id: &Uuid) -> Result<Arc<HashSet<Uuid>>> {
+        if let Some(cached) = self
+            .admins
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(community_id)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+
+        let loaded: Arc<HashSet<Uuid>> = Arc::new(
+            repos
+                .memberships
+                .list_admins(community_id)
+                .context("Failed to resolve community admins")?
+                .into_iter()
+                .map(|m| m.user_id)
+                .collect(),
+        );
+        let mut cache = self.admins.lock().unwrap_or_else(|e| e.into_inner());
+        Ok(cache
+            .entry(*community_id)
+            .or_insert_with(|| loaded.clone())
+            .clone())
+    }
+
+    fn invalidate_community(&self, community_id: &Uuid) {
+        self.members
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(community_id);
+        self.admins
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(community_id);
+    }
+}
+
 /// The realtime gateway: publish-time recipient resolution + broadcast fan-out.
 pub struct RealtimeGateway {
     repos: Repositories,
     sender: broadcast::Sender<OutboundEvent>,
     registry: ConnectionRegistry,
+    recipient_cache: RecipientCache,
     shutdown: watch::Sender<bool>,
 }
 
@@ -87,6 +161,7 @@ impl RealtimeGateway {
             repos,
             sender,
             registry: ConnectionRegistry::default(),
+            recipient_cache: RecipientCache::default(),
             shutdown,
         }
     }
@@ -110,33 +185,30 @@ impl RealtimeGateway {
         &self.registry
     }
 
-    /// Resolve the recipient set for an event via a single repo lookup.
-    fn resolve_recipients(&self, event: &Event) -> Result<HashSet<Uuid>> {
+    /// Drop cached community recipients after membership or role changes.
+    pub fn invalidate_community_recipients(&self, community_id: &Uuid) {
+        self.recipient_cache.invalidate_community(community_id);
+    }
+
+    /// Resolve the recipient set for an event. Community-scoped events use a
+    /// cache that is explicitly invalidated by membership mutations.
+    fn resolve_recipients(&self, event: &Event) -> Result<Arc<HashSet<Uuid>>> {
         let recipients = match event {
             Event::MessageCreated(payload) => self
-                .repos
-                .memberships
-                .list_members(&payload.community_id)
+                .recipient_cache
+                .members(&self.repos, &payload.community_id)
                 .context("Failed to resolve MessageCreated recipients")?
-                .into_iter()
-                .map(|m| m.user_id)
-                .collect(),
+                .clone(),
             Event::ThreadCreated(post) => self
-                .repos
-                .memberships
-                .list_members(&post.community_id)
+                .recipient_cache
+                .members(&self.repos, &post.community_id)
                 .context("Failed to resolve ThreadCreated recipients")?
-                .into_iter()
-                .map(|m| m.user_id)
-                .collect(),
+                .clone(),
             Event::ThreadPendingApproval(post) => self
-                .repos
-                .memberships
-                .list_admins(&post.community_id)
+                .recipient_cache
+                .admins(&self.repos, &post.community_id)
                 .context("Failed to resolve ThreadPendingApproval recipients")?
-                .into_iter()
-                .map(|m| m.user_id)
-                .collect(),
+                .clone(),
             Event::DmRequestCreated(payload) => {
                 let conversation = &payload.conversation;
                 let recipient = if conversation.initiator_id == conversation.user_a {
@@ -144,12 +216,14 @@ impl RealtimeGateway {
                 } else {
                     conversation.user_a
                 };
-                HashSet::from([recipient])
+                Arc::new(HashSet::from([recipient]))
             }
             Event::DmMessageCreated(message) => {
-                HashSet::from([message.from_user_id, message.to_user_id])
+                Arc::new(HashSet::from([message.from_user_id, message.to_user_id]))
             }
-            Event::NotificationCreated(notification) => HashSet::from([notification.user_id]),
+            Event::NotificationCreated(notification) => {
+                Arc::new(HashSet::from([notification.user_id]))
+            }
         };
         Ok(recipients)
     }
@@ -201,7 +275,7 @@ impl EventBus for RealtimeGateway {
         // Err means no live subscribers, which is fine: events are also
         // observable via the REST endpoints (polling fallback contract).
         let _ = self.sender.send(OutboundEvent {
-            recipients: Arc::new(recipients),
+            recipients,
             json: Arc::from(json),
         });
         Ok(())
@@ -217,6 +291,8 @@ mod tests {
         Channel, Community, Membership, MembershipRole, Message, Notification, NotificationType,
         User,
     };
+    use std::time::Instant;
+    use tokio::sync::broadcast::error::TryRecvError;
 
     fn test_user(username: &str) -> User {
         User {
@@ -327,5 +403,104 @@ mod tests {
         assert_eq!(registry.disconnect(user), 1);
         assert_eq!(registry.disconnect(user), 0);
         assert_eq!(registry.disconnect(user), 0);
+    }
+
+    #[test]
+    fn community_recipient_cache_refreshes_after_invalidation() -> Result<()> {
+        let (_db, gateway, community, channel, member, outsider) = setup()?;
+        let mut rx = gateway.subscribe();
+
+        gateway.emit(ServerEvent::MessageCreated(Message {
+            id: Uuid::new_v4(),
+            channel_id: channel.id,
+            author_id: member.id,
+            content: "warm cache".to_string(),
+            created_at: Utc::now(),
+        }))?;
+        let warmed = rx.try_recv()?;
+        assert!(warmed.is_for(&member.id));
+        assert!(!warmed.is_for(&outsider.id));
+
+        gateway.repos.memberships.insert(&Membership {
+            community_id: community.id,
+            user_id: outsider.id,
+            role: MembershipRole::Member,
+            created_at: Utc::now(),
+        })?;
+
+        gateway.emit(ServerEvent::MessageCreated(Message {
+            id: Uuid::new_v4(),
+            channel_id: channel.id,
+            author_id: member.id,
+            content: "still cached".to_string(),
+            created_at: Utc::now(),
+        }))?;
+        let stale = rx.try_recv()?;
+        assert!(!stale.is_for(&outsider.id));
+
+        gateway.invalidate_community_recipients(&community.id);
+        gateway.emit(ServerEvent::MessageCreated(Message {
+            id: Uuid::new_v4(),
+            channel_id: channel.id,
+            author_id: member.id,
+            content: "refreshed".to_string(),
+            created_at: Utc::now(),
+        }))?;
+        let refreshed = rx.try_recv()?;
+        assert!(refreshed.is_for(&outsider.id));
+        Ok(())
+    }
+
+    #[test]
+    fn large_room_fanout_keeps_broadcast_lag_bounded() -> Result<()> {
+        let (_db, gateway, community, channel, member, _outsider) = setup()?;
+
+        for i in 0..1_000 {
+            let user = test_user(&format!("member-{i}"));
+            gateway.repos.users.create(&user)?;
+            gateway.repos.memberships.insert(&Membership {
+                community_id: community.id,
+                user_id: user.id,
+                role: MembershipRole::Member,
+                created_at: Utc::now(),
+            })?;
+        }
+        gateway.invalidate_community_recipients(&community.id);
+
+        let mut receivers = (0..128).map(|_| gateway.subscribe()).collect::<Vec<_>>();
+        let started = Instant::now();
+        for i in 0..64 {
+            gateway.emit(ServerEvent::MessageCreated(Message {
+                id: Uuid::new_v4(),
+                channel_id: channel.id,
+                author_id: member.id,
+                content: format!("stress {i}"),
+                created_at: Utc::now(),
+            }))?;
+        }
+        eprintln!(
+            "realtime fanout stress: 64 emits to 1001 members and 128 subscribers in {:?}",
+            started.elapsed()
+        );
+
+        let outbound = receivers[0].try_recv()?;
+        assert!(outbound.is_for(&member.id));
+
+        let mut lagging = gateway.subscribe();
+        for i in 0..(BROADCAST_CAPACITY + 5) {
+            gateway.emit(ServerEvent::MessageCreated(Message {
+                id: Uuid::new_v4(),
+                channel_id: channel.id,
+                author_id: member.id,
+                content: format!("lag {i}"),
+                created_at: Utc::now(),
+            }))?;
+        }
+        assert!(
+            matches!(lagging.try_recv(), Err(TryRecvError::Lagged(_))),
+            "lagging receivers must observe bounded broadcast overflow so /ws can close and refetch"
+        );
+
+        Ok(())
     }
 }

--- a/fido-server/src/services/activity.rs
+++ b/fido-server/src/services/activity.rs
@@ -74,7 +74,10 @@ impl ActivityService {
                 }
                 Err(error)
                     .with_context(|| {
-                        format!("Failed to fetch repo activity for community {}", community_id)
+                        format!(
+                            "Failed to fetch repo activity for community {}",
+                            community_id
+                        )
                     })
                     .map_err(ApiError::from)
             }

--- a/fido-server/src/services/github.rs
+++ b/fido-server/src/services/github.rs
@@ -306,7 +306,10 @@ impl GithubService {
                 self.get_with_token::<Vec<GithubIssue>>(user_id, url, "repo_activity")
                     .await
             }
-            None => self.get_public::<Vec<GithubIssue>>(url, "repo_activity").await,
+            None => {
+                self.get_public::<Vec<GithubIssue>>(url, "repo_activity")
+                    .await
+            }
         }
         .map(|issues| issues.into_iter().map(map_issue_to_activity).collect());
 

--- a/fido-tui/src/app/activity.rs
+++ b/fido-tui/src/app/activity.rs
@@ -4,7 +4,11 @@ impl App {
     /// URL of the selected activity item, if the selection is an activity row.
     pub fn selected_activity_url(&self) -> Option<String> {
         match self.posts_state.selected_feed_entry()? {
-            FeedEntry::Activity(i) => self.posts_state.activity_items.get(i).map(|a| a.html_url.clone()),
+            FeedEntry::Activity(i) => self
+                .posts_state
+                .activity_items
+                .get(i)
+                .map(|a| a.html_url.clone()),
             FeedEntry::Post(_) => None,
         }
     }
@@ -24,8 +28,7 @@ impl App {
             }
             Err(e) => {
                 self.posts_state.activity_items.clear();
-                self.posts_state.activity_error =
-                    Some(format!("repo activity unavailable: {}", e));
+                self.posts_state.activity_error = Some(format!("repo activity unavailable: {}", e));
             }
         }
         self.posts_state.activity_loading = false;

--- a/fido-tui/src/app/state.rs
+++ b/fido-tui/src/app/state.rs
@@ -595,7 +595,9 @@ impl PostsState {
     pub fn selected_feed_entry(&self) -> Option<FeedEntry> {
         let list_idx = self.list_state.selected()?;
         let offset = self.items_before_posts();
-        self.feed_entries.get(list_idx.checked_sub(offset)?).copied()
+        self.feed_entries
+            .get(list_idx.checked_sub(offset)?)
+            .copied()
     }
 
     /// Convert a post index to a list index by locating it in `feed_entries`.

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -1016,7 +1016,11 @@ fn feed_entries_interleave_by_created_at_desc() {
     let entries = rebuild_feed_entries(&posts, &activity);
     assert_eq!(
         entries,
-        vec![FeedEntry::Post(0), FeedEntry::Activity(0), FeedEntry::Post(1)]
+        vec![
+            FeedEntry::Post(0),
+            FeedEntry::Activity(0),
+            FeedEntry::Post(1)
+        ]
     );
 }
 

--- a/fido-tui/src/ui/formatting.rs
+++ b/fido-tui/src/ui/formatting.rs
@@ -202,17 +202,35 @@ mod tests {
 
     #[test]
     fn activity_line_formats_issue_and_merged_pr() {
-        let issue = activity_item(ActivityKind::Issue, ActivityState::Open, 7, "Fix login", "alice");
+        let issue = activity_item(
+            ActivityKind::Issue,
+            ActivityState::Open,
+            7,
+            "Fix login",
+            "alice",
+        );
         let line = activity_line_text(&issue);
         assert_eq!(line, "⊙ #7 Fix login · issue opened by alice");
 
-        let pr = activity_item(ActivityKind::PullRequest, ActivityState::Merged, 9, "Dark mode", "bob");
+        let pr = activity_item(
+            ActivityKind::PullRequest,
+            ActivityState::Merged,
+            9,
+            "Dark mode",
+            "bob",
+        );
         assert_eq!(activity_line_text(&pr), "⇄ #9 Dark mode · merged · bob");
     }
 
     #[test]
     fn activity_line_appends_closed_for_issues() {
-        let issue = activity_item(ActivityKind::Issue, ActivityState::Closed, 3, "Old bug", "carol");
+        let issue = activity_item(
+            ActivityKind::Issue,
+            ActivityState::Closed,
+            3,
+            "Old bug",
+            "carol",
+        );
         assert_eq!(
             activity_line_text(&issue),
             "⊙ #3 Old bug · issue opened by carol · closed"

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -861,10 +861,13 @@ pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) 
                     let Some(activity) = app.posts_state.activity_items.get(*i) else {
                         return vec![];
                     };
-                    let is_selected =
-                        selected_feed_entry == Some(FeedEntry::Activity(*i));
+                    let is_selected = selected_feed_entry == Some(FeedEntry::Activity(*i));
 
-                    let rest_color = if is_selected { theme.text } else { theme.text_dim };
+                    let rest_color = if is_selected {
+                        theme.text
+                    } else {
+                        theme.text_dim
+                    };
                     let prefix = if is_selected { "▶ " } else { "  " };
                     let glyph_color = activity_glyph_color(activity, &theme);
 

--- a/justfile
+++ b/justfile
@@ -56,6 +56,18 @@ web:
 test:
     cargo test --workspace
 
+# Release gate before bump/publish. `deploy-cargo-dry` fails if the fido
+# publish dry-run cannot run against an indexed fido-types version.
+prerelease-check:
+    cargo fmt --check
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+    cargo test --workspace
+    cargo test -p fido-server --features sqlite-tests
+    cargo package -p fido-types
+    cargo package -p fido
+    chmod +x ./scripts/deploy-cargo.sh
+    ./scripts/deploy-cargo.sh --dry-run
+
 # End-to-end test: drive the real TUI in tmux against a real local server
 e2e-tui:
     chmod +x ./scripts/e2e_tui.sh

--- a/scripts/deploy-cargo.sh
+++ b/scripts/deploy-cargo.sh
@@ -14,9 +14,42 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 DRY_RUN_ONLY=false
-if [[ "${1:-}" == "--dry-run" ]]; then
-  DRY_RUN_ONLY=true
-fi
+case "${1:-}" in
+  "")
+    ;;
+  "--dry-run")
+    DRY_RUN_ONLY=true
+    ;;
+  *)
+    echo "error: unsupported argument: $1"
+    echo "usage: ./scripts/deploy-cargo.sh [--dry-run]"
+    exit 2
+    ;;
+esac
+
+crate_version_state() {
+  local crate="$1"
+  local version="$2"
+  local output
+  output="$(mktemp)"
+
+  if cargo info "${crate}@${version}" >"$output" 2>&1; then
+    rm -f "$output"
+    echo "published"
+    return 0
+  fi
+
+  if grep -Eiq 'could not find|no matching package|not found' "$output"; then
+    rm -f "$output"
+    echo "not-published"
+    return 0
+  fi
+
+  echo "error: could not determine crates.io state for ${crate}@${version}" >&2
+  sed 's/^/  /' "$output" >&2
+  rm -f "$output"
+  return 1
+}
 
 CURRENT_VERSION="$(sed -nE 's/^version = "([0-9]+\.[0-9]+\.[0-9]+)"/\1/p' Cargo.toml | head -n1)"
 if [[ -z "$CURRENT_VERSION" ]]; then
@@ -27,10 +60,16 @@ fi
 echo "Workspace version: $CURRENT_VERSION"
 echo "Dry-run only:      $DRY_RUN_ONLY"
 
-# Warn if worktree is dirty.
+# Fail closed on dirty worktrees; release artifacts must map to an exact commit.
 if [[ -n "$(git status --porcelain)" ]]; then
-  echo "warning: you have uncommitted changes."
-  echo "warning: publish is safer after version bump + commit (+ push if needed)."
+  if [[ "${FIDO_ALLOW_DIRTY_PUBLISH:-}" == "1" ]]; then
+    echo "warning: worktree is dirty; continuing because FIDO_ALLOW_DIRTY_PUBLISH=1."
+  else
+    echo "error: worktree has uncommitted changes."
+    echo "error: commit or stash changes before publish/dry-run so the preflight maps to one revision."
+    echo "error: set FIDO_ALLOW_DIRTY_PUBLISH=1 only for intentional local diagnostics."
+    exit 1
+  fi
 fi
 
 # Ensure dependency pin matches workspace version.
@@ -46,58 +85,71 @@ if [[ "$PINNED_TYPES_VERSION" != "$CURRENT_VERSION" ]]; then
   exit 1
 fi
 
-# Preflight: detect already-published versions.
-TYPES_PUBLISHED="$(cargo search fido-types 2>/dev/null | sed -nE 's/^fido-types = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' | head -n1)"
-FIDO_PUBLISHED="$(cargo search fido --limit 20 2>/dev/null | sed -nE 's/^fido = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' | head -n1)"
+# Preflight: detect exact already-published versions.
+TYPES_STATE="$(crate_version_state fido-types "$CURRENT_VERSION")"
+FIDO_STATE="$(crate_version_state fido "$CURRENT_VERSION")"
 
-if [[ "$TYPES_PUBLISHED" == "$CURRENT_VERSION" || "$FIDO_PUBLISHED" == "$CURRENT_VERSION" ]]; then
-  echo "warning: version $CURRENT_VERSION is already published on crates.io:"
-  echo "  fido-types: ${TYPES_PUBLISHED:-not found}"
-  echo "  fido:       ${FIDO_PUBLISHED:-not found}"
-  echo "warning: bump version manually, commit, and push, then rerun deploy-cargo."
+echo "Registry state:"
+echo "  fido-types@$CURRENT_VERSION: $TYPES_STATE"
+echo "  fido@$CURRENT_VERSION:       $FIDO_STATE"
+
+if [[ "$FIDO_STATE" == "published" ]]; then
+  echo "error: version $CURRENT_VERSION is already published on crates.io."
+  echo "error: bump version manually, commit, and push, then rerun deploy-cargo."
   exit 1
+fi
+if [[ "$TYPES_STATE" == "published" ]]; then
+  echo "warning: fido-types $CURRENT_VERSION is already published; fido publish can continue after dry-run."
 fi
 
 echo "==> Running publish dry-runs (dependency order)"
-cargo publish --dry-run -p fido-types
-
-if [[ "$TYPES_PUBLISHED" == "$CURRENT_VERSION" ]]; then
-  cargo publish --dry-run -p fido
+if [[ "$TYPES_STATE" == "published" ]]; then
+  echo "skipping fido-types dry-run because fido-types $CURRENT_VERSION is already published."
 else
-  echo "warning: skipping pre-publish fido dry-run (fido-types $CURRENT_VERSION not yet on crates.io)."
+  cargo publish --dry-run -p fido-types
 fi
 
 if [[ "$DRY_RUN_ONLY" == true ]]; then
-  if [[ "$TYPES_PUBLISHED" != "$CURRENT_VERSION" ]]; then
-    echo "warning: fido dry-run was skipped because fido-types $CURRENT_VERSION is not published yet."
+  if [[ "$TYPES_STATE" != "published" ]]; then
+    echo "error: incomplete publish dry-run."
+    echo "checked:   fido-types publish dry-run"
+    echo "unchecked: fido publish dry-run"
+    echo "reason:    fido-types $CURRENT_VERSION is not visible on crates.io yet, so fido cannot resolve its registry dependency."
+    echo "next:      publish fido-types first, wait for indexing, then rerun just deploy-cargo-dry or just deploy-cargo."
+    exit 1
   fi
+  cargo publish --dry-run -p fido
   echo "Dry-run completed. No publish performed."
   exit 0
 fi
 
-echo "==> Publishing fido-types $CURRENT_VERSION"
-cargo publish -p fido-types
+if [[ "$TYPES_STATE" == "published" ]]; then
+  echo "==> fido-types $CURRENT_VERSION already indexed; skipping dependency publish"
+else
+  echo "==> Publishing fido-types $CURRENT_VERSION"
+  cargo publish -p fido-types
 
-echo "==> Waiting for crates.io index to include fido-types $CURRENT_VERSION"
-MAX_WAIT_SECONDS=300
-SLEEP_SECONDS=10
-ELAPSED=0
-while true; do
-  VISIBLE_TYPES_VERSION="$(cargo search fido-types 2>/dev/null | sed -nE 's/^fido-types = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' | head -n1)"
-  if [[ "$VISIBLE_TYPES_VERSION" == "$CURRENT_VERSION" ]]; then
-    echo "fido-types $CURRENT_VERSION is now visible on crates.io."
-    break
-  fi
+  echo "==> Waiting for crates.io index to include fido-types $CURRENT_VERSION"
+  MAX_WAIT_SECONDS=300
+  SLEEP_SECONDS=10
+  ELAPSED=0
+  while true; do
+    VISIBLE_TYPES_STATE="$(crate_version_state fido-types "$CURRENT_VERSION")"
+    if [[ "$VISIBLE_TYPES_STATE" == "published" ]]; then
+      echo "fido-types $CURRENT_VERSION is now visible on crates.io."
+      break
+    fi
 
-  if (( ELAPSED >= MAX_WAIT_SECONDS )); then
-    echo "warning: timed out waiting for fido-types $CURRENT_VERSION to appear on crates.io."
-    echo "warning: rerun just deploy-cargo in a minute; fido-types is likely published but not indexed yet."
-    exit 1
-  fi
+    if (( ELAPSED >= MAX_WAIT_SECONDS )); then
+      echo "error: timed out waiting for fido-types $CURRENT_VERSION to appear on crates.io."
+      echo "error: rerun just deploy-cargo after crates.io indexing catches up."
+      exit 1
+    fi
 
-  sleep "$SLEEP_SECONDS"
-  ELAPSED=$((ELAPSED + SLEEP_SECONDS))
-done
+    sleep "$SLEEP_SECONDS"
+    ELAPSED=$((ELAPSED + SLEEP_SECONDS))
+  done
+fi
 
 echo "==> Running fido dry-run now that dependency is indexed"
 cargo publish --dry-run -p fido


### PR DESCRIPTION
## Stints
- 0021: benchmark and index feed query hot paths
- 0023: make release publish preflight fail closed
- 0024: bound realtime fanout and membership lookup cost

Blocked P2 0018 is not included; it is still blocked by 0017.

## Changes
- Added composite SQLite feed indexes for newest, popular, controversial, and pending approval board queries.
- Added a 5,000-thread SQLite query-plan stress test that asserts index-backed ordering and indexed reply-count probes.
- Added realtime community recipient caching with explicit invalidation on join, claim, and leave.
- Added realtime stress coverage for 1,001 members, 128 subscribers, and lagged broadcast overflow.
- Hardened scripts/deploy-cargo.sh: clean tree required by default, exact cargo info crate@version checks, and dry-run failure when fido publish dry-run cannot run.
- Added just prerelease-check and README release preflight notes.
- Applied rustfmt cleanup so the new global prerelease fmt gate can pass.

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo test -p fido-server --features sqlite-tests -- --nocapture
- cargo package -p fido-types
- cargo package -p fido
- just e2e-tui-startup
- just e2e-tui
- just deploy-cargo-dry: expected fail-closed because fido-types@0.5.2 and fido@0.5.2 are already published.

## Release notes
No version bump, crates publish, or Railway deploy in this PR.