### PR TITLE
feat: add TUI thread approval queue

### DIFF
--- a/fido-server/src/api/posts.rs
+++ b/fido-server/src/api/posts.rs
@@ -437,6 +437,19 @@ pub async fn approve_post(
     Ok(Json(service.approve_post(user_id, &post_id)?))
 }
 
+/// POST /posts/:id/reject - Reject a pending top-level thread.
+pub async fn reject_post(
+    State(state): State<AppState>,
+    AuthenticatedUser(user_id): AuthenticatedUser,
+    Path(post_id): Path<String>,
+) -> ApiResult<Json<Post>> {
+    let post_id = Uuid::parse_str(&post_id)
+        .map_err(|_| ApiError::BadRequest("Invalid post ID".to_string()))?;
+
+    let service = PostService::new(state.repos.clone(), state.event_bus.clone());
+    Ok(Json(service.reject_post(user_id, &post_id)?))
+}
+
 #[cfg(all(test, feature = "sqlite-tests"))]
 mod tests {
     use super::*;

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -117,6 +117,7 @@ pub fn create_router_with_security_config(
         .route("/posts", get(api::posts::get_posts))
         .route("/posts", post(api::posts::create_post))
         .route("/posts/:id/approve", post(api::posts::approve_post))
+        .route("/posts/:id/reject", post(api::posts::reject_post))
         .route("/posts/:id/vote", post(api::posts::vote_on_post))
         .route("/posts/:id/replies", get(api::posts::get_replies))
         .route("/posts/:id/reply", post(api::posts::create_reply))

--- a/fido-server/src/services/posts.rs
+++ b/fido-server/src/services/posts.rs
@@ -189,6 +189,29 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn rejecting_thread_deletes_and_notifies_author() -> Result<()> {
+        let (repos, _event_bus, community, admin, author, _mentioned) = setup()?;
+        let service = PostService::new(repos.clone(), Arc::new(RecordingEventBus::default()));
+        let pending = Post {
+            approved: false,
+            ..post(&author, community.id, "pending")
+        };
+        service.create_post(&pending).expect("pending creates");
+        service
+            .reject_post(admin.id, &pending.id)
+            .expect("admin rejects");
+
+        assert!(repos.posts.get_by_id(&pending.id)?.is_none());
+        let notifications = repos.notifications.list_for_user(&author.id, 10, 0)?;
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(
+            notifications[0].notification_type,
+            NotificationType::ThreadRejected
+        );
+        Ok(())
+    }
 }
 
 impl PostService {
@@ -351,6 +374,34 @@ impl PostService {
             post.community_id.to_string(),
         )?;
         self.populate_post(&mut post, Some(user_id))?;
+        Ok(post)
+    }
+
+    pub fn reject_post(&self, user_id: Uuid, post_id: &Uuid) -> ApiResult<Post> {
+        let post = self
+            .repos
+            .posts
+            .get_by_id(post_id)?
+            .ok_or_else(|| ApiError::NotFound("Post not found".to_string()))?;
+        if post.parent_post_id.is_some() {
+            return Err(ApiError::BadRequest(
+                "Replies do not require approval".to_string(),
+            ));
+        }
+        if post.approved {
+            return Err(ApiError::BadRequest(
+                "Thread is already approved".to_string(),
+            ));
+        }
+        self.require_admin(user_id, post.community_id)?;
+        self.repos.posts.delete(post_id)?;
+        NotificationService::new(self.repos.clone(), self.event_bus.clone()).create(
+            post.author_id,
+            NotificationType::ThreadRejected,
+            user_id,
+            "community",
+            post.community_id.to_string(),
+        )?;
         Ok(post)
     }
 

--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -333,6 +333,29 @@ impl ApiClient {
         self.handle_response(response).await
     }
 
+    /// Get pending top-level threads awaiting community admin approval.
+    pub async fn get_pending_posts(
+        &self,
+        community_id: Uuid,
+        limit: Option<i32>,
+    ) -> ApiResult<Vec<Post>> {
+        let mut params = Vec::new();
+        if let Some(limit) = limit {
+            params.push(("limit", limit.to_string()));
+        }
+        let params_ref: Vec<(&str, &str)> = params
+            .iter()
+            .map(|(key, value)| (*key, value.as_str()))
+            .collect();
+        let url = self.build_url_with_params(
+            &format!("/communities/{}/posts/pending", community_id),
+            &params_ref,
+        );
+        let req = self.add_auth_header(self.client.get(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
     /// Recent GitHub issues/PRs for a community's repo
     pub async fn get_community_activity(
         &self,
@@ -403,6 +426,22 @@ impl ApiClient {
             content,
         };
         let req = self.add_auth_header(self.client.post(&url).json(&request));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Approve a pending top-level thread.
+    pub async fn approve_post(&self, post_id: Uuid) -> ApiResult<Post> {
+        let url = self.build_url(&format!("/posts/{}/approve", post_id));
+        let req = self.add_auth_header(self.client.post(&url));
+        let response = req.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Reject a pending top-level thread.
+    pub async fn reject_post(&self, post_id: Uuid) -> ApiResult<Post> {
+        let url = self.build_url(&format!("/posts/{}/reject", post_id));
+        let req = self.add_auth_header(self.client.post(&url));
         let response = req.send().await?;
         self.handle_response(response).await
     }

--- a/fido-tui/src/app/activity.rs
+++ b/fido-tui/src/app/activity.rs
@@ -40,6 +40,7 @@ impl App {
         self.posts_state.activity_error = None;
         self.posts_state.activity_loading = false;
         self.posts_state.activity_pending_load = false;
+        self.clear_approval_queue();
         self.posts_state.rebuild_feed();
     }
 }

--- a/fido-tui/src/app/build.rs
+++ b/fido-tui/src/app/build.rs
@@ -72,6 +72,12 @@ impl App {
                 activity_error: None,
                 activity_pending_load: false,
                 feed_entries: Vec::new(),
+                pending_threads: Vec::new(),
+                pending_threads_list_state: ListState::default(),
+                show_approval_queue: false,
+                pending_threads_loading: false,
+                pending_threads_loaded: false,
+                pending_threads_error: None,
             },
             chat_state: ChatState {
                 channels: Vec::new(),

--- a/fido-tui/src/app/composer.rs
+++ b/fido-tui/src/app/composer.rs
@@ -182,9 +182,16 @@ impl App {
                     .create_post(community_id, parsed_content)
                     .await
                 {
-                    Ok(_) => {
+                    Ok(post) => {
+                        let pending_approval = !post.approved;
                         self.close_composer();
                         self.load_posts().await?;
+                        if pending_approval {
+                            self.posts_state.message = Some((
+                                "Thread submitted for admin approval.".to_string(),
+                                std::time::Instant::now(),
+                            ));
+                        }
                     }
                     Err(e) => {
                         self.posts_state.error = Some(categorize_error(&e.to_string()));

--- a/fido-tui/src/app/handlers/mod.rs
+++ b/fido-tui/src/app/handlers/mod.rs
@@ -120,6 +120,15 @@ fn handle_global_keys(app: &mut App, key: KeyEvent) -> Result<bool> {
             app.toggle_help();
             Ok(true)
         }
+        KeyCode::Esc
+            if app.input_mode == InputMode::Navigation
+                && app.current_screen == Screen::Main
+                && app.current_tab == Tab::Posts
+                && app.posts_state.show_approval_queue =>
+        {
+            app.close_approval_queue();
+            Ok(true)
+        }
         // Esc from a board opened off the Home list returns to the list
         // (repo mode has no list to return to, so Esc falls through to quit).
         KeyCode::Esc

--- a/fido-tui/src/app/handlers/posts.rs
+++ b/fido-tui/src/app/handlers/posts.rs
@@ -26,6 +26,19 @@ pub fn handle_posts_keys(app: &mut App, key: KeyEvent) -> Result<()> {
         return Ok(());
     }
 
+    if app.posts_state.show_approval_queue {
+        match key.code {
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => {
+                app.next_pending_thread();
+            }
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => {
+                app.previous_pending_thread();
+            }
+            _ => {}
+        }
+        return Ok(());
+    }
+
     match key.code {
         KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => {
             app.next_post();
@@ -38,9 +51,7 @@ pub fn handle_posts_keys(app: &mut App, key: KeyEvent) -> Result<()> {
         KeyCode::Char('n') | KeyCode::Char('N') => {
             app.open_composer_new_post();
         }
-        KeyCode::Char('f') | KeyCode::Char('F') => {
-            app.open_filter_modal();
-        }
+        KeyCode::Char('f') | KeyCode::Char('F') => {}
         KeyCode::Char('s') | KeyCode::Char('S') => {
             app.open_user_search_modal();
         }

--- a/fido-tui/src/app/posts.rs
+++ b/fido-tui/src/app/posts.rs
@@ -42,6 +42,7 @@ impl App {
     pub async fn load_posts(&mut self) -> Result<()> {
         self.posts_state.loading = true;
         self.posts_state.error = None;
+        self.posts_state.current_filter = PostFilter::All;
 
         // Yield to allow UI to render the loading state
         tokio::task::yield_now().await;
@@ -71,89 +72,16 @@ impl App {
 
         self.posts_state.message = None;
 
-        // Apply current filter
-        let result = match &self.posts_state.current_filter {
-            PostFilter::All => {
-                self.api_client
-                    .get_posts(
-                        community_id,
-                        Some(max_posts),
-                        Some(sort_order.clone()),
-                        None,
-                        None,
-                    )
-                    .await
-            }
-            PostFilter::Hashtag(tag) => {
-                self.api_client
-                    .get_posts(
-                        community_id,
-                        Some(max_posts),
-                        Some(sort_order.clone()),
-                        Some(tag.clone()),
-                        None,
-                    )
-                    .await
-            }
-            PostFilter::User(user) => {
-                self.api_client
-                    .get_posts(
-                        community_id,
-                        Some(max_posts),
-                        Some(sort_order.clone()),
-                        None,
-                        Some(user.clone()),
-                    )
-                    .await
-            }
-            PostFilter::Multi { hashtags, users } => {
-                // Fetch posts for each filter and combine them
-                let mut all_posts = Vec::new();
-
-                // Fetch for each hashtag
-                for hashtag in hashtags {
-                    if let Ok(posts) = self
-                        .api_client
-                        .get_posts(
-                            community_id,
-                            Some(max_posts),
-                            Some(sort_order.clone()),
-                            Some(hashtag.clone()),
-                            None,
-                        )
-                        .await
-                    {
-                        all_posts.extend(posts);
-                    }
-                }
-
-                // Fetch for each user
-                for username in users {
-                    if let Ok(posts) = self
-                        .api_client
-                        .get_posts(
-                            community_id,
-                            Some(max_posts),
-                            Some(sort_order.clone()),
-                            None,
-                            Some(username.clone()),
-                        )
-                        .await
-                    {
-                        all_posts.extend(posts);
-                    }
-                }
-
-                // Remove duplicates by post ID
-                all_posts.sort_by(|a, b| b.created_at.cmp(&a.created_at)); // Sort by newest first
-                all_posts.dedup_by(|a, b| a.id == b.id);
-
-                // Limit to max_posts
-                all_posts.truncate(max_posts as usize);
-
-                Ok(all_posts)
-            }
-        };
+        let result = self
+            .api_client
+            .get_posts(
+                community_id,
+                Some(max_posts),
+                Some(sort_order.clone()),
+                None,
+                None,
+            )
+            .await;
 
         match result {
             Ok(posts) => {
@@ -181,6 +109,170 @@ impl App {
         }
 
         Ok(())
+    }
+
+    pub fn is_current_community_admin(&self) -> bool {
+        self.community.as_ref().and_then(|community| community.role)
+            == Some(fido_types::MembershipRole::Admin)
+    }
+
+    pub fn clear_approval_queue(&mut self) {
+        self.posts_state.pending_threads.clear();
+        self.posts_state.pending_threads_list_state.select(None);
+        self.posts_state.show_approval_queue = false;
+        self.posts_state.pending_threads_loading = false;
+        self.posts_state.pending_threads_loaded = false;
+        self.posts_state.pending_threads_error = None;
+    }
+
+    pub async fn open_approval_queue(&mut self) -> Result<()> {
+        if !self.is_current_community_admin() {
+            self.posts_state.error =
+                Some("Community admin role required to review pending threads.".to_string());
+            return Ok(());
+        }
+        self.posts_state.show_approval_queue = true;
+        self.posts_state.pending_threads_error = None;
+        self.load_pending_threads().await
+    }
+
+    pub fn close_approval_queue(&mut self) {
+        self.posts_state.show_approval_queue = false;
+        self.posts_state.pending_threads_error = None;
+        self.input_mode = InputMode::Navigation;
+    }
+
+    pub async fn load_pending_threads(&mut self) -> Result<()> {
+        let Some(community_id) = self.current_community_id() else {
+            self.posts_state.pending_threads_error =
+                Some("Open a community before reviewing pending threads.".to_string());
+            return Ok(());
+        };
+
+        self.posts_state.pending_threads_loading = true;
+        self.posts_state.pending_threads_error = None;
+
+        match self
+            .api_client
+            .get_pending_posts(community_id, Some(50))
+            .await
+        {
+            Ok(posts) => {
+                let has_posts = !posts.is_empty();
+                self.posts_state.pending_threads = posts;
+                self.posts_state.pending_threads_loaded = true;
+                if has_posts {
+                    self.posts_state.pending_threads_list_state.select(Some(0));
+                } else {
+                    self.posts_state.pending_threads_list_state.select(None);
+                }
+            }
+            Err(e) => {
+                self.posts_state.pending_threads_error = Some(categorize_error(&e.to_string()));
+            }
+        }
+
+        self.posts_state.pending_threads_loading = false;
+        Ok(())
+    }
+
+    pub fn next_pending_thread(&mut self) {
+        let len = self.posts_state.pending_threads.len();
+        if len == 0 {
+            self.posts_state.pending_threads_list_state.select(None);
+            return;
+        }
+        let current = self
+            .posts_state
+            .pending_threads_list_state
+            .selected()
+            .unwrap_or(0);
+        self.posts_state
+            .pending_threads_list_state
+            .select(Some((current + 1).min(len - 1)));
+    }
+
+    pub fn previous_pending_thread(&mut self) {
+        let len = self.posts_state.pending_threads.len();
+        if len == 0 {
+            self.posts_state.pending_threads_list_state.select(None);
+            return;
+        }
+        let current = self
+            .posts_state
+            .pending_threads_list_state
+            .selected()
+            .unwrap_or(0);
+        self.posts_state
+            .pending_threads_list_state
+            .select(Some(current.saturating_sub(1)));
+    }
+
+    fn selected_pending_thread_id(&self) -> Option<uuid::Uuid> {
+        self.posts_state
+            .pending_threads_list_state
+            .selected()
+            .and_then(|i| self.posts_state.pending_threads.get(i))
+            .map(|post| post.id)
+    }
+
+    pub async fn approve_selected_pending_thread(&mut self) -> Result<()> {
+        let Some(post_id) = self.selected_pending_thread_id() else {
+            return Ok(());
+        };
+
+        match self.api_client.approve_post(post_id).await {
+            Ok(post) => {
+                self.remove_pending_thread(post_id);
+                self.load_posts().await?;
+                self.posts_state.message = Some((
+                    format!("Approved @{}'s thread.", post.author_username),
+                    std::time::Instant::now(),
+                ));
+            }
+            Err(e) => {
+                self.posts_state.pending_threads_error = Some(categorize_error(&e.to_string()));
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn reject_selected_pending_thread(&mut self) -> Result<()> {
+        let Some(post_id) = self.selected_pending_thread_id() else {
+            return Ok(());
+        };
+
+        match self.api_client.reject_post(post_id).await {
+            Ok(post) => {
+                self.remove_pending_thread(post_id);
+                self.posts_state.message = Some((
+                    format!("Rejected @{}'s thread.", post.author_username),
+                    std::time::Instant::now(),
+                ));
+            }
+            Err(e) => {
+                self.posts_state.pending_threads_error = Some(categorize_error(&e.to_string()));
+            }
+        }
+        Ok(())
+    }
+
+    fn remove_pending_thread(&mut self, post_id: uuid::Uuid) {
+        let previous = self
+            .posts_state
+            .pending_threads_list_state
+            .selected()
+            .unwrap_or(0);
+        self.posts_state
+            .pending_threads
+            .retain(|post| post.id != post_id);
+        if self.posts_state.pending_threads.is_empty() {
+            self.posts_state.pending_threads_list_state.select(None);
+        } else {
+            self.posts_state.pending_threads_list_state.select(Some(
+                previous.min(self.posts_state.pending_threads.len().saturating_sub(1)),
+            ));
+        }
     }
 
     /// Vote on the currently selected post
@@ -243,6 +335,7 @@ impl App {
     }
 
     /// Open filter modal
+    #[allow(dead_code)]
     pub fn open_filter_modal(&mut self) {
         self.posts_state.show_filter_modal = true;
         self.posts_state.filter_modal_state.selected_index = 0;
@@ -391,22 +484,11 @@ impl App {
     }
 
     /// Save current filter preference to disk
-    fn save_filter_preference(&self) {
-        if let Some(user) = &self.auth_state.current_user {
-            let prefs = self.posts_state.current_filter.to_preferences();
-            let _ = self
-                .config_manager
-                .save_preferences(&user.id.to_string(), &prefs);
-        }
-    }
+    fn save_filter_preference(&self) {}
 
     /// Load filter preference from disk
     pub fn load_filter_preference(&mut self) {
-        if let Some(user) = &self.auth_state.current_user {
-            if let Ok(Some(prefs)) = self.config_manager.load_preferences(&user.id.to_string()) {
-                self.posts_state.current_filter = PostFilter::from_preferences(&prefs);
-            }
-        }
+        self.posts_state.current_filter = PostFilter::All;
     }
 
     /// Add character to new post content

--- a/fido-tui/src/app/state.rs
+++ b/fido-tui/src/app/state.rs
@@ -528,6 +528,7 @@ pub struct UserProfileViewState {
 }
 
 /// Filter type for posts
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum PostFilter {
     All,
@@ -539,6 +540,7 @@ pub enum PostFilter {
     },
 }
 
+#[allow(dead_code)]
 impl PostFilter {
     /// Convert to UserPreferences format for saving
     pub fn to_preferences(&self) -> crate::config::UserPreferences {
@@ -627,6 +629,13 @@ pub struct PostsState {
     pub activity_pending_load: bool,
     /// Posts and activity merged descending by `created_at`
     pub feed_entries: Vec<FeedEntry>,
+    /// Admin queue for pending top-level community threads.
+    pub pending_threads: Vec<Post>,
+    pub pending_threads_list_state: ListState,
+    pub show_approval_queue: bool,
+    pub pending_threads_loading: bool,
+    pub pending_threads_loaded: bool,
+    pub pending_threads_error: Option<String>,
 }
 
 /// One row in the interleaved posts + repo-activity feed.

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -80,6 +80,37 @@ fn test_escape_closes_community_browser_before_quit() {
 }
 
 #[test]
+fn test_approval_queue_navigation_and_escape_priority() {
+    let mut app = App::new();
+    app.current_screen = Screen::Main;
+    app.current_tab = Tab::Posts;
+    set_test_community(&mut app);
+    app.posts_state.show_approval_queue = true;
+    app.posts_state.pending_threads = vec![
+        test_post_created_at("2026-07-02T12:00:00Z"),
+        test_post_created_at("2026-07-02T12:01:00Z"),
+    ];
+    app.posts_state.pending_threads_list_state.select(Some(0));
+    app.running = true;
+
+    app.handle_key_event(key_event(KeyCode::Down)).unwrap();
+    assert_eq!(
+        app.posts_state.pending_threads_list_state.selected(),
+        Some(1)
+    );
+
+    app.handle_key_event(key_event(KeyCode::Up)).unwrap();
+    assert_eq!(
+        app.posts_state.pending_threads_list_state.selected(),
+        Some(0)
+    );
+
+    app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
+    assert!(!app.posts_state.show_approval_queue);
+    assert!(app.running);
+}
+
+#[test]
 fn test_escape_closes_help_modal_first() {
     let mut app = App::new();
     app.show_help = true;
@@ -1254,6 +1285,12 @@ fn test_posts_state_with(
         activity_error: None,
         activity_pending_load: false,
         feed_entries: Vec::new(),
+        pending_threads: Vec::new(),
+        pending_threads_list_state: ListState::default(),
+        show_approval_queue: false,
+        pending_threads_loading: false,
+        pending_threads_loaded: false,
+        pending_threads_error: None,
     }
 }
 

--- a/fido-tui/src/config.rs
+++ b/fido-tui/src/config.rs
@@ -12,6 +12,7 @@ pub struct SessionData {
 }
 
 /// User preferences stored locally
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserPreferences {
     pub filter_type: String, // "all", "hashtag", "user", "multi"
@@ -60,6 +61,7 @@ impl ConfigManager {
     }
 
     /// Get the preferences file path for a specific user
+    #[allow(dead_code)]
     fn get_preferences_file(&self, user_id: &str) -> PathBuf {
         self.config_dir.join(format!("prefs_{}.json", user_id))
     }
@@ -99,6 +101,7 @@ impl ConfigManager {
     }
 
     /// Save user preferences
+    #[allow(dead_code)]
     pub fn save_preferences(&self, user_id: &str, prefs: &UserPreferences) -> Result<()> {
         let prefs_file = self.get_preferences_file(user_id);
         let json =
@@ -110,6 +113,7 @@ impl ConfigManager {
     }
 
     /// Load user preferences
+    #[allow(dead_code)]
     pub fn load_preferences(&self, user_id: &str) -> Result<Option<UserPreferences>> {
         let prefs_file = self.get_preferences_file(user_id);
 

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -618,6 +618,7 @@ impl EventLoop {
             KeyCode::Enter | KeyCode::Char(' ')
                 if app.current_tab == Tab::Posts
                     && !app.posts_state.show_new_post_modal
+                    && !app.posts_state.show_approval_queue
                     && !app.viewing_post_detail
                     && !app.composer_state.is_open()
                     && !app.posts_state.show_filter_modal
@@ -646,6 +647,35 @@ impl EventLoop {
             {
                 app.retry_community().await?;
             }
+            KeyCode::Char('a') | KeyCode::Char('A')
+                if app.current_screen == Screen::Main
+                    && app.current_tab == Tab::Posts
+                    && app.posts_state.show_approval_queue
+                    && app.input_mode == InputMode::Navigation =>
+            {
+                app.approve_selected_pending_thread().await?;
+            }
+            KeyCode::Char('x') | KeyCode::Char('X')
+                if app.current_screen == Screen::Main
+                    && app.current_tab == Tab::Posts
+                    && app.posts_state.show_approval_queue
+                    && app.input_mode == InputMode::Navigation =>
+            {
+                app.reject_selected_pending_thread().await?;
+            }
+            KeyCode::Char('a') | KeyCode::Char('A')
+                if app.current_screen == Screen::Main
+                    && app.current_tab == Tab::Posts
+                    && app.input_mode == InputMode::Navigation
+                    && !app.posts_state.show_approval_queue
+                    && !app.viewing_post_detail
+                    && !app.composer_state.is_open()
+                    && !app.posts_state.show_filter_modal
+                    && app.user_profile_view.is_none()
+                    && app.is_current_community_admin() =>
+            {
+                app.open_approval_queue().await?;
+            }
             KeyCode::Enter
                 if app.current_tab == Tab::DMs
                     && !app.dms_state.show_new_conversation_modal
@@ -663,6 +693,7 @@ impl EventLoop {
             KeyCode::Char('u') | KeyCode::Char('U')
                 if app.current_screen == Screen::Main
                     && app.current_tab == Tab::Posts
+                    && !app.posts_state.show_approval_queue
                     && !app.composer_state.is_open()
                     && !app.posts_state.show_filter_modal
                     && app.user_profile_view.is_none() =>
@@ -672,6 +703,7 @@ impl EventLoop {
             KeyCode::Char('d') | KeyCode::Char('D')
                 if app.current_screen == Screen::Main
                     && app.current_tab == Tab::Posts
+                    && !app.posts_state.show_approval_queue
                     && !app.composer_state.is_open()
                     && !app.posts_state.show_filter_modal
                     && app.user_profile_view.is_none() =>

--- a/fido-tui/src/ui/components/action_bar.rs
+++ b/fido-tui/src/ui/components/action_bar.rs
@@ -17,7 +17,9 @@ pub fn action_bar_text(app: &App) -> &'static str {
 
     match app.current_tab {
         crate::app::Tab::Posts => {
-            if app.show_community_modal {
+            if app.posts_state.show_approval_queue {
+                "↑/↓/j/k: Navigate | a: Approve | x: Reject | Esc: Board"
+            } else if app.show_community_modal {
                 if app.community.as_ref().map(|c| !c.claimed).unwrap_or(false) {
                     "c: Claim admin | Esc: Close"
                 } else {
@@ -32,8 +34,10 @@ pub fn action_bar_text(app: &App) -> &'static str {
                 Some(crate::app::FeedEntry::Activity(_))
             ) {
                 "↑/↓/j/k: Navigate | o: Open on GitHub"
+            } else if app.is_current_community_admin() {
+                "u/d: Vote | n: Post | a: Approvals | i: Community | b: Browse | Space: View"
             } else {
-                "u/d: Vote | n: Post | i: Community | b: Browse | f: Filter | Space: View"
+                "u/d: Vote | n: Post | i: Community | b: Browse | Space: View"
             }
         }
         crate::app::Tab::Chat => {

--- a/fido-tui/src/ui/modals/help.rs
+++ b/fido-tui/src/ui/modals/help.rs
@@ -259,22 +259,35 @@ pub fn add_posts_feed_shortcuts(
         return;
     }
 
-    shortcuts.push((
-        "Board",
-        vec![
-            ("↓/j", "Next post"),
-            ("↑/k", "Previous post"),
-            ("Space/Enter", "Open post detail"),
-            ("u", "Upvote selected post"),
-            ("d", "Downvote selected post"),
-            ("n", "New post"),
-            ("i", "Community info & settings"),
-            ("b", "Browse starred repos"),
-            ("f", "Filter posts"),
-            ("s", "Search users"),
-            ("p", "View author profile"),
-        ],
-    ));
+    let mut board_shortcuts = vec![
+        ("↓/j", "Next post"),
+        ("↑/k", "Previous post"),
+        ("Space/Enter", "Open post detail"),
+        ("u", "Upvote selected post"),
+        ("d", "Downvote selected post"),
+        ("n", "New post"),
+        ("i", "Community info & settings"),
+        ("b", "Browse starred repos"),
+        ("s", "Search users"),
+        ("p", "View author profile"),
+    ];
+    if app.is_current_community_admin() {
+        board_shortcuts.push(("a", "Review pending threads"));
+    }
+    shortcuts.push(("Board", board_shortcuts));
+
+    if app.posts_state.show_approval_queue {
+        shortcuts.push((
+            "Pending Threads",
+            vec![
+                ("↓/j", "Next pending thread"),
+                ("↑/k", "Previous pending thread"),
+                ("a", "Approve selected thread"),
+                ("x", "Reject selected thread"),
+                ("Esc", "Return to board"),
+            ],
+        ));
+    }
 
     if app.posts_state.show_new_post_modal {
         shortcuts.push((

--- a/fido-tui/src/ui/modals/mod.rs
+++ b/fido-tui/src/ui/modals/mod.rs
@@ -1,7 +1,6 @@
 // Modal rendering modules
 mod community;
 mod composer;
-mod filters;
 mod help;
 mod posts;
 mod social;
@@ -10,7 +9,6 @@ mod social_components;
 // Re-export all public functions
 pub use community::*;
 pub use composer::*;
-pub use filters::*;
 pub use help::*;
 pub use posts::*;
 pub use social::*;

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -888,6 +888,102 @@ fn render_home_list(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_stateful_widget(list, area, &mut app.home_state.list_state);
 }
 
+/// Admin mode: pending top-level threads for the current community.
+fn render_approval_queue(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = get_theme_colors(app);
+    let title = " Pending Threads ";
+
+    if app.posts_state.pending_threads_loading {
+        render_panel_lines(
+            frame,
+            area,
+            title,
+            create_loading_display("Loading pending threads...", &theme),
+            &theme,
+        );
+        return;
+    }
+
+    if let Some(error) = &app.posts_state.pending_threads_error {
+        render_panel_lines(
+            frame,
+            area,
+            title,
+            create_error_display(error, Some("Press Esc to return to the board"), &theme),
+            &theme,
+        );
+        return;
+    }
+
+    if app.posts_state.pending_threads.is_empty() {
+        let empty = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "No pending threads",
+                Style::default()
+                    .fg(theme.success)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "New threads that require approval will appear here.",
+                Style::default().fg(theme.text_dim),
+            )),
+        ])
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL).title(title));
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let selected = app.posts_state.pending_threads_list_state.selected();
+    let width = area.width.saturating_sub(6) as usize;
+    let items: Vec<ListItem> = app
+        .posts_state
+        .pending_threads
+        .iter()
+        .enumerate()
+        .map(|(index, post)| {
+            let is_selected = selected == Some(index);
+            let header_style = if is_selected {
+                Style::default()
+                    .fg(theme.success)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.primary)
+            };
+            let prefix = if is_selected { "> " } else { "  " };
+            let mut lines = vec![Line::from(vec![
+                Span::styled(prefix, header_style),
+                Span::styled(format!("@{}", post.author_username), header_style),
+                Span::raw(" • "),
+                Span::styled(
+                    format_timestamp(&post.created_at),
+                    Style::default().fg(theme.text_dim),
+                ),
+            ])];
+            for content_line in post.content.lines() {
+                for wrapped in textwrap::wrap(content_line, width) {
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", wrapped),
+                        Style::default().fg(theme.text),
+                    )));
+                }
+            }
+            lines.push(Line::from(Span::styled(
+                "  a: approve  x: reject",
+                Style::default().fg(theme.text_dim),
+            )));
+            lines.push(Line::from(""));
+            ListItem::new(lines)
+        })
+        .collect();
+
+    let list =
+        styled_list(items, &theme, None).block(Block::default().borders(Borders::ALL).title(title));
+    frame.render_stateful_widget(list, area, &mut app.posts_state.pending_threads_list_state);
+}
+
 /// Render Posts tab with global feed
 pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) {
     // Log at start of render
@@ -934,6 +1030,11 @@ pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) 
         return;
     }
 
+    if app.posts_state.show_approval_queue {
+        render_approval_queue(frame, app, posts_area);
+        return;
+    }
+
     let community_title = community_board_title(app);
 
     // Only show full-page loading on initial load (when there are no posts yet)
@@ -946,10 +1047,6 @@ pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) 
             &theme,
         );
 
-        // Render filter modal if open (even when loading)
-        if app.posts_state.show_filter_modal {
-            render_filter_modal(frame, app, area);
-        }
         return;
     }
 
@@ -980,10 +1077,6 @@ pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) 
         );
         frame.render_widget(empty, posts_area);
 
-        // Render filter modal if open (even when no posts)
-        if app.posts_state.show_filter_modal {
-            render_filter_modal(frame, app, area);
-        }
         return;
     }
 
@@ -1170,26 +1263,13 @@ pub fn render_posts_tab_with_data(frame: &mut Frame, app: &mut App, area: Rect) 
         items.push(ListItem::new(end_of_feed));
     }
 
-    // Build title with current filter
-    let title = match &app.posts_state.current_filter {
-        crate::app::PostFilter::All => community_title,
-        crate::app::PostFilter::Hashtag(tag) => format!("{} / #{}", community_title, tag),
-        crate::app::PostFilter::User(username) => format!("{} / @{}", community_title, username),
-        crate::app::PostFilter::Multi { hashtags, users } => {
-            let total = hashtags.len() + users.len();
-            format!("{} / Filtered ({} items)", community_title, total)
-        }
-    };
-
-    let posts_widget =
-        styled_list(items, &theme, None).block(Block::default().borders(Borders::ALL).title(title));
+    let posts_widget = styled_list(items, &theme, None).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(community_title),
+    );
 
     frame.render_stateful_widget(posts_widget, posts_area, &mut app.posts_state.list_state);
-
-    // Render filter modal if open
-    if app.posts_state.show_filter_modal {
-        render_filter_modal(frame, app, area);
-    }
 }
 
 /// Create a formatted error message display with optional help text

--- a/scripts/e2e_tui.sh
+++ b/scripts/e2e_tui.sh
@@ -160,6 +160,56 @@ pane | grep -qF "Your role" && fail "community modal should close on Esc"
 
 tmux kill-session -t "$SESSION"
 
+# --- Scenario 2b: admin approval queue ---------------------------------------
+echo "==> scenario 2b: pending thread approval queue"
+sqlite3 "$WORK/fido.db" \
+    "UPDATE communities SET require_thread_approval = 1
+     WHERE owner = 'testowner' AND name = 'testrepo';
+     UPDATE memberships
+        SET role = 'admin'
+      WHERE community_id = (SELECT id FROM communities WHERE owner = 'testowner' AND name = 'testrepo')
+        AND user_id = (SELECT id FROM users WHERE username = 'alice');
+     DELETE FROM post_rate_limits
+      WHERE user_id = (SELECT id FROM users WHERE username = 'alice');"
+
+launch_tui "$REPO"
+wait_for "testowner/testrepo" "repo community board with approval required"
+pane | grep -qF "admin" || fail "board title should show admin role after promotion"
+
+keys 'n'
+wait_for "New Post" "composer modal for pending thread" 25
+tmux send-keys -t "$SESSION" -l "pending approval from e2e"
+sleep 0.3
+keys Enter
+wait_for "Thread submitted for admin approval." "pending approval author feedback"
+
+PENDING_COUNT=$(sqlite3 "$WORK/fido.db" \
+    "SELECT count(*) FROM posts p
+     JOIN communities c ON p.community_id = c.id
+     WHERE c.owner = 'testowner' AND c.name = 'testrepo'
+       AND p.content = 'pending approval from e2e'
+       AND p.approved = 0;")
+[[ "$PENDING_COUNT" == "1" ]] || fail "pending thread not found before approval (count=$PENDING_COUNT)"
+
+keys 'a'
+wait_for "Pending Threads" "approval queue opens"
+wait_for "pending approval from e2e" "pending thread appears in approval queue"
+keys 'a'
+wait_for "No pending threads" "pending queue empty after approval"
+
+APPROVED_COUNT=$(sqlite3 "$WORK/fido.db" \
+    "SELECT count(*) FROM posts p
+     JOIN communities c ON p.community_id = c.id
+     WHERE c.owner = 'testowner' AND c.name = 'testrepo'
+       AND p.content = 'pending approval from e2e'
+       AND p.approved = 1;")
+[[ "$APPROVED_COUNT" == "1" ]] || fail "thread not approved from queue (count=$APPROVED_COUNT)"
+
+keys Escape
+wait_for "pending approval from e2e" "approved thread appears on board"
+
+tmux kill-session -t "$SESSION"
+
 # --- Scenario 3: Home mode — launch outside a repo ---------------------------
 echo "==> scenario 3: home mode lists joined communities"
 launch_tui "$NON_REPO"


### PR DESCRIPTION
## Summary
- adds admin-only pending thread queue in the repo board with approve/reject actions
- adds server-side pending thread reject endpoint and rejected-thread notification path
- shows pending-approval feedback to thread authors and removes visible hashtag/filter board UI
- expands tmux E2E to cover repo launch, pending thread submission, approval, and board visibility

## Validation
- cargo fmt --check
- cargo check -p fido-server -p fido
- cargo test -p fido-server -p fido
- cargo clippy -p fido-server -p fido --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- just e2e-tui-startup
- just e2e-tui