### PR TITLE
TUI realtime websocket client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "dotenv",
  "emojis",
  "fido-types",
+ "futures-util",
  "log",
  "ratatui",
  "reqwest",
@@ -723,6 +724,7 @@ dependencies = [
  "textwrap",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tui-textarea",
  "urlencoding",
  "uuid",
@@ -2621,7 +2623,9 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -2813,6 +2817,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.6",
  "sha1",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ axum = { version = "0.7", features = ["ws"] }
 tokio = { version = "1.35", features = ["macros", "rt-multi-thread", "time", "net", "sync", "signal"] }
 tower-http = { version = "0.5", features = ["cors", "fs", "limit"] }
 reqwest = { version = "0.11", default-features = false, features = ["json", "native-tls"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+futures-util = "0.3"
 
 # Terminal UI framework
 ratatui = "0.28"

--- a/fido-tui/Cargo.toml
+++ b/fido-tui/Cargo.toml
@@ -27,6 +27,8 @@ tui-textarea = "0.6"
 
 reqwest.workspace = true
 tokio.workspace = true
+tokio-tungstenite.workspace = true
+futures-util.workspace = true
 
 emojis = "0.6"
 dirs = "5.0"

--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -128,9 +128,27 @@ impl ApiClient {
         self.session_token = token;
     }
 
+    /// Current session token used for authenticated requests.
+    pub fn session_token(&self) -> Option<&str> {
+        self.session_token.as_deref()
+    }
+
     /// Server URL used to scope local session storage.
     pub fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    /// WebSocket URL for the realtime gateway that matches the configured API origin.
+    pub fn websocket_url(&self) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        let websocket_base = if let Some(rest) = base.strip_prefix("https://") {
+            format!("wss://{}", rest)
+        } else if let Some(rest) = base.strip_prefix("http://") {
+            format!("ws://{}", rest)
+        } else {
+            format!("ws://{}", base)
+        };
+        format!("{}/ws", websocket_base)
     }
 
     /// Helper to add session token to request if available
@@ -599,11 +617,13 @@ impl ApiClient {
         Ok(())
     }
 
-    // Placeholder for future WebSocket integration
-    // TODO: Add WebSocket support for real-time updates
-    // pub async fn connect_websocket(&self) -> ApiResult<WebSocketStream> {
-    //     // WebSocket connection logic will go here
-    // }
+    /// Get grouped unread notification counts.
+    pub async fn get_notification_unread_counts(&self) -> ApiResult<Vec<NotificationUnreadCount>> {
+        let url = self.build_url("/notifications/unread-count");
+        let req = self.add_auth_header(self.client.get(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
 }
 
 impl Default for ApiClient {

--- a/fido-tui/src/api/mod.rs
+++ b/fido-tui/src/api/mod.rs
@@ -1,7 +1,11 @@
 mod client;
 mod error;
+mod realtime;
 
 pub use client::{
     ApiClient, CommunityMemberInfo, CommunityViewResponse, SocialUserInfo, VoteDirection,
 };
 pub use error::{ApiError, ApiResult};
+pub use realtime::{
+    spawn_realtime_task, RealtimeClientEvent, RealtimeConnectionStatus, RealtimeStatusUpdate,
+};

--- a/fido-tui/src/api/realtime.rs
+++ b/fido-tui/src/api/realtime.rs
@@ -1,0 +1,255 @@
+use std::time::Duration;
+
+use fido_types::EventEnvelope;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::protocol::Message;
+use tokio_tungstenite::tungstenite::Error as WebSocketError;
+
+use super::ApiClient;
+
+const CHANNEL_CAPACITY: usize = 256;
+const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RealtimeConnectionStatus {
+    Disabled,
+    Connecting,
+    Connected,
+    Reconnecting,
+    Unauthorized,
+}
+
+impl RealtimeConnectionStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            RealtimeConnectionStatus::Disabled => "off",
+            RealtimeConnectionStatus::Connecting => "connecting",
+            RealtimeConnectionStatus::Connected => "live",
+            RealtimeConnectionStatus::Reconnecting => "polling",
+            RealtimeConnectionStatus::Unauthorized => "auth",
+        }
+    }
+
+    pub fn uses_polling_fallback(self) -> bool {
+        matches!(
+            self,
+            RealtimeConnectionStatus::Connecting | RealtimeConnectionStatus::Reconnecting
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealtimeStatusUpdate {
+    pub status: RealtimeConnectionStatus,
+    pub message: Option<String>,
+}
+
+impl RealtimeStatusUpdate {
+    fn new(status: RealtimeConnectionStatus, message: impl Into<Option<String>>) -> Self {
+        Self {
+            status,
+            message: message.into(),
+        }
+    }
+}
+
+impl From<RealtimeConnectionStatus> for RealtimeStatusUpdate {
+    fn from(status: RealtimeConnectionStatus) -> Self {
+        Self {
+            status,
+            message: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum RealtimeClientEvent {
+    Status(RealtimeStatusUpdate),
+    Event(Box<EventEnvelope>),
+    RefetchRequired,
+}
+
+enum ConnectionOutcome {
+    Retry(String),
+    Unauthorized(String),
+    ReceiverDropped,
+}
+
+pub fn spawn_realtime_task(
+    api_client: ApiClient,
+) -> (JoinHandle<()>, mpsc::Receiver<RealtimeClientEvent>) {
+    let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+    let handle = tokio::spawn(async move {
+        run_realtime_client(api_client, tx).await;
+    });
+    (handle, rx)
+}
+
+async fn run_realtime_client(api_client: ApiClient, tx: mpsc::Sender<RealtimeClientEvent>) {
+    let Some(token) = api_client.session_token().map(ToOwned::to_owned) else {
+        let _ = tx
+            .send(RealtimeClientEvent::Status(RealtimeStatusUpdate::new(
+                RealtimeConnectionStatus::Disabled,
+                Some("missing session token".to_string()),
+            )))
+            .await;
+        return;
+    };
+
+    let websocket_url = api_client.websocket_url();
+    let mut attempt = 0_u32;
+
+    loop {
+        let status = if attempt == 0 {
+            RealtimeConnectionStatus::Connecting
+        } else {
+            RealtimeConnectionStatus::Reconnecting
+        };
+        if tx
+            .send(RealtimeClientEvent::Status(RealtimeStatusUpdate::new(
+                status, None,
+            )))
+            .await
+            .is_err()
+        {
+            return;
+        }
+
+        match connect_and_read(&websocket_url, &token, &tx).await {
+            ConnectionOutcome::ReceiverDropped => return,
+            ConnectionOutcome::Unauthorized(message) => {
+                let _ = tx
+                    .send(RealtimeClientEvent::Status(RealtimeStatusUpdate::new(
+                        RealtimeConnectionStatus::Unauthorized,
+                        Some(message),
+                    )))
+                    .await;
+                return;
+            }
+            ConnectionOutcome::Retry(message) => {
+                let _ = tx.send(RealtimeClientEvent::RefetchRequired).await;
+                if tx
+                    .send(RealtimeClientEvent::Status(RealtimeStatusUpdate::new(
+                        RealtimeConnectionStatus::Reconnecting,
+                        Some(message),
+                    )))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                tokio::time::sleep(reconnect_delay(attempt)).await;
+                attempt = attempt.saturating_add(1);
+            }
+        }
+    }
+}
+
+async fn connect_and_read(
+    websocket_url: &str,
+    token: &str,
+    tx: &mpsc::Sender<RealtimeClientEvent>,
+) -> ConnectionOutcome {
+    let mut request = match websocket_url.into_client_request() {
+        Ok(request) => request,
+        Err(e) => return ConnectionOutcome::Retry(format!("invalid websocket url: {e}")),
+    };
+
+    let header_value = match token.parse() {
+        Ok(value) => value,
+        Err(e) => return ConnectionOutcome::Retry(format!("invalid session header: {e}")),
+    };
+    request
+        .headers_mut()
+        .insert("X-Session-Token", header_value);
+
+    let (mut socket, _) = match connect_async(request).await {
+        Ok(connected) => connected,
+        Err(WebSocketError::Http(response)) if response.status().as_u16() == 401 => {
+            return ConnectionOutcome::Unauthorized("session rejected by /ws".to_string());
+        }
+        Err(e) => return ConnectionOutcome::Retry(e.to_string()),
+    };
+
+    if tx
+        .send(RealtimeClientEvent::Status(RealtimeStatusUpdate::new(
+            RealtimeConnectionStatus::Connected,
+            None,
+        )))
+        .await
+        .is_err()
+    {
+        return ConnectionOutcome::ReceiverDropped;
+    }
+
+    loop {
+        let Some(frame) = socket.next().await else {
+            return ConnectionOutcome::Retry("websocket closed".to_string());
+        };
+
+        match frame {
+            Ok(Message::Text(text)) => match serde_json::from_str::<EventEnvelope>(&text) {
+                Ok(envelope) => {
+                    if tx
+                        .send(RealtimeClientEvent::Event(Box::new(envelope)))
+                        .await
+                        .is_err()
+                    {
+                        return ConnectionOutcome::ReceiverDropped;
+                    }
+                }
+                Err(e) => {
+                    log::warn!("Ignoring invalid realtime event envelope: {}", e);
+                }
+            },
+            Ok(Message::Ping(payload)) => {
+                if let Err(e) = socket.send(Message::Pong(payload)).await {
+                    return ConnectionOutcome::Retry(e.to_string());
+                }
+            }
+            Ok(Message::Close(frame)) => {
+                let reason = frame
+                    .map(|f| f.reason.to_string())
+                    .filter(|reason| !reason.is_empty())
+                    .unwrap_or_else(|| "websocket closed".to_string());
+                return ConnectionOutcome::Retry(reason);
+            }
+            Ok(Message::Pong(_)) | Ok(Message::Binary(_)) | Ok(Message::Frame(_)) => {}
+            Err(e) => return ConnectionOutcome::Retry(e.to_string()),
+        }
+    }
+}
+
+pub(crate) fn reconnect_delay(attempt: u32) -> Duration {
+    let multiplier = 2_u32.saturating_pow(attempt).min(30);
+    (INITIAL_RECONNECT_DELAY * multiplier).min(MAX_RECONNECT_DELAY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconnect_delay_caps_at_maximum() {
+        assert_eq!(reconnect_delay(0), Duration::from_secs(1));
+        assert_eq!(reconnect_delay(1), Duration::from_secs(2));
+        assert_eq!(reconnect_delay(20), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn websocket_url_matches_http_origin_scheme() {
+        assert_eq!(
+            ApiClient::new("https://example.com").websocket_url(),
+            "wss://example.com/ws"
+        );
+        assert_eq!(
+            ApiClient::new("http://127.0.0.1:3000/").websocket_url(),
+            "ws://127.0.0.1:3000/ws"
+        );
+    }
+}

--- a/fido-tui/src/app/auth.rs
+++ b/fido-tui/src/app/auth.rs
@@ -47,6 +47,7 @@ impl App {
         self.community_error = None;
         self.show_community_modal = false;
         self.home_state = super::state::HomeState::new();
+        self.realtime_state = super::state::RealtimeState::new();
 
         // Reset GitHub Device Flow state
         self.auth_state.github_auth_in_progress = false;

--- a/fido-tui/src/app/build.rs
+++ b/fido-tui/src/app/build.rs
@@ -174,6 +174,7 @@ impl App {
             home_state: HomeState::new(),
             show_community_modal: false,
             community_members: Vec::new(),
+            realtime_state: RealtimeState::new(),
         }
     }
 }

--- a/fido-tui/src/app/dms.rs
+++ b/fido-tui/src/app/dms.rs
@@ -127,6 +127,9 @@ impl App {
         match self.api_client.get_conversation(other_user_id).await {
             Ok(messages) => {
                 self.dms_state.messages = messages;
+                self.realtime_state
+                    .seen_dm_messages
+                    .extend(self.dms_state.messages.iter().map(|message| message.id));
 
                 // Mark conversation as read when opening it
                 self.mark_conversation_as_read(other_user_id).await?;

--- a/fido-tui/src/app/mod.rs
+++ b/fido-tui/src/app/mod.rs
@@ -17,6 +17,7 @@ mod post_detail;
 mod posts;
 mod profile;
 mod profile_view;
+mod realtime;
 mod settings;
 mod user_search;
 

--- a/fido-tui/src/app/posts.rs
+++ b/fido-tui/src/app/posts.rs
@@ -159,6 +159,9 @@ impl App {
             Ok(posts) => {
                 let has_posts = !posts.is_empty();
                 self.posts_state.posts = posts;
+                self.realtime_state
+                    .seen_posts
+                    .extend(self.posts_state.posts.iter().map(|post| post.id));
                 self.posts_state.rebuild_feed();
                 // Server now includes user_vote in each post
                 if has_posts {

--- a/fido-tui/src/app/realtime.rs
+++ b/fido-tui/src/app/realtime.rs
@@ -1,0 +1,379 @@
+use anyhow::Result;
+use fido_types::{
+    DirectMessage, DmConversationState, Event, EventEnvelope, Notification,
+    NotificationUnreadCount, Post, SortOrder,
+};
+use uuid::Uuid;
+
+use super::{App, Conversation, DMSelection, DmRequest, FeedEntry, PostFilter, Screen, Tab};
+use crate::api::RealtimeStatusUpdate;
+
+impl App {
+    pub fn apply_realtime_status(&mut self, update: RealtimeStatusUpdate) {
+        self.realtime_state.status = update.status;
+        self.realtime_state.last_error = update.message;
+    }
+
+    pub fn apply_realtime_envelope(&mut self, envelope: EventEnvelope) {
+        self.realtime_state.last_event_at = Some(std::time::Instant::now());
+        match envelope.event {
+            Event::MessageCreated(payload) => {
+                if self
+                    .realtime_state
+                    .seen_channel_messages
+                    .insert(payload.message.id)
+                {
+                    self.realtime_state.channel_message_count =
+                        self.realtime_state.channel_message_count.saturating_add(1);
+                    self.realtime_state.last_channel_message = Some(payload);
+                }
+            }
+            Event::ThreadCreated(post) => self.apply_realtime_thread(post),
+            Event::ThreadPendingApproval(post) => {
+                self.realtime_state.seen_posts.insert(post.id);
+            }
+            Event::DmRequestCreated(payload) => {
+                self.apply_realtime_dm_request(payload.message, payload.conversation.state);
+            }
+            Event::DmMessageCreated(message) => self.apply_realtime_dm_message(message, None),
+            Event::NotificationCreated(notification) => {
+                self.apply_realtime_notification(notification);
+            }
+        }
+    }
+
+    pub async fn refresh_realtime_fallback_visible_surface(&mut self) -> Result<()> {
+        self.refresh_notification_counts().await;
+
+        if self.current_screen != Screen::Main {
+            return Ok(());
+        }
+
+        match self.current_tab {
+            Tab::Posts if self.community.is_some() => {
+                self.load_posts().await?;
+            }
+            Tab::DMs => {
+                self.load_conversations().await?;
+                if self.dms_state.selection.conversation_index().is_some() {
+                    self.load_conversation_messages().await?;
+                }
+            }
+            Tab::Profile => {
+                if self.profile_state.profile.is_some() {
+                    self.load_profile().await?;
+                }
+            }
+            Tab::Settings => {}
+            Tab::Posts => {}
+        }
+
+        Ok(())
+    }
+
+    pub async fn refresh_notification_counts(&mut self) {
+        match self.api_client.get_notification_unread_counts().await {
+            Ok(counts) => {
+                self.realtime_state.unread_notifications = counts;
+            }
+            Err(e) => {
+                self.realtime_state.last_error = Some(e.to_string());
+            }
+        }
+    }
+
+    fn apply_realtime_thread(&mut self, post: Post) {
+        if self
+            .posts_state
+            .posts
+            .iter()
+            .any(|existing| existing.id == post.id)
+        {
+            self.realtime_state.seen_posts.insert(post.id);
+            return;
+        }
+        if !self.realtime_state.seen_posts.insert(post.id) {
+            return;
+        }
+        if !post.approved || post.parent_post_id.is_some() {
+            return;
+        }
+        if self.community.as_ref().map(|c| c.id) != Some(post.community_id) {
+            return;
+        }
+        if !self.post_matches_current_filter(&post) {
+            return;
+        }
+
+        let selected_post = self.selected_post_id();
+        self.posts_state.posts.push(post);
+        self.sort_and_limit_posts();
+        self.posts_state.rebuild_feed();
+        self.restore_selected_post(selected_post);
+    }
+
+    fn post_matches_current_filter(&self, post: &Post) -> bool {
+        match &self.posts_state.current_filter {
+            PostFilter::All => true,
+            PostFilter::Hashtag(tag) => post
+                .hashtags
+                .iter()
+                .any(|hashtag| hashtag.eq_ignore_ascii_case(tag)),
+            PostFilter::User(username) => post.author_username.eq_ignore_ascii_case(username),
+            PostFilter::Multi { hashtags, users } => {
+                let hashtag_match = hashtags.iter().any(|tag| {
+                    post.hashtags
+                        .iter()
+                        .any(|hashtag| hashtag.eq_ignore_ascii_case(tag))
+                });
+                let user_match = users
+                    .iter()
+                    .any(|username| post.author_username.eq_ignore_ascii_case(username));
+                hashtag_match || user_match
+            }
+        }
+    }
+
+    fn selected_post_id(&self) -> Option<Uuid> {
+        let selected = self.posts_state.selected_feed_entry()?;
+        match selected {
+            FeedEntry::Post(index) => self.posts_state.posts.get(index).map(|post| post.id),
+            FeedEntry::Activity(_) => None,
+        }
+    }
+
+    fn restore_selected_post(&mut self, selected_post: Option<Uuid>) {
+        if let Some(post_id) = selected_post {
+            if let Some(index) = self
+                .posts_state
+                .posts
+                .iter()
+                .position(|post| post.id == post_id)
+            {
+                let list_index = self.posts_state.post_index_to_list_index(index);
+                self.posts_state.list_state.select(Some(list_index));
+                return;
+            }
+        }
+
+        if self.posts_state.posts.is_empty() {
+            self.posts_state.list_state.select(None);
+        } else if self.posts_state.list_state.selected().is_none() {
+            self.posts_state
+                .list_state
+                .select(Some(self.posts_state.items_before_posts()));
+        }
+    }
+
+    fn sort_and_limit_posts(&mut self) {
+        let sort_order = self
+            .settings_state
+            .config
+            .as_ref()
+            .map(|config| config.sort_order)
+            .unwrap_or(SortOrder::Newest);
+
+        match sort_order {
+            SortOrder::Newest => self
+                .posts_state
+                .posts
+                .sort_by(|a, b| b.created_at.cmp(&a.created_at)),
+            SortOrder::Popular => self.posts_state.posts.sort_by(|a, b| {
+                b.upvotes
+                    .cmp(&a.upvotes)
+                    .then_with(|| b.created_at.cmp(&a.created_at))
+            }),
+            SortOrder::Controversial => self.posts_state.posts.sort_by(|a, b| {
+                let a_score = (a.upvotes - a.downvotes).abs();
+                let b_score = (b.upvotes - b.downvotes).abs();
+                a_score
+                    .cmp(&b_score)
+                    .then_with(|| b.created_at.cmp(&a.created_at))
+            }),
+        }
+
+        let max_posts = self
+            .settings_state
+            .config
+            .as_ref()
+            .map(|config| config.max_posts_display.max(1) as usize)
+            .unwrap_or(25);
+        self.posts_state.posts.truncate(max_posts);
+    }
+
+    fn apply_realtime_dm_request(&mut self, message: DirectMessage, state: DmConversationState) {
+        let Some((other_user_id, other_username, from_me)) = self.dm_counterparty(&message) else {
+            return;
+        };
+
+        if !from_me
+            && !self
+                .dms_state
+                .pending_requests
+                .iter()
+                .any(|request| request.from_user_id == other_user_id)
+        {
+            self.dms_state.pending_requests.push(DmRequest {
+                from_user_id: other_user_id,
+                from_username: other_username,
+            });
+        }
+
+        self.apply_realtime_dm_message(message, Some(state));
+    }
+
+    fn apply_realtime_dm_message(
+        &mut self,
+        message: DirectMessage,
+        state_hint: Option<DmConversationState>,
+    ) {
+        if self
+            .dms_state
+            .messages
+            .iter()
+            .any(|existing| existing.id == message.id)
+        {
+            self.realtime_state.seen_dm_messages.insert(message.id);
+            return;
+        }
+        if !self.realtime_state.seen_dm_messages.insert(message.id) {
+            return;
+        }
+
+        let Some((other_user_id, other_username, from_me)) = self.dm_counterparty(&message) else {
+            return;
+        };
+
+        let is_open = self.dms_state.current_conversation_user == Some(other_user_id);
+        let is_incoming = !from_me;
+
+        if is_open {
+            let mut visible_message = message.clone();
+            visible_message.is_read = true;
+            self.dms_state.messages.push(visible_message);
+            self.dms_state.unread_counts.insert(other_user_id, 0);
+        } else if is_incoming {
+            let count = self
+                .dms_state
+                .unread_counts
+                .entry(other_user_id)
+                .or_insert(0);
+            *count = count.saturating_add(1);
+        }
+
+        let pending_incoming =
+            is_incoming && matches!(state_hint, Some(DmConversationState::Pending));
+        if !pending_incoming {
+            self.upsert_dm_conversation(
+                other_user_id,
+                other_username,
+                message.content,
+                state_hint.unwrap_or(DmConversationState::Accepted),
+                from_me,
+            );
+        }
+
+        self.sync_conversation_unread_count(other_user_id);
+    }
+
+    fn dm_counterparty(&self, message: &DirectMessage) -> Option<(Uuid, String, bool)> {
+        let current_user = self.auth_state.current_user.as_ref()?;
+        if message.from_user_id == current_user.id {
+            Some((message.to_user_id, message.to_username.clone(), true))
+        } else if message.to_user_id == current_user.id {
+            Some((message.from_user_id, message.from_username.clone(), false))
+        } else {
+            None
+        }
+    }
+
+    fn upsert_dm_conversation(
+        &mut self,
+        other_user_id: Uuid,
+        other_username: String,
+        last_message: String,
+        state: DmConversationState,
+        initiated_by_me: bool,
+    ) {
+        if let Some(conversation) = self
+            .dms_state
+            .conversations
+            .iter_mut()
+            .find(|conversation| conversation.other_user_id == other_user_id)
+        {
+            conversation.last_message = last_message;
+            conversation.state = state;
+            return;
+        }
+
+        let unread_count = self
+            .dms_state
+            .unread_counts
+            .get(&other_user_id)
+            .copied()
+            .unwrap_or_default() as i32;
+        self.dms_state.conversations.insert(
+            0,
+            Conversation {
+                other_user_id,
+                other_username,
+                last_message,
+                unread_count,
+                state,
+                initiated_by_me,
+            },
+        );
+        self.dms_state.conversations_loaded = true;
+        if self.dms_state.selection == DMSelection::NewConversation {
+            self.dms_state.selection = DMSelection::Conversation(0);
+        }
+    }
+
+    fn sync_conversation_unread_count(&mut self, other_user_id: Uuid) {
+        let unread_count = self
+            .dms_state
+            .unread_counts
+            .get(&other_user_id)
+            .copied()
+            .unwrap_or_default() as i32;
+        if let Some(conversation) = self
+            .dms_state
+            .conversations
+            .iter_mut()
+            .find(|conversation| conversation.other_user_id == other_user_id)
+        {
+            conversation.unread_count = unread_count;
+        }
+    }
+
+    fn apply_realtime_notification(&mut self, notification: Notification) {
+        if notification.read
+            || !self
+                .realtime_state
+                .seen_notifications
+                .insert(notification.id)
+        {
+            return;
+        }
+
+        if let Some(count) = self
+            .realtime_state
+            .unread_notifications
+            .iter_mut()
+            .find(|count| {
+                count.subject_type == notification.subject_type
+                    && count.subject_id == notification.subject_id
+            })
+        {
+            count.count += 1;
+        } else {
+            self.realtime_state
+                .unread_notifications
+                .push(NotificationUnreadCount {
+                    subject_type: notification.subject_type,
+                    subject_id: notification.subject_id,
+                    count: 1,
+                });
+        }
+    }
+}

--- a/fido-tui/src/app/realtime.rs
+++ b/fido-tui/src/app/realtime.rs
@@ -244,7 +244,9 @@ impl App {
             return;
         };
 
-        let is_open = self.dms_state.current_conversation_user == Some(other_user_id);
+        let is_open = self.current_screen == Screen::Main
+            && self.current_tab == Tab::DMs
+            && self.dms_state.current_conversation_user == Some(other_user_id);
         let is_incoming = !from_me;
 
         if is_open {
@@ -252,6 +254,9 @@ impl App {
             visible_message.is_read = true;
             self.dms_state.messages.push(visible_message);
             self.dms_state.unread_counts.insert(other_user_id, 0);
+            if is_incoming {
+                self.dms_state.needs_message_load = true;
+            }
         } else if is_incoming {
             let count = self
                 .dms_state

--- a/fido-tui/src/app/state.rs
+++ b/fido-tui/src/app/state.rs
@@ -1,11 +1,14 @@
-use fido_types::{ActivityItem, Post, User, UserProfile};
+use fido_types::{
+    ActivityItem, ChannelMessageEvent, NotificationUnreadCount, Post, User, UserProfile,
+};
 
 use ratatui::widgets::ListState;
+use std::collections::HashSet;
 use std::time::Instant;
 use tui_textarea::TextArea;
 use uuid::Uuid;
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, RealtimeConnectionStatus};
 
 /// Get platform-appropriate modifier key name for display
 /// Returns "Cmd" on macOS, "Ctrl" on other platforms
@@ -175,6 +178,43 @@ pub struct App {
     pub show_community_modal: bool,
     /// Members of the current community, loaded when the community modal opens
     pub community_members: Vec<crate::api::CommunityMemberInfo>,
+    /// Realtime transport and applied-event bookkeeping
+    pub realtime_state: RealtimeState,
+}
+
+/// Realtime transport state plus idempotency markers for pushed events.
+pub struct RealtimeState {
+    pub status: RealtimeConnectionStatus,
+    pub last_error: Option<String>,
+    pub last_event_at: Option<Instant>,
+    pub unread_notifications: Vec<NotificationUnreadCount>,
+    pub last_channel_message: Option<ChannelMessageEvent>,
+    pub channel_message_count: u64,
+    pub seen_posts: HashSet<Uuid>,
+    pub seen_dm_messages: HashSet<Uuid>,
+    pub seen_notifications: HashSet<Uuid>,
+    pub seen_channel_messages: HashSet<Uuid>,
+}
+
+impl RealtimeState {
+    pub fn new() -> Self {
+        Self {
+            status: RealtimeConnectionStatus::Disabled,
+            last_error: None,
+            last_event_at: None,
+            unread_notifications: Vec::new(),
+            last_channel_message: None,
+            channel_message_count: 0,
+            seen_posts: HashSet::new(),
+            seen_dm_messages: HashSet::new(),
+            seen_notifications: HashSet::new(),
+            seen_channel_messages: HashSet::new(),
+        }
+    }
+
+    pub fn is_polling_fallback_active(&self) -> bool {
+        self.status.uses_polling_fallback()
+    }
 }
 
 /// The community the board is scoped to, with the caller's standing in it

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use fido_types::Post;
+use fido_types::{Event, EventEnvelope, Post};
 
 /// Put the app on a community board (the launch-repo path in production).
 fn set_test_community(app: &mut App) {
@@ -933,6 +933,85 @@ fn dm_stray_key_on_request_selection_does_not_enter_typing_mode() {
     assert_eq!(app.input_mode, InputMode::Navigation);
 }
 
+#[test]
+fn realtime_thread_created_upserts_once_for_current_board() {
+    let mut app = App::new();
+    app.current_screen = Screen::Main;
+    set_test_community(&mut app);
+
+    let community_id = app.community.as_ref().unwrap().id;
+    let mut post = test_post_created_at("2026-07-02T12:00:00Z");
+    post.community_id = community_id;
+
+    app.apply_realtime_envelope(test_envelope(Event::ThreadCreated(post.clone())));
+    app.apply_realtime_envelope(test_envelope(Event::ThreadCreated(post)));
+
+    assert_eq!(app.posts_state.posts.len(), 1);
+    assert_eq!(app.posts_state.feed_entries.len(), 1);
+}
+
+#[test]
+fn realtime_dm_message_appends_once_to_open_conversation() {
+    let mut app = App::new();
+    let current_user_id = uuid::Uuid::new_v4();
+    let other_user_id = uuid::Uuid::new_v4();
+    app.auth_state.current_user = Some(test_user(current_user_id, "me"));
+    app.current_screen = Screen::Main;
+    app.current_tab = Tab::DMs;
+    app.dms_state.current_conversation_user = Some(other_user_id);
+    app.dms_state.conversations = vec![crate::app::Conversation {
+        other_user_id,
+        other_username: "friend".to_string(),
+        last_message: "before".to_string(),
+        unread_count: 0,
+        state: fido_types::DmConversationState::Accepted,
+        initiated_by_me: false,
+    }];
+
+    let message = fido_types::DirectMessage {
+        id: uuid::Uuid::new_v4(),
+        from_user_id: other_user_id,
+        to_user_id: current_user_id,
+        from_username: "friend".to_string(),
+        to_username: "me".to_string(),
+        content: "hello".to_string(),
+        created_at: chrono::Utc::now(),
+        is_read: false,
+    };
+
+    app.apply_realtime_envelope(test_envelope(Event::DmMessageCreated(message.clone())));
+    app.apply_realtime_envelope(test_envelope(Event::DmMessageCreated(message)));
+
+    assert_eq!(app.dms_state.messages.len(), 1);
+    assert_eq!(
+        app.dms_state.unread_counts.get(&other_user_id).copied(),
+        Some(0)
+    );
+}
+
+#[test]
+fn realtime_notification_created_increments_group_once() {
+    let mut app = App::new();
+    let notification = fido_types::Notification {
+        id: uuid::Uuid::new_v4(),
+        user_id: uuid::Uuid::new_v4(),
+        notification_type: fido_types::NotificationType::Mention,
+        actor_id: uuid::Uuid::new_v4(),
+        subject_type: "post".to_string(),
+        subject_id: "abc".to_string(),
+        read: false,
+        created_at: chrono::Utc::now(),
+    };
+
+    app.apply_realtime_envelope(test_envelope(Event::NotificationCreated(
+        notification.clone(),
+    )));
+    app.apply_realtime_envelope(test_envelope(Event::NotificationCreated(notification)));
+
+    assert_eq!(app.realtime_state.unread_notifications.len(), 1);
+    assert_eq!(app.realtime_state.unread_notifications[0].count, 1);
+}
+
 fn test_post_created_at(created_at: &str) -> Post {
     Post {
         id: uuid::Uuid::new_v4(),
@@ -950,6 +1029,24 @@ fn test_post_created_at(created_at: &str) -> Post {
         reply_count: 0,
         reply_to_user_id: None,
         reply_to_username: None,
+    }
+}
+
+fn test_user(id: uuid::Uuid, username: &str) -> fido_types::User {
+    fido_types::User {
+        id,
+        username: username.to_string(),
+        bio: None,
+        join_date: chrono::Utc::now(),
+        is_test_user: true,
+        is_admin: false,
+    }
+}
+
+fn test_envelope(event: Event) -> EventEnvelope {
+    EventEnvelope {
+        event,
+        ts: chrono::Utc::now(),
     }
 }
 

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -987,6 +987,56 @@ fn realtime_dm_message_appends_once_to_open_conversation() {
         app.dms_state.unread_counts.get(&other_user_id).copied(),
         Some(0)
     );
+    assert!(
+        app.dms_state.needs_message_load,
+        "visible incoming realtime messages should schedule a REST refresh so the server marks them read"
+    );
+}
+
+#[test]
+fn realtime_dm_message_hidden_tab_counts_unread_instead_of_open_read() {
+    let mut app = App::new();
+    let current_user_id = uuid::Uuid::new_v4();
+    let other_user_id = uuid::Uuid::new_v4();
+    app.auth_state.current_user = Some(test_user(current_user_id, "me"));
+    app.current_screen = Screen::Main;
+    app.current_tab = Tab::Posts;
+    app.dms_state.current_conversation_user = Some(other_user_id);
+    app.dms_state.conversations = vec![crate::app::Conversation {
+        other_user_id,
+        other_username: "friend".to_string(),
+        last_message: "before".to_string(),
+        unread_count: 0,
+        state: fido_types::DmConversationState::Accepted,
+        initiated_by_me: false,
+    }];
+
+    let message = fido_types::DirectMessage {
+        id: uuid::Uuid::new_v4(),
+        from_user_id: other_user_id,
+        to_user_id: current_user_id,
+        from_username: "friend".to_string(),
+        to_username: "me".to_string(),
+        content: "hidden tab".to_string(),
+        created_at: chrono::Utc::now(),
+        is_read: false,
+    };
+
+    app.apply_realtime_envelope(test_envelope(Event::DmMessageCreated(message)));
+
+    assert!(
+        app.dms_state.messages.is_empty(),
+        "hidden DMs should not append as if the conversation were visible"
+    );
+    assert_eq!(
+        app.dms_state.unread_counts.get(&other_user_id).copied(),
+        Some(1)
+    );
+    assert_eq!(app.dms_state.conversations[0].unread_count, 1);
+    assert!(
+        !app.dms_state.needs_message_load,
+        "hidden tab should wait for the next DMs load to mark messages read"
+    );
 }
 
 #[test]

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -3,19 +3,28 @@ use crate::auth::{self, AuthFlow, RestoredSession};
 use crate::{log_key_event, ui};
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+const REALTIME_FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 pub struct EventLoop {
     modal_tracker: ModalStateTracker,
     last_tab: Tab,
     last_dm_selection: DMSelection,
     last_terminal_size: (u16, u16),
-    last_device_poll: std::time::Instant,
+    last_device_poll: Instant,
     startup_started: bool,
     startup_data_load_pending: bool,
     session_restore_task: Option<JoinHandle<Result<Option<RestoredSession>, String>>>,
     update_check_task: Option<JoinHandle<Option<String>>>,
+    realtime_task: Option<JoinHandle<()>>,
+    realtime_rx: Option<mpsc::Receiver<crate::api::RealtimeClientEvent>>,
+    realtime_user_id: Option<Uuid>,
+    last_realtime_fallback_poll: Instant,
+    realtime_refetch_pending: bool,
     is_web_mode: bool,
 }
 
@@ -26,11 +35,16 @@ impl EventLoop {
             last_tab: Tab::Posts, // Default starting tab
             last_dm_selection: DMSelection::NewConversation,
             last_terminal_size: (0, 0),
-            last_device_poll: std::time::Instant::now(),
+            last_device_poll: Instant::now(),
             startup_started: false,
             startup_data_load_pending: false,
             session_restore_task: None,
             update_check_task: None,
+            realtime_task: None,
+            realtime_rx: None,
+            realtime_user_id: None,
+            last_realtime_fallback_poll: Instant::now(),
+            realtime_refetch_pending: false,
             is_web_mode,
         }
     }
@@ -47,6 +61,9 @@ impl EventLoop {
 
             // Clear expired messages
             app.clear_expired_messages();
+
+            // Drain pushed events before rendering this frame.
+            self.handle_realtime(app).await?;
 
             // Render UI
             self.render_ui(app, tui)?;
@@ -71,6 +88,103 @@ impl EventLoop {
             self.handle_dm_conversation_changes(app).await?;
         }
 
+        self.stop_realtime();
+        Ok(())
+    }
+
+    async fn handle_realtime(&mut self, app: &mut App) -> Result<()> {
+        self.sync_realtime_lifecycle(app);
+        self.drain_realtime_events(app);
+        self.handle_realtime_polling_fallback(app).await
+    }
+
+    fn sync_realtime_lifecycle(&mut self, app: &mut App) {
+        let Some(current_user) = app.auth_state.current_user.as_ref() else {
+            self.stop_realtime();
+            app.apply_realtime_status(crate::api::RealtimeConnectionStatus::Disabled.into());
+            return;
+        };
+        if app.current_screen != Screen::Main {
+            self.stop_realtime();
+            app.apply_realtime_status(crate::api::RealtimeConnectionStatus::Disabled.into());
+            return;
+        }
+        if app.api_client.session_token().is_none() {
+            self.stop_realtime();
+            app.apply_realtime_status(crate::api::RealtimeConnectionStatus::Disabled.into());
+            return;
+        }
+
+        if self.realtime_user_id != Some(current_user.id) {
+            self.stop_realtime();
+        }
+
+        if self.realtime_task.is_some() {
+            return;
+        }
+        if app.realtime_state.status == crate::api::RealtimeConnectionStatus::Unauthorized {
+            return;
+        }
+
+        let (handle, rx) = crate::api::spawn_realtime_task(app.api_client.clone());
+        self.realtime_task = Some(handle);
+        self.realtime_rx = Some(rx);
+        self.realtime_user_id = Some(current_user.id);
+        self.realtime_refetch_pending = false;
+    }
+
+    fn stop_realtime(&mut self) {
+        if let Some(handle) = self.realtime_task.take() {
+            handle.abort();
+        }
+        self.realtime_rx = None;
+        self.realtime_user_id = None;
+        self.realtime_refetch_pending = false;
+    }
+
+    fn drain_realtime_events(&mut self, app: &mut App) {
+        loop {
+            let event = match self.realtime_rx.as_mut() {
+                Some(rx) => rx.try_recv(),
+                None => return,
+            };
+
+            match event {
+                Ok(crate::api::RealtimeClientEvent::Status(update)) => {
+                    app.apply_realtime_status(update);
+                }
+                Ok(crate::api::RealtimeClientEvent::Event(envelope)) => {
+                    app.apply_realtime_envelope(*envelope);
+                }
+                Ok(crate::api::RealtimeClientEvent::RefetchRequired) => {
+                    self.realtime_refetch_pending = true;
+                }
+                Err(mpsc::error::TryRecvError::Empty) => return,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    self.realtime_rx = None;
+                    self.realtime_task = None;
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn handle_realtime_polling_fallback(&mut self, app: &mut App) -> Result<()> {
+        if !app.realtime_state.is_polling_fallback_active() {
+            return Ok(());
+        }
+
+        let poll_due =
+            self.last_realtime_fallback_poll.elapsed() >= REALTIME_FALLBACK_POLL_INTERVAL;
+        if !poll_due && !self.realtime_refetch_pending {
+            return Ok(());
+        }
+
+        self.realtime_refetch_pending = false;
+        self.last_realtime_fallback_poll = Instant::now();
+        if let Err(e) = app.refresh_realtime_fallback_visible_surface().await {
+            app.realtime_state.last_error = Some(e.to_string());
+        }
         Ok(())
     }
 

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -389,6 +389,9 @@ impl EventLoop {
                 if !app.dms_state.conversations_loaded || app.dms_state.error.is_some() {
                     app.load_conversations().await?;
                 }
+                if app.dms_state.selection.conversation_index().is_some() {
+                    app.dms_state.needs_message_load = true;
+                }
             }
             Tab::Settings => {
                 if app.settings_state.config.is_none() || app.settings_state.error.is_some() {

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -473,10 +473,14 @@ pub fn render_global_footer(frame: &mut Frame, app: &mut App, area: Rect) {
     // Clear the area first to prevent text bleeding
     frame.render_widget(Clear, area);
 
+    let footer_text = format!(
+        "RT: {} | Tab/Shift+Tab: Tabs | Shift+L: Logout | ?: Help | q/Esc: Quit | ↑/↓/j/k: Navigate",
+        app.realtime_state.status.label()
+    );
     render_footer_with_style(
         frame,
         area,
-        "Tab: Next | Shift+Tab: Previous | Shift+L: Logout | ?: Help | q/Esc: Quit | ↑/↓/j/k: Navigate",
+        &footer_text,
         &theme,
         Style::default().fg(theme.text_dim),
     );


### PR DESCRIPTION
## Summary
- implements stint 0011 with a TUI websocket client for /ws using header auth and reconnect backoff
- drains typed realtime envelopes in the event loop before render, applies idempotent state updates for threads, DMs, notifications, and tracks channel-message events for future chat screens
- keeps REST polling fallback for visible surfaces and notification counts while the socket is connecting/reconnecting, with footer realtime status

## Stint
- 0011

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build
- cargo test --workspace
- cargo test -p fido-server --features sqlite-tests
- cargo test -p fido-server --test ws_integration_tests -- --nocapture
- just e2e-tui-startup
- just e2e-tui

## Release notes
- Rust behavior changed in the TUI; release/publish should happen after merge if we are cutting a new version.
