### PR TITLE
feat: add Discord-style TUI shell

### DIFF
--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -281,6 +281,14 @@ impl ApiClient {
         self.handle_response(response).await
     }
 
+    /// Browse the authenticated user's starred repos with community state.
+    pub async fn browse_communities(&self) -> ApiResult<Vec<BrowseCommunityResponse>> {
+        let url = self.build_url("/communities/browse");
+        let req = self.add_auth_header(self.client.get(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
     /// Join a repo community; the server resolves the repo via GitHub and
     /// lazily creates the community on first join.
     pub async fn join_community(
@@ -698,6 +706,16 @@ pub struct CommunityResponse {
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct MembershipResponse {
     pub role: fido_types::MembershipRole,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct BrowseCommunityResponse {
+    pub owner: String,
+    pub name: String,
+    pub full_name: String,
+    pub private: bool,
+    pub community: Option<CommunityResponse>,
+    pub membership: Option<MembershipResponse>,
 }
 
 /// Response body for `GET /communities/:id/activity`

--- a/fido-tui/src/api/mod.rs
+++ b/fido-tui/src/api/mod.rs
@@ -3,7 +3,8 @@ mod error;
 mod realtime;
 
 pub use client::{
-    ApiClient, CommunityMemberInfo, CommunityViewResponse, SocialUserInfo, VoteDirection,
+    ApiClient, BrowseCommunityResponse, CommunityMemberInfo, CommunityViewResponse, SocialUserInfo,
+    VoteDirection,
 };
 pub use error::{ApiError, ApiResult};
 pub use realtime::{

--- a/fido-tui/src/app/build.rs
+++ b/fido-tui/src/app/build.rs
@@ -172,6 +172,7 @@ impl App {
             community: None,
             community_error: None,
             home_state: HomeState::new(),
+            community_browser_state: CommunityBrowserState::new(),
             show_community_modal: false,
             community_members: Vec::new(),
             realtime_state: RealtimeState::new(),

--- a/fido-tui/src/app/communities.rs
+++ b/fido-tui/src/app/communities.rs
@@ -5,6 +5,7 @@
 //! and let the user open one.
 
 use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
 
 use crate::api::CommunityViewResponse;
 
@@ -163,6 +164,121 @@ impl App {
     pub fn previous_home_community(&mut self) {
         move_home_selection(&mut self.home_state, -1);
     }
+
+    /// Open the starred-repo browser, loading it on first use.
+    pub async fn open_community_browser(&mut self) -> Result<()> {
+        self.community_browser_state.show = true;
+        self.community_browser_state.error = None;
+        if !self.community_browser_state.loaded {
+            self.load_community_browser().await;
+        }
+        Ok(())
+    }
+
+    pub fn close_community_browser(&mut self) {
+        self.community_browser_state.show = false;
+        self.community_browser_state.error = None;
+        self.community_browser_state.message = None;
+    }
+
+    pub async fn load_community_browser(&mut self) {
+        self.community_browser_state.loading = true;
+        self.community_browser_state.error = None;
+        self.community_browser_state.message = None;
+
+        match self.api_client.browse_communities().await {
+            Ok(repos) => {
+                self.community_browser_state.repos = repos;
+                self.community_browser_state.loaded = true;
+                if self.community_browser_state.repos.is_empty() {
+                    self.community_browser_state.list_state.select(None);
+                } else {
+                    self.community_browser_state.list_state.select(Some(0));
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to browse starred communities: {}", e);
+                self.community_browser_state.error = Some(categorize_error(&e.to_string()));
+            }
+        }
+
+        self.community_browser_state.loading = false;
+    }
+
+    pub async fn open_or_join_browser_selection(&mut self) -> Result<()> {
+        let Some(selected) = self.community_browser_state.selected() else {
+            return Ok(());
+        };
+
+        if selected.private {
+            self.community_browser_state.error =
+                Some("Private repositories cannot create Fido communities yet".to_string());
+            return Ok(());
+        }
+
+        let owner = selected.owner.clone();
+        let name = selected.name.clone();
+        let existing_community = selected
+            .community
+            .as_ref()
+            .filter(|_| selected.membership.is_some())
+            .map(|community| community.id);
+
+        self.community_browser_state.joining = true;
+        self.community_browser_state.error = None;
+        self.community_browser_state.message = None;
+
+        let result = if let Some(community_id) = existing_community {
+            self.api_client.get_community(community_id).await
+        } else {
+            self.api_client.join_community(&owner, &name).await
+        };
+
+        match result {
+            Ok(view) => {
+                self.clear_activity();
+                self.apply_community_view(view);
+                self.current_tab = crate::app::Tab::Posts;
+                self.community_browser_state.show = false;
+                self.community_browser_state.loaded = false;
+                self.load_home_communities().await;
+                self.load_posts().await?;
+            }
+            Err(e) => {
+                log::error!("Failed to open or join {}/{}: {}", owner, name, e);
+                self.community_browser_state.error = Some(categorize_error(&e.to_string()));
+            }
+        }
+
+        self.community_browser_state.joining = false;
+        Ok(())
+    }
+
+    pub fn next_browser_repo(&mut self) {
+        move_browser_selection(&mut self.community_browser_state, 1);
+    }
+
+    pub fn previous_browser_repo(&mut self) {
+        move_browser_selection(&mut self.community_browser_state, -1);
+    }
+
+    pub fn handle_community_browser_keys(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('b') | KeyCode::Char('B') => {
+                self.close_community_browser();
+            }
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => self.next_browser_repo(),
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => self.previous_browser_repo(),
+            KeyCode::Char('r') | KeyCode::Char('R') => {
+                self.community_browser_state.loaded = false;
+                self.community_browser_state.message =
+                    Some("Reloading starred repos...".to_string());
+            }
+            KeyCode::Enter => {}
+            _ => {}
+        }
+        Ok(())
+    }
 }
 
 fn move_home_selection(home: &mut crate::app::state::HomeState, delta: i64) {
@@ -174,4 +290,15 @@ fn move_home_selection(home: &mut crate::app::state::HomeState, delta: i64) {
     let current = home.list_state.selected().unwrap_or(0) as i64;
     let next = (current + delta).rem_euclid(len as i64) as usize;
     home.list_state.select(Some(next));
+}
+
+fn move_browser_selection(browser: &mut crate::app::state::CommunityBrowserState, delta: i64) {
+    let len = browser.repos.len();
+    if len == 0 {
+        browser.list_state.select(None);
+        return;
+    }
+    let current = browser.list_state.selected().unwrap_or(0) as i64;
+    let next = (current + delta).rem_euclid(len as i64) as usize;
+    browser.list_state.select(Some(next));
 }

--- a/fido-tui/src/app/handlers/mod.rs
+++ b/fido-tui/src/app/handlers/mod.rs
@@ -26,6 +26,11 @@ pub fn handle_key_event(app: &mut App, key: KeyEvent) -> Result<()> {
         return handle_help_keys(app, key);
     }
 
+    // Priority 1.25: Community browser overlay
+    if app.community_browser_state.show {
+        return app.handle_community_browser_keys(key);
+    }
+
     // Priority 1.5: User profile view
     if app.user_profile_view.is_some() {
         return app.handle_user_profile_view_keys(key);

--- a/fido-tui/src/app/state.rs
+++ b/fido-tui/src/app/state.rs
@@ -174,6 +174,8 @@ pub struct App {
     pub community_error: Option<String>,
     /// Joined-communities list shown when launched outside a repo
     pub home_state: HomeState,
+    /// Starred-repo browser for joining additional communities
+    pub community_browser_state: CommunityBrowserState,
     /// Community settings modal (role, member count, claim)
     pub show_community_modal: bool,
     /// Members of the current community, loaded when the community modal opens
@@ -258,6 +260,37 @@ impl HomeState {
         self.list_state
             .selected()
             .and_then(|i| self.communities.get(i))
+    }
+}
+
+/// Starred GitHub repos annotated with Fido community state.
+pub struct CommunityBrowserState {
+    pub show: bool,
+    pub repos: Vec<crate::api::BrowseCommunityResponse>,
+    pub list_state: ListState,
+    pub loading: bool,
+    pub loaded: bool,
+    pub joining: bool,
+    pub error: Option<String>,
+    pub message: Option<String>,
+}
+
+impl CommunityBrowserState {
+    pub fn new() -> Self {
+        Self {
+            show: false,
+            repos: Vec::new(),
+            list_state: ListState::default(),
+            loading: false,
+            loaded: false,
+            joining: false,
+            error: None,
+            message: None,
+        }
+    }
+
+    pub fn selected(&self) -> Option<&crate::api::BrowseCommunityResponse> {
+        self.list_state.selected().and_then(|i| self.repos.get(i))
     }
 }
 

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -21,6 +21,62 @@ fn key_event(code: KeyCode) -> KeyEvent {
     event
 }
 
+fn test_browse_repo(name: &str) -> crate::api::BrowseCommunityResponse {
+    crate::api::BrowseCommunityResponse {
+        owner: "octocat".to_string(),
+        name: name.to_string(),
+        full_name: format!("octocat/{}", name),
+        private: false,
+        community: None,
+        membership: None,
+    }
+}
+
+#[test]
+fn test_rail_tab_order_matches_launch_shell() {
+    let mut app = App::new();
+    app.current_tab = Tab::Posts;
+
+    app.next_tab();
+    assert_eq!(app.current_tab, Tab::DMs);
+    app.next_tab();
+    assert_eq!(app.current_tab, Tab::Profile);
+    app.next_tab();
+    assert_eq!(app.current_tab, Tab::Settings);
+    app.next_tab();
+    assert_eq!(app.current_tab, Tab::Posts);
+
+    app.previous_tab();
+    assert_eq!(app.current_tab, Tab::Settings);
+}
+
+#[test]
+fn test_community_browser_selection_wraps() {
+    let mut app = App::new();
+    app.community_browser_state.repos = vec![test_browse_repo("alpha"), test_browse_repo("beta")];
+    app.community_browser_state.list_state.select(Some(0));
+
+    app.next_browser_repo();
+    assert_eq!(app.community_browser_state.list_state.selected(), Some(1));
+    app.next_browser_repo();
+    assert_eq!(app.community_browser_state.list_state.selected(), Some(0));
+    app.previous_browser_repo();
+    assert_eq!(app.community_browser_state.list_state.selected(), Some(1));
+}
+
+#[test]
+fn test_escape_closes_community_browser_before_quit() {
+    let mut app = App::new();
+    app.current_screen = Screen::Main;
+    app.community_browser_state.show = true;
+    app.running = true;
+
+    app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
+
+    assert!(!app.community_browser_state.show);
+    assert!(app.running);
+}
+
 #[test]
 fn test_escape_closes_help_modal_first() {
     let mut app = App::new();

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -567,6 +567,33 @@ impl EventLoop {
             KeyCode::Enter if app.posts_state.show_filter_modal => {
                 self.handle_filter_modal_enter(app).await?;
             }
+            KeyCode::Char('b') | KeyCode::Char('B')
+                if app.current_screen == Screen::Main
+                    && app.input_mode == InputMode::Navigation
+                    && !app.community_browser_state.show
+                    && !app.composer_state.is_open()
+                    && !app.viewing_post_detail
+                    && app.user_profile_view.is_none() =>
+            {
+                app.open_community_browser().await?;
+            }
+            KeyCode::Enter
+                if app.current_screen == Screen::Main
+                    && app.community_browser_state.show
+                    && !app.community_browser_state.loading
+                    && !app.community_browser_state.joining =>
+            {
+                app.open_or_join_browser_selection().await?;
+            }
+            KeyCode::Char('r') | KeyCode::Char('R')
+                if app.current_screen == Screen::Main
+                    && app.community_browser_state.show
+                    && !app.community_browser_state.loading
+                    && !app.community_browser_state.joining =>
+            {
+                app.community_browser_state.loaded = false;
+                app.load_community_browser().await;
+            }
             KeyCode::Enter | KeyCode::Char(' ')
                 if app.current_tab == Tab::Posts
                     && !app.posts_state.show_new_post_modal

--- a/fido-tui/src/ui/components/action_bar.rs
+++ b/fido-tui/src/ui/components/action_bar.rs
@@ -3,6 +3,10 @@ use crate::app::App;
 /// Action bar hints for the current view.
 pub fn action_bar_text(app: &App) -> &'static str {
     // Don't show page actions when modal is open (modal has its own footer)
+    if app.community_browser_state.show {
+        return "Enter: Open/Join | r: Reload | b/Esc: Close";
+    }
+
     if app.viewing_post_detail {
         if let Some(detail_state) = &app.post_detail_state {
             if detail_state.show_full_post_modal {
@@ -22,14 +26,14 @@ pub fn action_bar_text(app: &App) -> &'static str {
             } else if app.community_error.is_some() {
                 "r: Retry"
             } else if app.is_home_list_active() {
-                "↑/↓/j/k: Navigate | Enter: Open community"
+                "↑/↓/j/k: Navigate | Enter: Open community | b: Browse starred"
             } else if matches!(
                 app.posts_state.selected_feed_entry(),
                 Some(crate::app::FeedEntry::Activity(_))
             ) {
                 "↑/↓/j/k: Navigate | o: Open on GitHub"
             } else {
-                "u/d: Vote | n: Post | i: Community | f: Filter | s: Search | Space: View"
+                "u/d: Vote | n: Post | i: Community | b: Browse | f: Filter | Space: View"
             }
         }
         crate::app::Tab::DMs => {

--- a/fido-tui/src/ui/modals/help.rs
+++ b/fido-tui/src/ui/modals/help.rs
@@ -252,6 +252,7 @@ pub fn add_posts_feed_shortcuts(
                 ("↓/j", "Next community"),
                 ("↑/k", "Previous community"),
                 ("Enter", "Open community board"),
+                ("b", "Browse starred repos"),
             ],
         ));
         return;
@@ -267,6 +268,7 @@ pub fn add_posts_feed_shortcuts(
             ("d", "Downvote selected post"),
             ("n", "New post"),
             ("i", "Community info & settings"),
+            ("b", "Browse starred repos"),
             ("f", "Filter posts"),
             ("s", "Search users"),
             ("p", "View author profile"),

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -12,6 +12,7 @@ use super::components::empty_state::render_empty_state_block;
 use super::components::footer::render_footer_with_style;
 use super::components::layout::{auth_layout, banner_layout, main_layout};
 use super::components::list::styled_list;
+use super::components::modal::centered_rect;
 use super::components::panel::render_panel_lines;
 use super::formatting::*;
 use super::modals::*;
@@ -223,24 +224,28 @@ pub fn render_auth_screen(frame: &mut Frame, app: &mut App) {
     );
 }
 
-/// Render the main screen with tabs
+/// Render the main screen with a persistent Discord-style rail.
 pub fn render_main_screen(frame: &mut Frame, app: &mut App) {
     let layout = main_layout(frame, app);
     let area = frame.area();
 
-    // Render tab header
-    render_tab_header(frame, app, layout.header);
+    render_workspace_header(frame, app, layout.header);
 
-    // Render tab content
+    let content_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(30), Constraint::Min(0)])
+        .split(layout.content);
+
+    render_left_rail(frame, app, content_chunks[0]);
+
+    // Render selected rail content.
     match app.current_tab {
         crate::app::Tab::Posts => {
-            // Always render the feed
-            render_posts_tab_with_data(frame, app, layout.content);
-            // Modal is rendered later at the top level (after all tabs)
+            render_posts_tab_with_data(frame, app, content_chunks[1]);
         }
-        crate::app::Tab::DMs => render_dms_tab(frame, app, layout.content),
-        crate::app::Tab::Profile => render_profile_tab(frame, app, layout.content),
-        crate::app::Tab::Settings => render_settings_tab(frame, app, layout.content),
+        crate::app::Tab::DMs => render_dms_tab(frame, app, content_chunks[1]),
+        crate::app::Tab::Profile => render_profile_tab(frame, app, content_chunks[1]),
+        crate::app::Tab::Settings => render_settings_tab(frame, app, content_chunks[1]),
     }
 
     // Render page-specific actions bar (NEW)
@@ -390,13 +395,251 @@ pub fn render_main_screen(frame: &mut Frame, app: &mut App) {
         render_community_modal(frame, app, area);
     }
 
+    if app.community_browser_state.show {
+        render_community_browser(frame, app, area);
+    }
+
     // Render help modal (highest priority - render last)
     if app.show_help {
         render_help_modal(frame, app, area);
     }
 }
 
+fn render_workspace_header(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = get_theme_colors(app);
+    let title = match &app.community {
+        Some(c) => format!(" Fido · {} ", c.full_name()),
+        None if app.launch_repo.is_none() => " Fido · Home ".to_string(),
+        None => " Fido · Repo community ".to_string(),
+    };
+    let status = format!(
+        "{} · {}",
+        app.auth_state
+            .current_user
+            .as_ref()
+            .map(|user| format!("@{}", user.username))
+            .unwrap_or_else(|| "signed out".to_string()),
+        app.realtime_state.status.label()
+    );
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            title,
+            Style::default()
+                .fg(theme.success)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(status, Style::default().fg(theme.text_dim)),
+    ]))
+    .alignment(Alignment::Center)
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(header, area);
+}
+
+fn render_left_rail(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = get_theme_colors(app);
+    let total_unread: usize = app.dms_state.unread_counts.values().sum();
+    let request_count = app.dms_state.pending_requests.len();
+
+    let mut lines = Vec::new();
+    lines.push(Line::from(Span::styled(
+        "COMMUNITIES",
+        Style::default()
+            .fg(theme.text_dim)
+            .add_modifier(Modifier::BOLD),
+    )));
+
+    let board_label = if let Some(community) = &app.community {
+        format!("# {}", community.full_name())
+    } else if app.is_home_list_active() {
+        "Home".to_string()
+    } else {
+        "Board".to_string()
+    };
+    lines.push(rail_line(
+        app.current_tab == crate::app::Tab::Posts,
+        &board_label,
+        theme.success,
+        &theme,
+    ));
+
+    for community in app.home_state.communities.iter().take(6) {
+        let label = format!(
+            "  {}/{}",
+            community.community.owner, community.community.name
+        );
+        lines.push(Line::from(Span::styled(
+            label,
+            Style::default().fg(theme.text_dim),
+        )));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "DIRECT MESSAGES",
+        Style::default()
+            .fg(theme.text_dim)
+            .add_modifier(Modifier::BOLD),
+    )));
+    let dm_label = if total_unread > 0 {
+        format!("DMs ({})", total_unread)
+    } else if request_count > 0 {
+        format!(
+            "DMs · {} request{}",
+            request_count,
+            if request_count == 1 { "" } else { "s" }
+        )
+    } else {
+        "DMs".to_string()
+    };
+    lines.push(rail_line(
+        app.current_tab == crate::app::Tab::DMs,
+        &dm_label,
+        theme.accent,
+        &theme,
+    ));
+    for conversation in app.dms_state.conversations.iter().take(5) {
+        let unread = app
+            .dms_state
+            .unread_counts
+            .get(&conversation.other_user_id)
+            .copied()
+            .unwrap_or(0);
+        let label = if unread > 0 {
+            format!("  @{} ({})", conversation.other_username, unread)
+        } else {
+            format!("  @{}", conversation.other_username)
+        };
+        lines.push(Line::from(Span::styled(
+            label,
+            Style::default().fg(theme.text_dim),
+        )));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "TOOLS",
+        Style::default()
+            .fg(theme.text_dim)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(rail_line(
+        app.current_tab == crate::app::Tab::Profile,
+        "Profile",
+        theme.primary,
+        &theme,
+    ));
+    lines.push(rail_line(
+        app.current_tab == crate::app::Tab::Settings,
+        "Settings",
+        theme.primary,
+        &theme,
+    ));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "b Browse starred repos",
+        Style::default().fg(theme.text_dim),
+    )));
+
+    let rail = Paragraph::new(lines)
+        .wrap(Wrap { trim: true })
+        .block(Block::default().borders(Borders::ALL).title(" Fido "));
+    frame.render_widget(rail, area);
+}
+
+fn rail_line(selected: bool, label: &str, accent: Color, theme: &ThemeColors) -> Line<'static> {
+    let prefix = if selected { ">" } else { " " };
+    let style = if selected {
+        Style::default()
+            .fg(accent)
+            .bg(theme.highlight_bg)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.text)
+    };
+    Line::from(Span::styled(format!("{} {}", prefix, label), style))
+}
+
+fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = get_theme_colors(app);
+    let popup_area = centered_rect(76, 76, area);
+    frame.render_widget(Clear, popup_area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(3)])
+        .split(popup_area);
+
+    let items: Vec<ListItem> = if app.community_browser_state.loading {
+        vec![ListItem::new(Line::from(Span::styled(
+            "Loading starred repositories...",
+            Style::default().fg(theme.text_dim),
+        )))]
+    } else if let Some(error) = &app.community_browser_state.error {
+        vec![ListItem::new(Line::from(Span::styled(
+            error.clone(),
+            Style::default().fg(theme.error),
+        )))]
+    } else if app.community_browser_state.repos.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "No starred repositories found.",
+            Style::default().fg(theme.text_dim),
+        )))]
+    } else {
+        app.community_browser_state
+            .repos
+            .iter()
+            .map(|repo| {
+                let status = if repo.private {
+                    "private"
+                } else if repo.membership.is_some() {
+                    "joined"
+                } else if repo.community.is_some() {
+                    "available"
+                } else {
+                    "new"
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(
+                        format!("{:<38}", repo.full_name),
+                        Style::default().fg(theme.text),
+                    ),
+                    Span::styled(status, Style::default().fg(theme.text_dim)),
+                ]))
+            })
+            .collect()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Browse starred repos "),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(theme.success)
+                .bg(theme.highlight_bg)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(list, chunks[0], &mut app.community_browser_state.list_state);
+
+    let footer = if app.community_browser_state.joining {
+        "Joining..."
+    } else {
+        "Enter: Open/Join | r: Reload | b/Esc: Close"
+    };
+    render_footer_with_style(
+        frame,
+        chunks[1],
+        footer,
+        &theme,
+        Style::default().fg(theme.text_dim),
+    );
+}
+
 /// Render tab header
+#[allow(dead_code)]
 pub fn render_tab_header(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme = get_theme_colors(app);
 
@@ -474,7 +717,7 @@ pub fn render_global_footer(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(Clear, area);
 
     let footer_text = format!(
-        "RT: {} | Tab/Shift+Tab: Tabs | Shift+L: Logout | ?: Help | q/Esc: Quit | ↑/↓/j/k: Navigate",
+        "RT: {} | Tab/Shift+Tab: Rail | b: Browse repos | Shift+L: Logout | ?: Help | q/Esc: Quit",
         app.realtime_state.status.label()
     );
     render_footer_with_style(


### PR DESCRIPTION
## Summary
- Implements stint 0012.
- Replaces the top tab presentation with a persistent Discord-style left rail for communities, DMs, profile, and settings.
- Adds a starred-repo community browser using the existing /communities/browse and /communities/join APIs.
- Keeps existing board, DM, profile, settings, community modal, and post flows intact inside the new shell.

## Validation
- cargo fmt --check
- cargo clippy -p fido --all-targets --all-features -- -D warnings
- cargo test -p fido
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- just e2e-tui-startup
- just e2e-tui

## Release Notes
- Rust behavior changed; include this in the next launch-train release bump.
