### PR TITLE
feat: add TUI channel chat

### DIFF
--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -344,6 +344,57 @@ impl ApiClient {
         self.handle_response(response).await
     }
 
+    /// List chat channels for a community.
+    pub async fn list_community_channels(&self, community_id: Uuid) -> ApiResult<Vec<Channel>> {
+        let url = self.build_url(&format!("/communities/{}/channels", community_id));
+        let req = self.add_auth_header(self.client.get(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Load channel message history. Results are oldest-to-newest.
+    pub async fn get_channel_messages(
+        &self,
+        channel_id: Uuid,
+        before: Option<Uuid>,
+        after: Option<Uuid>,
+        limit: i32,
+    ) -> ApiResult<Vec<Message>> {
+        let mut params = vec![("limit", limit.to_string())];
+        let before_string;
+        if let Some(before) = before {
+            before_string = before.to_string();
+            params.push(("before", before_string));
+        }
+        let after_string;
+        if let Some(after) = after {
+            after_string = after.to_string();
+            params.push(("after", after_string));
+        }
+        let params_ref: Vec<(&str, &str)> = params
+            .iter()
+            .map(|(key, value)| (*key, value.as_str()))
+            .collect();
+        let url =
+            self.build_url_with_params(&format!("/channels/{}/messages", channel_id), &params_ref);
+        let req = self.add_auth_header(self.client.get(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Send a message to a chat channel.
+    pub async fn send_channel_message(
+        &self,
+        channel_id: Uuid,
+        content: String,
+    ) -> ApiResult<Message> {
+        let url = self.build_url(&format!("/channels/{}/messages", channel_id));
+        let request = SendChannelMessageRequest { content };
+        let req = self.add_auth_header(self.client.post(&url).json(&request));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
     /// Create a new post
     pub async fn create_post(&self, community_id: Uuid, content: String) -> ApiResult<Post> {
         let url = format!("{}/posts", self.base_url);

--- a/fido-tui/src/app/auth.rs
+++ b/fido-tui/src/app/auth.rs
@@ -39,6 +39,7 @@ impl App {
         self.posts_state.posts.clear();
         self.posts_state.message = None;
         self.clear_activity();
+        self.clear_chat();
         self.profile_state.profile = None;
         self.dms_state.conversations.clear();
         self.dms_state.conversations_loaded = false;

--- a/fido-tui/src/app/build.rs
+++ b/fido-tui/src/app/build.rs
@@ -73,6 +73,25 @@ impl App {
                 activity_pending_load: false,
                 feed_entries: Vec::new(),
             },
+            chat_state: ChatState {
+                channels: Vec::new(),
+                selected_channel_index: 0,
+                messages: Vec::new(),
+                list_state: ListState::default(),
+                message_textarea: {
+                    let mut textarea = TextArea::default();
+                    textarea.set_cursor_line_style(Style::default());
+                    textarea.set_style(Style::default());
+                    textarea.set_hard_tab_indent(true);
+                    textarea
+                },
+                loading: false,
+                loaded: false,
+                loading_older: false,
+                pending_older_load: false,
+                at_history_start: false,
+                error: None,
+            },
             profile_state: ProfileState {
                 profile: None,
                 user_posts: Vec::new(),

--- a/fido-tui/src/app/chat.rs
+++ b/fido-tui/src/app/chat.rs
@@ -1,0 +1,257 @@
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::style::Style;
+use tui_textarea::{Input, TextArea};
+use uuid::Uuid;
+
+use super::{categorize_error, App, InputMode};
+
+impl App {
+    pub fn clear_chat(&mut self) {
+        self.chat_state.channels.clear();
+        self.chat_state.selected_channel_index = 0;
+        self.chat_state.messages.clear();
+        self.chat_state.list_state.select(None);
+        self.chat_state.loading = false;
+        self.chat_state.loaded = false;
+        self.chat_state.loading_older = false;
+        self.chat_state.pending_older_load = false;
+        self.chat_state.at_history_start = false;
+        self.chat_state.error = None;
+        self.clear_chat_message();
+    }
+
+    pub fn selected_chat_channel_id(&self) -> Option<Uuid> {
+        self.chat_state.selected_channel().map(|channel| channel.id)
+    }
+
+    pub async fn load_chat(&mut self) -> Result<()> {
+        let Some(community_id) = self.current_community_id() else {
+            self.chat_state.error = Some("Open a community before using chat.".to_string());
+            return Ok(());
+        };
+
+        self.chat_state.loading = true;
+        self.chat_state.error = None;
+
+        match self.api_client.list_community_channels(community_id).await {
+            Ok(channels) => {
+                self.chat_state.channels = channels;
+                self.chat_state.selected_channel_index = 0;
+                self.chat_state.loaded = true;
+                self.chat_state.at_history_start = false;
+                self.load_selected_channel_messages().await?;
+            }
+            Err(e) => {
+                self.chat_state.error = Some(categorize_error(&e.to_string()));
+            }
+        }
+
+        self.chat_state.loading = false;
+        Ok(())
+    }
+
+    pub async fn load_selected_channel_messages(&mut self) -> Result<()> {
+        let Some(channel_id) = self.selected_chat_channel_id() else {
+            self.chat_state.messages.clear();
+            self.chat_state.list_state.select(None);
+            return Ok(());
+        };
+
+        match self
+            .api_client
+            .get_channel_messages(channel_id, None, None, 50)
+            .await
+        {
+            Ok(messages) => {
+                self.chat_state.messages = messages;
+                self.realtime_state
+                    .seen_channel_messages
+                    .extend(self.chat_state.messages.iter().map(|message| message.id));
+                self.select_last_chat_message();
+            }
+            Err(e) => {
+                self.chat_state.error = Some(categorize_error(&e.to_string()));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn load_older_channel_messages(&mut self) -> Result<()> {
+        if self.chat_state.loading_older || self.chat_state.at_history_start {
+            return Ok(());
+        }
+        let Some(channel_id) = self.selected_chat_channel_id() else {
+            return Ok(());
+        };
+        let Some(before) = self.chat_state.messages.first().map(|message| message.id) else {
+            return Ok(());
+        };
+
+        self.chat_state.loading_older = true;
+        match self
+            .api_client
+            .get_channel_messages(channel_id, Some(before), None, 50)
+            .await
+        {
+            Ok(mut older) => {
+                if older.is_empty() {
+                    self.chat_state.at_history_start = true;
+                } else {
+                    older.append(&mut self.chat_state.messages);
+                    self.chat_state.messages = older;
+                    self.chat_state.list_state.select(Some(0));
+                }
+            }
+            Err(e) => {
+                self.chat_state.error = Some(categorize_error(&e.to_string()));
+            }
+        }
+        self.chat_state.loading_older = false;
+        Ok(())
+    }
+
+    pub async fn send_channel_message(&mut self) -> Result<()> {
+        let Some(channel_id) = self.selected_chat_channel_id() else {
+            self.chat_state.error = Some("No chat channel is available.".to_string());
+            return Ok(());
+        };
+
+        let content = self.get_chat_message_content();
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            self.chat_state.error = Some("Cannot send an empty message.".to_string());
+            return Ok(());
+        }
+
+        match self
+            .api_client
+            .send_channel_message(channel_id, trimmed.to_string())
+            .await
+        {
+            Ok(message) => {
+                self.apply_chat_message(message);
+                self.clear_chat_message();
+                self.input_mode = InputMode::Navigation;
+                self.chat_state.error = None;
+            }
+            Err(e) => {
+                self.chat_state.error = Some(categorize_error(&e.to_string()));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn apply_chat_message(&mut self, message: fido_types::Message) {
+        if self
+            .chat_state
+            .messages
+            .iter()
+            .any(|existing| existing.id == message.id)
+        {
+            self.realtime_state.seen_channel_messages.insert(message.id);
+            return;
+        }
+        self.realtime_state.seen_channel_messages.insert(message.id);
+        self.chat_state.messages.push(message);
+        self.select_last_chat_message();
+    }
+
+    pub fn handle_chat_keys(&mut self, key: KeyEvent) -> Result<()> {
+        match self.input_mode {
+            InputMode::Navigation => match key.code {
+                KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => {
+                    self.next_chat_message();
+                }
+                KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => {
+                    self.previous_chat_message();
+                }
+                KeyCode::Enter => {
+                    self.input_mode = InputMode::Typing;
+                }
+                _ => {
+                    self.input_mode = InputMode::Typing;
+                    self.handle_chat_input(key);
+                }
+            },
+            InputMode::Typing => match key.code {
+                KeyCode::Esc => {
+                    self.clear_chat_message();
+                    self.input_mode = InputMode::Navigation;
+                }
+                KeyCode::Enter => {}
+                _ => {
+                    self.handle_chat_input(key);
+                    if self.is_chat_message_empty() && key.code == KeyCode::Backspace {
+                        self.input_mode = InputMode::Navigation;
+                    }
+                }
+            },
+        }
+        Ok(())
+    }
+
+    pub fn get_chat_message_content(&self) -> String {
+        self.chat_state.message_textarea.lines().join("\n")
+    }
+
+    pub fn clear_chat_message(&mut self) {
+        let mut textarea = TextArea::default();
+        textarea.set_cursor_line_style(Style::default());
+        textarea.set_style(Style::default());
+        textarea.set_hard_tab_indent(true);
+        self.chat_state.message_textarea = textarea;
+    }
+
+    fn is_chat_message_empty(&self) -> bool {
+        self.get_chat_message_content().trim().is_empty()
+    }
+
+    fn handle_chat_input(&mut self, key: KeyEvent) {
+        let input = Input::from(crossterm::event::Event::Key(key));
+        self.chat_state.message_textarea.input(input);
+        crate::text_wrapper::wrap_textarea_if_needed(
+            &mut self.chat_state.message_textarea,
+            crate::text_wrapper::WrapConfig::DM_PANEL,
+        );
+    }
+
+    fn next_chat_message(&mut self) {
+        let len = self.chat_state.messages.len();
+        if len == 0 {
+            self.chat_state.list_state.select(None);
+            return;
+        }
+        let current = self.chat_state.list_state.selected().unwrap_or(len - 1);
+        self.chat_state
+            .list_state
+            .select(Some((current + 1).min(len - 1)));
+    }
+
+    fn previous_chat_message(&mut self) {
+        let len = self.chat_state.messages.len();
+        if len == 0 {
+            self.chat_state.list_state.select(None);
+            return;
+        }
+        let current = self.chat_state.list_state.selected().unwrap_or(len - 1);
+        if current == 0 {
+            self.chat_state.pending_older_load = true;
+        }
+        self.chat_state
+            .list_state
+            .select(Some(current.saturating_sub(1)));
+    }
+
+    fn select_last_chat_message(&mut self) {
+        if self.chat_state.messages.is_empty() {
+            self.chat_state.list_state.select(None);
+        } else {
+            self.chat_state
+                .list_state
+                .select(Some(self.chat_state.messages.len() - 1));
+        }
+    }
+}

--- a/fido-tui/src/app/communities.rs
+++ b/fido-tui/src/app/communities.rs
@@ -35,6 +35,7 @@ impl App {
         match self.api_client.join_community(owner, name).await {
             Ok(view) => {
                 self.clear_activity();
+                self.clear_chat();
                 self.apply_community_view(view);
             }
             Err(e) => {
@@ -88,6 +89,7 @@ impl App {
         match self.api_client.get_community(community_id).await {
             Ok(view) => {
                 self.clear_activity();
+                self.clear_chat();
                 self.apply_community_view(view);
                 self.load_posts().await?;
             }
@@ -107,6 +109,7 @@ impl App {
         self.posts_state.list_state.select(None);
         self.posts_state.error = None;
         self.clear_activity();
+        self.clear_chat();
     }
 
     /// Repo mode: retry after a failed join (server down, repo unresolvable).
@@ -237,6 +240,7 @@ impl App {
         match result {
             Ok(view) => {
                 self.clear_activity();
+                self.clear_chat();
                 self.apply_community_view(view);
                 self.current_tab = crate::app::Tab::Posts;
                 self.community_browser_state.show = false;

--- a/fido-tui/src/app/handlers/mod.rs
+++ b/fido-tui/src/app/handlers/mod.rs
@@ -161,6 +161,7 @@ pub fn handle_main_keys(app: &mut App, key: KeyEvent) -> Result<()> {
         }
         _ => match app.current_tab {
             Tab::Posts => posts::handle_posts_keys(app, key)?,
+            Tab::Chat => app.handle_chat_keys(key)?,
             Tab::Profile => profile::handle_profile_keys(app, key)?,
             Tab::DMs => dms::handle_dms_keys(app, key)?,
             Tab::Settings => settings::handle_settings_keys(app, key)?,

--- a/fido-tui/src/app/mod.rs
+++ b/fido-tui/src/app/mod.rs
@@ -6,6 +6,7 @@ pub(crate) use error::categorize_error;
 mod activity;
 mod auth;
 mod build;
+mod chat;
 mod communities;
 mod composer;
 mod dms;

--- a/fido-tui/src/app/realtime.rs
+++ b/fido-tui/src/app/realtime.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use fido_types::{
-    DirectMessage, DmConversationState, Event, EventEnvelope, Notification,
+    ChannelMessageEvent, DirectMessage, DmConversationState, Event, EventEnvelope, Notification,
     NotificationUnreadCount, Post, SortOrder,
 };
 use uuid::Uuid;
@@ -18,15 +18,7 @@ impl App {
         self.realtime_state.last_event_at = Some(std::time::Instant::now());
         match envelope.event {
             Event::MessageCreated(payload) => {
-                if self
-                    .realtime_state
-                    .seen_channel_messages
-                    .insert(payload.message.id)
-                {
-                    self.realtime_state.channel_message_count =
-                        self.realtime_state.channel_message_count.saturating_add(1);
-                    self.realtime_state.last_channel_message = Some(payload);
-                }
+                self.apply_realtime_channel_message(payload);
             }
             Event::ThreadCreated(post) => self.apply_realtime_thread(post),
             Event::ThreadPendingApproval(post) => {
@@ -59,16 +51,52 @@ impl App {
                     self.load_conversation_messages().await?;
                 }
             }
+            Tab::Chat if self.community.is_some() => {
+                self.load_chat().await?;
+            }
             Tab::Profile => {
                 if self.profile_state.profile.is_some() {
                     self.load_profile().await?;
                 }
             }
             Tab::Settings => {}
+            Tab::Chat => {}
             Tab::Posts => {}
         }
 
         Ok(())
+    }
+
+    fn apply_realtime_channel_message(&mut self, payload: ChannelMessageEvent) {
+        let message_id = payload.message.id;
+        if !self.realtime_state.seen_channel_messages.insert(message_id) {
+            return;
+        }
+
+        self.realtime_state.channel_message_count =
+            self.realtime_state.channel_message_count.saturating_add(1);
+        self.realtime_state.last_channel_message = Some(payload.clone());
+
+        let chat_is_open = self.current_screen == Screen::Main
+            && self.current_tab == Tab::Chat
+            && self.community.as_ref().map(|community| community.id) == Some(payload.community_id)
+            && self.selected_chat_channel_id() == Some(payload.message.channel_id);
+        if !chat_is_open {
+            return;
+        }
+
+        if self
+            .chat_state
+            .messages
+            .iter()
+            .any(|existing| existing.id == message_id)
+        {
+            return;
+        }
+        self.chat_state.messages.push(payload.message);
+        self.chat_state
+            .list_state
+            .select(Some(self.chat_state.messages.len().saturating_sub(1)));
     }
 
     pub async fn refresh_notification_counts(&mut self) {

--- a/fido-tui/src/app/state.rs
+++ b/fido-tui/src/app/state.rs
@@ -1,5 +1,6 @@
 use fido_types::{
-    ActivityItem, ChannelMessageEvent, NotificationUnreadCount, Post, User, UserProfile,
+    ActivityItem, Channel, ChannelMessageEvent, Message, NotificationUnreadCount, Post, User,
+    UserProfile,
 };
 
 use ratatui::widgets::ListState;
@@ -147,6 +148,7 @@ pub struct App {
     pub auth_state: AuthState,
     pub current_tab: Tab,
     pub posts_state: PostsState,
+    pub chat_state: ChatState,
     pub profile_state: ProfileState,
     pub dms_state: DMsState,
     pub settings_state: SettingsState,
@@ -260,6 +262,27 @@ impl HomeState {
         self.list_state
             .selected()
             .and_then(|i| self.communities.get(i))
+    }
+}
+
+/// Community chat state for the selected repo's default channel.
+pub struct ChatState {
+    pub channels: Vec<Channel>,
+    pub selected_channel_index: usize,
+    pub messages: Vec<Message>,
+    pub list_state: ListState,
+    pub message_textarea: TextArea<'static>,
+    pub loading: bool,
+    pub loaded: bool,
+    pub loading_older: bool,
+    pub pending_older_load: bool,
+    pub at_history_start: bool,
+    pub error: Option<String>,
+}
+
+impl ChatState {
+    pub fn selected_channel(&self) -> Option<&Channel> {
+        self.channels.get(self.selected_channel_index)
     }
 }
 
@@ -869,6 +892,7 @@ pub enum Screen {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Tab {
     Posts,
+    Chat,
     DMs,
     Profile,
     Settings,
@@ -877,7 +901,8 @@ pub enum Tab {
 impl Tab {
     pub fn next(&self) -> Self {
         match self {
-            Tab::Posts => Tab::DMs,
+            Tab::Posts => Tab::Chat,
+            Tab::Chat => Tab::DMs,
             Tab::DMs => Tab::Profile,
             Tab::Profile => Tab::Settings,
             Tab::Settings => Tab::Posts,
@@ -887,7 +912,8 @@ impl Tab {
     pub fn previous(&self) -> Self {
         match self {
             Tab::Posts => Tab::Settings,
-            Tab::DMs => Tab::Posts,
+            Tab::Chat => Tab::Posts,
+            Tab::DMs => Tab::Chat,
             Tab::Profile => Tab::DMs,
             Tab::Settings => Tab::Profile,
         }

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use fido_types::{Event, EventEnvelope, Post};
+use fido_types::{Channel, ChannelMessageEvent, Event, EventEnvelope, Message, Post};
 
 /// Put the app on a community board (the launch-repo path in production).
 fn set_test_community(app: &mut App) {
@@ -37,6 +37,8 @@ fn test_rail_tab_order_matches_launch_shell() {
     let mut app = App::new();
     app.current_tab = Tab::Posts;
 
+    app.next_tab();
+    assert_eq!(app.current_tab, Tab::Chat);
     app.next_tab();
     assert_eq!(app.current_tab, Tab::DMs);
     app.next_tab();
@@ -1004,6 +1006,52 @@ fn realtime_thread_created_upserts_once_for_current_board() {
 
     assert_eq!(app.posts_state.posts.len(), 1);
     assert_eq!(app.posts_state.feed_entries.len(), 1);
+}
+
+#[test]
+fn realtime_channel_message_appends_once_to_open_channel() {
+    let mut app = App::new();
+    let current_user_id = uuid::Uuid::new_v4();
+    let community_id = uuid::Uuid::new_v4();
+    let channel_id = uuid::Uuid::new_v4();
+
+    app.auth_state.current_user = Some(test_user(current_user_id, "me"));
+    app.current_screen = Screen::Main;
+    app.current_tab = Tab::Chat;
+    app.community = Some(crate::app::state::CommunityContext {
+        id: community_id,
+        owner: "owner".to_string(),
+        name: "repo".to_string(),
+        role: Some(fido_types::MembershipRole::Member),
+        member_count: 2,
+        claimed: true,
+    });
+    app.chat_state.channels = vec![Channel {
+        id: channel_id,
+        community_id,
+        name: "general".to_string(),
+        created_at: chrono::Utc::now(),
+    }];
+
+    let message = Message {
+        id: uuid::Uuid::new_v4(),
+        channel_id,
+        author_id: uuid::Uuid::new_v4(),
+        content: "hello channel".to_string(),
+        created_at: chrono::Utc::now(),
+    };
+    let event = Event::MessageCreated(ChannelMessageEvent {
+        message: message.clone(),
+        community_id,
+    });
+
+    app.apply_realtime_envelope(test_envelope(event.clone()));
+    app.apply_realtime_envelope(test_envelope(event));
+
+    assert_eq!(app.chat_state.messages.len(), 1);
+    assert_eq!(app.chat_state.messages[0].content, "hello channel");
+    assert_eq!(app.chat_state.list_state.selected(), Some(0));
+    assert_eq!(app.realtime_state.channel_message_count, 1);
 }
 
 #[test]

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -86,6 +86,9 @@ impl EventLoop {
 
             // Handle DM conversation changes
             self.handle_dm_conversation_changes(app).await?;
+
+            // Handle channel history pagination after keyboard navigation
+            self.handle_chat_pending_loads(app).await?;
         }
 
         self.stop_realtime();
@@ -393,6 +396,11 @@ impl EventLoop {
                     app.dms_state.needs_message_load = true;
                 }
             }
+            Tab::Chat => {
+                if !app.chat_state.loaded || app.chat_state.error.is_some() {
+                    app.load_chat().await?;
+                }
+            }
             Tab::Settings => {
                 if app.settings_state.config.is_none() || app.settings_state.error.is_some() {
                     app.load_settings().await?;
@@ -418,6 +426,19 @@ impl EventLoop {
             app.dms_state.needs_message_load = false;
         } else if app.dms_state.selection != self.last_dm_selection {
             self.last_dm_selection = app.dms_state.selection.clone();
+        }
+
+        Ok(())
+    }
+
+    async fn handle_chat_pending_loads(&mut self, app: &mut App) -> Result<()> {
+        if app.current_tab != Tab::Chat {
+            return Ok(());
+        }
+
+        if app.chat_state.pending_older_load {
+            app.chat_state.pending_older_load = false;
+            app.load_older_channel_messages().await?;
         }
 
         Ok(())
@@ -631,6 +652,13 @@ impl EventLoop {
                     && app.input_mode == InputMode::Typing =>
             {
                 app.send_dm().await?;
+            }
+            KeyCode::Enter
+                if app.current_tab == Tab::Chat
+                    && app.input_mode == InputMode::Typing
+                    && !app.community_browser_state.show =>
+            {
+                app.send_channel_message().await?;
             }
             KeyCode::Char('u') | KeyCode::Char('U')
                 if app.current_screen == Screen::Main

--- a/fido-tui/src/ui/components/action_bar.rs
+++ b/fido-tui/src/ui/components/action_bar.rs
@@ -36,6 +36,17 @@ pub fn action_bar_text(app: &App) -> &'static str {
                 "u/d: Vote | n: Post | i: Community | b: Browse | f: Filter | Space: View"
             }
         }
+        crate::app::Tab::Chat => {
+            if app.community.is_none() {
+                "Open a community to use chat"
+            } else if app.chat_state.channels.is_empty() {
+                "No channels available"
+            } else if app.input_mode == crate::app::InputMode::Typing {
+                "Enter: Send | Esc: Clear | Type: Compose"
+            } else {
+                "↑/↓/j/k: Navigate | Type: Compose | Enter: Focus input"
+            }
+        }
         crate::app::Tab::DMs => {
             let has_active_conversation = app.dms_state.selection.conversation_index().is_some();
             let has_pending_draft = app.dms_state.pending_conversation_username.is_some();

--- a/fido-tui/src/ui/modals/help.rs
+++ b/fido-tui/src/ui/modals/help.rs
@@ -160,6 +160,7 @@ pub fn add_main_screen_shortcuts(
     // Context-specific shortcuts based on current tab
     match app.current_tab {
         crate::app::Tab::Posts => add_posts_tab_shortcuts(app, shortcuts),
+        crate::app::Tab::Chat => add_chat_tab_shortcuts(shortcuts),
         crate::app::Tab::DMs => add_dms_tab_shortcuts(shortcuts),
         crate::app::Tab::Profile => add_profile_tab_shortcuts(app, shortcuts),
         crate::app::Tab::Settings => add_settings_tab_shortcuts(shortcuts),
@@ -299,6 +300,23 @@ pub fn add_posts_feed_shortcuts(
             ],
         ));
     }
+}
+
+/// Add Chat tab shortcuts
+pub fn add_chat_tab_shortcuts(
+    shortcuts: &mut Vec<(&'static str, Vec<(&'static str, &'static str)>)>,
+) {
+    shortcuts.push((
+        "Chat Tab",
+        vec![
+            ("↓/j", "Next message"),
+            ("↑/k", "Previous message / load older"),
+            ("Type", "Compose channel message"),
+            ("Enter", "Focus input / send message"),
+            ("Esc", "Clear message / stop typing"),
+            (":emoji:", "Use emoji shortcodes"),
+        ],
+    ));
 }
 
 /// Add DMs tab shortcuts

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -243,6 +243,7 @@ pub fn render_main_screen(frame: &mut Frame, app: &mut App) {
         crate::app::Tab::Posts => {
             render_posts_tab_with_data(frame, app, content_chunks[1]);
         }
+        crate::app::Tab::Chat => render_chat_tab(frame, app, content_chunks[1]),
         crate::app::Tab::DMs => render_dms_tab(frame, app, content_chunks[1]),
         crate::app::Tab::Profile => render_profile_tab(frame, app, content_chunks[1]),
         crate::app::Tab::Settings => render_settings_tab(frame, app, content_chunks[1]),
@@ -462,6 +463,18 @@ fn render_left_rail(frame: &mut Frame, app: &App, area: Rect) {
         &theme,
     ));
 
+    let chat_label = app
+        .chat_state
+        .selected_channel()
+        .map(|channel| format!("# {}", channel.name))
+        .unwrap_or_else(|| "# chat".to_string());
+    lines.push(rail_line(
+        app.current_tab == crate::app::Tab::Chat,
+        &chat_label,
+        theme.secondary,
+        &theme,
+    ));
+
     for community in app.home_state.communities.iter().take(6) {
         let label = format!(
             "  {}/{}",
@@ -651,12 +664,13 @@ pub fn render_tab_header(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         "Board"
     };
-    let tabs = [board_label, "DMs", "Profile", "Settings"];
+    let tabs = [board_label, "Chat", "DMs", "Profile", "Settings"];
     let current_index = match app.current_tab {
         crate::app::Tab::Posts => 0,
-        crate::app::Tab::DMs => 1,
-        crate::app::Tab::Profile => 2,
-        crate::app::Tab::Settings => 3,
+        crate::app::Tab::Chat => 1,
+        crate::app::Tab::DMs => 2,
+        crate::app::Tab::Profile => 3,
+        crate::app::Tab::Settings => 4,
     };
 
     let mut tab_spans = vec![];
@@ -670,7 +684,7 @@ pub fn render_tab_header(frame: &mut Frame, app: &mut App, area: Rect) {
         };
 
         // Add unread badge for DMs tab
-        let tab_text = if i == 1 && total_unread > 0 {
+        let tab_text = if i == 2 && total_unread > 0 {
             format!(" {} ({}) ", tab, total_unread)
         } else {
             format!(" {} ", tab)
@@ -1279,6 +1293,266 @@ fn truncated_activity_line(item: &fido_types::ActivityItem, available_width: usi
 fn format_timestamp(timestamp: &chrono::DateTime<chrono::Utc>) -> String {
     // Format as date and time
     timestamp.format("%Y-%m-%d %H:%M").to_string()
+}
+
+/// Render channel chat for the current community.
+pub fn render_chat_tab(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = get_theme_colors(app);
+
+    let has_error = app.chat_state.error.is_some();
+    let layout = banner_layout(area, false, has_error);
+
+    if has_error {
+        if let Some(error) = &app.chat_state.error {
+            if let Some(error_area) = layout.error {
+                render_error_banner(frame, error_area, error, &theme);
+            }
+        }
+    }
+
+    if app.community.is_none() {
+        render_panel_lines(
+            frame,
+            layout.content,
+            "Chat",
+            vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "No community open",
+                    Style::default()
+                        .fg(theme.warning)
+                        .add_modifier(Modifier::BOLD),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "Open a repo community before using chat.",
+                    Style::default().fg(theme.text_dim),
+                )),
+            ],
+            &theme,
+        );
+        return;
+    }
+
+    if app.chat_state.loading && app.chat_state.channels.is_empty() {
+        render_panel_lines(
+            frame,
+            layout.content,
+            "Chat",
+            create_loading_display("Loading chat...", &theme),
+            &theme,
+        );
+        return;
+    }
+
+    if app.chat_state.channels.is_empty() {
+        render_panel_lines(
+            frame,
+            layout.content,
+            "Chat",
+            vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "No channels available",
+                    Style::default()
+                        .fg(theme.warning)
+                        .add_modifier(Modifier::BOLD),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "This community does not have a chat channel yet.",
+                    Style::default().fg(theme.text_dim),
+                )),
+            ],
+            &theme,
+        );
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(6)])
+        .split(layout.content);
+
+    render_channel_messages(frame, app, chunks[0]);
+    render_channel_input(frame, app, chunks[1]);
+}
+
+fn render_channel_messages(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = get_theme_colors(app);
+    let channel_name = app
+        .chat_state
+        .selected_channel()
+        .map(|channel| channel.name.as_str())
+        .unwrap_or("chat");
+    let title = format!(" #{} ", channel_name);
+
+    if app.chat_state.messages.is_empty() {
+        let empty_lines = vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "No messages yet",
+                Style::default()
+                    .fg(theme.warning)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Type below to start the channel.",
+                Style::default().fg(theme.text_dim),
+            )),
+        ];
+        let empty = Paragraph::new(empty_lines)
+            .alignment(Alignment::Center)
+            .block(Block::default().borders(Borders::ALL).title(title));
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let viewport_height = area.height.saturating_sub(2) as usize;
+    let lines_per_message = 4;
+    let messages_per_screen = (viewport_height / lines_per_message).max(1);
+    let total_messages = app.chat_state.messages.len();
+    let selected = app
+        .chat_state
+        .list_state
+        .selected()
+        .unwrap_or(total_messages.saturating_sub(1));
+    let start_index = selected.saturating_sub(messages_per_screen.saturating_sub(1));
+    let message_width = (area.width as usize).saturating_sub(8);
+    let current_user = app.auth_state.current_user.as_ref();
+    let current_user_id = current_user.map(|user| user.id);
+    let current_username = current_user.map(|user| user.username.as_str());
+
+    let mut items = Vec::new();
+    if app.chat_state.loading_older {
+        items.push(ListItem::new(Line::from(Span::styled(
+            "Loading older messages...",
+            Style::default().fg(theme.text_dim),
+        ))));
+    } else if app.chat_state.at_history_start && start_index == 0 {
+        items.push(ListItem::new(Line::from(Span::styled(
+            "Start of channel history",
+            Style::default().fg(theme.text_dim),
+        ))));
+    }
+
+    for (index, message) in app
+        .chat_state
+        .messages
+        .iter()
+        .enumerate()
+        .skip(start_index)
+        .take(messages_per_screen)
+    {
+        let is_selected = index == selected;
+        let is_from_me = Some(message.author_id) == current_user_id;
+        let author = chat_author_label(message, current_username, is_from_me);
+        let timestamp = message.created_at.format("%H:%M").to_string();
+        let header_style = if is_from_me {
+            Style::default().fg(theme.primary)
+        } else {
+            Style::default().fg(theme.success)
+        };
+        let prefix = if is_selected { ">" } else { " " };
+
+        let mut lines = vec![Line::from(vec![
+            Span::styled(prefix, Style::default().fg(theme.text_dim)),
+            Span::styled(
+                format!(" [{}] ", timestamp),
+                Style::default().fg(theme.text_dim),
+            ),
+            Span::styled(author, header_style.add_modifier(Modifier::BOLD)),
+        ])];
+
+        for content_line in message.content.lines() {
+            for wrapped in textwrap::wrap(content_line, message_width) {
+                lines.push(chat_content_line(
+                    &wrapped,
+                    current_username,
+                    is_selected,
+                    &theme,
+                ));
+            }
+        }
+        lines.push(Line::from(""));
+        items.push(ListItem::new(lines));
+    }
+
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .highlight_style(
+            Style::default()
+                .fg(theme.success)
+                .bg(theme.highlight_bg)
+                .add_modifier(Modifier::BOLD),
+        );
+    frame.render_stateful_widget(list, area, &mut app.chat_state.list_state);
+}
+
+fn chat_author_label(
+    message: &fido_types::Message,
+    current_username: Option<&str>,
+    is_from_me: bool,
+) -> String {
+    if is_from_me {
+        return current_username
+            .map(|username| format!("@{}", username))
+            .unwrap_or_else(|| "you".to_string());
+    }
+
+    let id = message.author_id.to_string();
+    format!("user:{}", &id[..8])
+}
+
+fn chat_content_line(
+    content: &str,
+    current_username: Option<&str>,
+    selected: bool,
+    theme: &ThemeColors,
+) -> Line<'static> {
+    let mention = current_username
+        .map(|username| content.contains(&format!("@{}", username)))
+        .unwrap_or(false);
+    let style = if mention {
+        Style::default()
+            .fg(theme.warning)
+            .add_modifier(Modifier::BOLD)
+    } else if selected {
+        Style::default().fg(theme.text)
+    } else {
+        Style::default().fg(theme.text_dim)
+    };
+    Line::from(Span::styled(format!("  {}", content), style))
+}
+
+fn render_channel_input(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = get_theme_colors(app);
+    let channel_name = app
+        .chat_state
+        .selected_channel()
+        .map(|channel| channel.name.as_str())
+        .unwrap_or("chat");
+    let title = if app.input_mode == crate::app::InputMode::Typing {
+        format!(" Message #{} (Enter to send) ", channel_name)
+    } else {
+        format!(" Message #{} ", channel_name)
+    };
+
+    app.chat_state
+        .message_textarea
+        .set_style(Style::default().fg(theme.primary));
+    app.chat_state
+        .message_textarea
+        .set_cursor_style(Style::default().fg(theme.background).bg(theme.primary));
+    app.chat_state
+        .message_textarea
+        .set_cursor_line_style(Style::default());
+    app.chat_state
+        .message_textarea
+        .set_block(Block::default().borders(Borders::ALL).title(title));
+
+    frame.render_widget(&app.chat_state.message_textarea, area);
 }
 
 /// Render DMs tab

--- a/scripts/e2e_tui.sh
+++ b/scripts/e2e_tui.sh
@@ -5,9 +5,9 @@
 # the SQLite database, and log files. GitHub is stubbed via GITHUB_API_BASE.
 #
 # Covers: test-user login, directory-scoped community join (repo mode),
-# board title with role, posting, community modal, Home mode outside a repo,
-# opening a community from the Home list, search -> profile -> DM, and the
-# repo activity feed (GitHub issues fetch + cache).
+# board title with role, posting, channel chat, community modal, Home mode
+# outside a repo, opening a community from the Home list, search -> profile ->
+# DM, and the repo activity feed (GitHub issues fetch + cache).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -126,6 +126,28 @@ POST_COUNT=$(sqlite3 "$WORK/fido.db" \
      WHERE c.owner = 'testowner' AND c.name = 'testrepo'
        AND p.content = 'hello from the e2e harness';")
 [[ "$POST_COUNT" == "1" ]] || fail "post not found in testowner/testrepo community (count=$POST_COUNT)"
+
+# --- Scenario 1b: repo-scoped channel chat -----------------------------------
+echo "==> scenario 1b: repo community chat"
+keys Tab
+wait_for "#general" "repo community chat channel"
+tmux send-keys -t "$SESSION" -l "hello from channel e2e"
+sleep 0.3
+keys Enter
+wait_for "hello from channel e2e" "sent channel message"
+
+CHAT_COUNT=$(sqlite3 "$WORK/fido.db" \
+    "SELECT count(*) FROM messages m
+     JOIN channels ch ON m.channel_id = ch.id
+     JOIN communities c ON ch.community_id = c.id
+     JOIN users u ON m.author_id = u.id
+     WHERE c.owner = 'testowner' AND c.name = 'testrepo'
+       AND ch.name = 'general'
+       AND u.username = 'alice'
+       AND m.content = 'hello from channel e2e';")
+[[ "$CHAT_COUNT" == "1" ]] || fail "channel message not found in testowner/testrepo #general (count=$CHAT_COUNT)"
+keys BTab
+wait_for "hello from the e2e harness" "returned from chat to board"
 
 # --- Scenario 2: community modal ---------------------------------------------
 echo "==> scenario 2: community settings modal"


### PR DESCRIPTION
## Summary
- adds a Chat rail tab for the current repo community and loads existing community channels/messages
- wires channel send, history pagination, realtime channel-message append, and mention highlighting
- extends tmux E2E to prove repo launch still opens the GitHub community and can send a #general channel message

## Validation
- cargo fmt --check
- cargo check -p fido
- cargo test -p fido
- cargo clippy -p fido --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- just e2e-tui-startup
- just e2e-tui