### PR TITLE
fix: proxy realtime websocket upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Proxy API WebSocket upgrades through nginx for the `/ws` realtime gateway.
+
 ### Removed
 
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -79,6 +79,20 @@ http {
             proxy_pass http://ttyd_server/ttyd/ws;
         }
 
+        # API realtime gateway. This must be explicit because the generic API
+        # proxy below does not forward WebSocket upgrade headers.
+        location = /ws {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_read_timeout 1d;
+            proxy_pass http://fido_server/ws;
+        }
+
         location /ttyd/ {
             limit_req zone=fido burst=20 nodelay;
 

--- a/start.sh
+++ b/start.sh
@@ -213,6 +213,18 @@ http {
             proxy_pass http://ttyd_server/ttyd/ws;
         }
 
+        location = /ws {
+            proxy_http_version 1.1;
+            proxy_set_header Host \$host;
+            proxy_set_header X-Real-IP \$remote_addr;
+            proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto \$scheme;
+            proxy_set_header Upgrade \$http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_read_timeout 1d;
+            proxy_pass http://fido_server/ws;
+        }
+
         location /ttyd/ {
             proxy_http_version 1.1;
             proxy_set_header Host \$host;


### PR DESCRIPTION
## Summary
- add an exact /ws nginx location that forwards WebSocket upgrade headers to fido-server
- mirror the same /ws proxy rule in the local start.sh generated nginx config
- document the fix under Unreleased

## Validation
- production pre-fix probe returned HTTP 400: Connection header did not include upgrade
- bash -n start.sh
- rendered nginx.conf with NGINX_PORT=8080 and Homebrew mime path; nginx -t succeeded
- git diff --check

## Follow-up
- merge and redeploy, then re-probe /ws through production nginx.