### PR TITLE
fix: report server crate version at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Proxy API WebSocket upgrades through nginx for the `/ws` realtime gateway.
+- Report the actual `fido-server` crate version in startup logs instead of a stale hard-coded version.
 
 ### Removed
 

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    tracing::info!("Starting Fido server v1.0.1...");
+    tracing::info!("Starting Fido server v{}...", env!("CARGO_PKG_VERSION"));
 
     // Load and validate security configuration
     let security_config = match security::SecurityConfig::from_env() {


### PR DESCRIPTION
## Summary
- replace the hard-coded fido-server startup version with CARGO_PKG_VERSION
- document the log fix under Unreleased

## Validation
- cargo fmt --check
- git diff --check
- cargo check -p fido-server
- cargo test -p fido-server
- cargo clippy -p fido-server --all-targets --all-features -- -D warnings