### PR TITLE
docs: add DOX agent hierarchy

### DIFF
--- a/.stint/tasks/0018-add-dox-agents-files.md
+++ b/.stint/tasks/0018-add-dox-agents-files.md
@@ -1,9 +1,10 @@
 ---
 id: "0018"
 title: "Add DOX AGENTS.md files: adopt root template and initialize child docs tree"
-status: todo
+status: in-progress
 priority: p2
 estimate: "1h"
+started_at: "2026-07-11T00:36:10Z"
 blocked_by: []
 gh_issue: []
 area:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,19 @@
 # AGENTS.md
 
+## DOX Framework
+
+`AGENTS.md` files are binding work contracts for their subtrees. Before editing, read this root file and every `AGENTS.md` on the route from the repository root to each target. The nearest file controls local details; parent files still apply. A child may add local rules but may not weaken this contract.
+
+### Read Before Editing
+
+1. Identify every file or folder the change will touch.
+2. Walk from the repository root to each target and read every `AGENTS.md` on that route.
+3. Use the nearest file for local rules and its parents for repository-wide rules.
+
+### Update After Editing
+
+For every meaningful change, update the closest owning `AGENTS.md` when it changes purpose, structure, contracts, workflow, constraints, or verification. Update parent files when a child index changes. Remove stale or contradictory guidance in the same pass.
+
 This file provides guidance to AI coding assistants when working with code in this repository.
 
 ## Project Overview
@@ -436,3 +450,9 @@ Implementation plan:
 2. Wrap existing `ApiClient`
 3. Add cache invalidation logic
 4. Store cache in `.fido/cache/`
+
+## Child DOX Index
+
+- [`fido-server/AGENTS.md`](fido-server/AGENTS.md): API server crate, tests, and server-specific contracts.
+- [`fido-tui/AGENTS.md`](fido-tui/AGENTS.md): terminal client crate, startup, and interaction contracts.
+- [`fido-types/AGENTS.md`](fido-types/AGENTS.md): shared public models, events, and enums.

--- a/fido-server/AGENTS.md
+++ b/fido-server/AGENTS.md
@@ -1,0 +1,37 @@
+# fido-server
+
+## Purpose
+
+This crate runs Fido's Axum API, SQLite persistence, GitHub integration, and web-terminal server process.
+
+## Ownership
+
+- `src/` owns production server code and the shared router.
+- `tests/` owns black-box server coverage, including the GitHub fixture-backed community test.
+- `settings.toml` defines local default settings. Environment variables remain the deployment boundary.
+
+## Local Contracts
+
+- Keep `create_router_with_security_config` in `src/lib.rs` usable by tests. Mount production-only static fallback routes in `src/main.rs`.
+- Server handlers use `AppState`, services own business logic, and repositories own SQL.
+- Do not mount passwordless test authentication in production.
+- Treat `FIDO_TOKEN_KEY`, cookie settings, CORS, and environment parsing as security-sensitive. Production must fail closed.
+- SQLite remains a single-writer store. Preserve transaction boundaries and existing indexes when changing persistence.
+
+## Work Guidance
+
+- Add or change an endpoint through its handler, service, repository, shared types, router registration, and relevant tests.
+- Use `just server` or `just server-reset` when reproducing local startup behavior. Read `logs/fido-server.log` before guessing.
+
+## Verification
+
+```bash
+cargo test -p fido-server --features sqlite-tests
+cargo test --test e2e_community_rewrite -p fido-server
+```
+
+Run the focused integration test for routes, auth, GitHub, or database changes. Follow with the workspace checks required by the root guide.
+
+## Child DOX Index
+
+- [`src/AGENTS.md`](src/AGENTS.md): server module boundaries.

--- a/fido-server/src/AGENTS.md
+++ b/fido-server/src/AGENTS.md
@@ -1,0 +1,31 @@
+# fido-server/src
+
+## Purpose
+
+Production server modules, shared router construction, startup wiring, and application state.
+
+## Ownership
+
+- `lib.rs` exports server modules and builds the API router used by production and tests.
+- `main.rs` loads configuration, initializes the database and state, then starts the HTTP process.
+- `state.rs` wires repositories, services, sessions, and runtime state.
+
+## Local Contracts
+
+- Keep routes, middleware, security configuration, and request limits consistent between production and test router construction.
+- Handlers should translate HTTP input and output. Services should contain domain behavior. Repositories should contain SQL.
+- Preserve explicit production checks for test-only routes, token encryption, cookies, and environment configuration.
+
+## Verification
+
+```bash
+cargo test -p fido-server --features sqlite-tests
+```
+
+## Child DOX Index
+
+- [`api/AGENTS.md`](api/AGENTS.md): request handlers and API errors.
+- [`db/AGENTS.md`](db/AGENTS.md): SQLite connection, schema, rows, and repositories.
+- [`http/AGENTS.md`](http/AGENTS.md): request metadata and authentication extractors.
+- [`security/AGENTS.md`](security/AGENTS.md): security configuration and middleware.
+- [`services/AGENTS.md`](services/AGENTS.md): business logic and GitHub integration.

--- a/fido-server/src/api/AGENTS.md
+++ b/fido-server/src/api/AGENTS.md
@@ -1,0 +1,28 @@
+# fido-server/src/api
+
+## Purpose
+
+Axum handlers for authentication, communities, chat, posts, DMs, notifications, profiles, and WebSocket connections.
+
+## Ownership
+
+- Each endpoint family has one module.
+- `error.rs` owns the API error response shape.
+- Route registration stays in `../lib.rs`.
+
+## Local Contracts
+
+- Authenticate and authorize before invoking stateful behavior.
+- Validate all client input here or in the service boundary. Return `ApiError` rather than ad hoc response formats.
+- Keep handlers thin. Call services and repositories through `AppState`; do not duplicate SQL or GitHub calls in handlers.
+- Route changes require a matching update in `../lib.rs` and endpoint coverage.
+
+## Verification
+
+```bash
+cargo test -p fido-server --features sqlite-tests
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-server/src/db/AGENTS.md
+++ b/fido-server/src/db/AGENTS.md
@@ -1,0 +1,29 @@
+# fido-server/src/db
+
+## Purpose
+
+SQLite connection pooling, schema setup, row conversion, and repository exports.
+
+## Ownership
+
+- `connection.rs` owns `Database` and the pool.
+- `schema.rs` owns schema creation, migrations, seed data, and indexes.
+- `row.rs` owns database-to-domain conversions.
+- `repositories/` owns entity-specific SQL.
+
+## Local Contracts
+
+- Use parameterized SQL only.
+- Keep schema changes compatible with existing persisted databases and add indexes for new query paths.
+- Use transactions when a domain operation changes multiple rows.
+- Repositories are cheap `DbPool` wrappers. Add them to `Repositories` when a new domain service needs shared access.
+
+## Verification
+
+```bash
+cargo test -p fido-server --features sqlite-tests
+```
+
+## Child DOX Index
+
+- [`repositories/AGENTS.md`](repositories/AGENTS.md): entity repositories and the shared repository bundle.

--- a/fido-server/src/db/repositories/AGENTS.md
+++ b/fido-server/src/db/repositories/AGENTS.md
@@ -1,0 +1,26 @@
+# fido-server/src/db/repositories
+
+## Purpose
+
+Entity-specific SQLite access and the `Repositories` bundle injected into application services.
+
+## Ownership
+
+Each `*_repository.rs` file owns the SQL for one entity or relation. `mod.rs` exports repositories and constructs `Repositories` from a shared pool.
+
+## Local Contracts
+
+- Bind every SQL value as a parameter.
+- Keep row conversion and null handling explicit. Return domain types or repository errors, not HTTP responses.
+- When adding a repository, export it and wire it into `Repositories::new` if other layers need it.
+- Add repository tests beside the affected code when query behavior, ordering, constraints, or migrations change.
+
+## Verification
+
+```bash
+cargo test -p fido-server --features sqlite-tests
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-server/src/http/AGENTS.md
+++ b/fido-server/src/http/AGENTS.md
@@ -1,0 +1,26 @@
+# fido-server/src/http
+
+## Purpose
+
+Shared HTTP extractors for authenticated users and request metadata.
+
+## Ownership
+
+- `auth.rs` owns required and optional session authentication extractors.
+- `headers.rs` owns client IP and user-agent extraction.
+
+## Local Contracts
+
+- Keep authentication decisions centralized in extractors and security middleware.
+- Treat forwarded headers as untrusted unless the deployment boundary explicitly guarantees them.
+- Preserve error behavior used by handlers and WebSocket setup.
+
+## Verification
+
+```bash
+cargo test -p fido-server --features sqlite-tests
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-server/src/security/AGENTS.md
+++ b/fido-server/src/security/AGENTS.md
@@ -1,0 +1,27 @@
+# fido-server/src/security
+
+## Purpose
+
+Environment-aware security configuration, CORS, cookies, headers, admin access, validation, and audit records.
+
+## Ownership
+
+`mod.rs` owns `SecurityConfig` and `Environment`; child modules own their named policy surface.
+
+## Local Contracts
+
+- Production configuration must fail closed. Do not default an invalid or missing environment to development.
+- Do not weaken secure-cookie, CORS, admin, header, or token requirements to make a local test pass.
+- Make policy changes explicit in tests for development and production behavior.
+- Keep secrets out of logs and error messages.
+
+## Verification
+
+```bash
+cargo test -p fido-server --features sqlite-tests
+cargo test --test test_https_cookies -p fido-server
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-server/src/services/AGENTS.md
+++ b/fido-server/src/services/AGENTS.md
@@ -1,0 +1,27 @@
+# fido-server/src/services
+
+## Purpose
+
+Business operations for communities, chat, posts, DMs, profiles, notifications, activity, and GitHub.
+
+## Ownership
+
+Each module owns one domain operation family. `github.rs` owns GitHub API access and encrypted token handling.
+
+## Local Contracts
+
+- Services coordinate repositories and external APIs. They do not construct HTTP responses.
+- Keep GitHub API calls behind `GithubService` and preserve its configured API base for fixture-backed tests.
+- Enforce domain authorization before writes and emit activity or notifications through the existing service paths.
+- Handle token encryption and decryption only through the existing GitHub token helpers.
+
+## Verification
+
+```bash
+cargo test -p fido-server --features sqlite-tests
+cargo test --test e2e_community_rewrite -p fido-server
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-tui/AGENTS.md
+++ b/fido-tui/AGENTS.md
@@ -1,0 +1,33 @@
+# fido-tui
+
+## Purpose
+
+This crate builds the `fido` terminal client published to crates.io.
+
+## Ownership
+
+- `src/` owns startup, terminal lifecycle, state, input handling, API calls, and Ratatui rendering.
+- `tests/` owns client integration coverage.
+- `README.md` documents client installation and usage.
+
+## Local Contracts
+
+- The TUI starts with a first frame before network startup work completes.
+- Keep input handling keyboard-first. Every user action must have a keyboard path.
+- Run in a GitHub repository to open that repository's community; run elsewhere to open Home mode.
+- Session files stay under `~/.fido/`. Release binaries do not auto-load a repository `.env` unless `FIDO_LOAD_DOTENV` is explicitly enabled.
+- Keep rendering responsive. Avoid blocking network or disk work in the event loop or render path.
+
+## Verification
+
+```bash
+cargo test -p fido
+just e2e-tui-startup
+just e2e-tui
+```
+
+Use `just e2e-tui` for any changed interaction, screen, navigation, community behavior, or displayed data.
+
+## Child DOX Index
+
+- [`src/AGENTS.md`](src/AGENTS.md): client module boundaries.

--- a/fido-tui/src/AGENTS.md
+++ b/fido-tui/src/AGENTS.md
@@ -1,0 +1,34 @@
+# fido-tui/src
+
+## Purpose
+
+Terminal client implementation: startup, terminal lifecycle, app state, input dispatch, HTTP and WebSocket API access, and rendering.
+
+## Ownership
+
+- `main.rs` owns CLI parsing, startup sequencing, terminal initialization, and the main event loop handoff.
+- `event_loop.rs` drives events and redraws.
+- `repo_context.rs` detects GitHub repository context for directory-scoped communities.
+- `terminal.rs` owns terminal setup and restoration.
+- `session.rs` owns local session persistence.
+
+## Local Contracts
+
+- Preserve first-frame-before-network behavior in startup.
+- Keep side effects out of render functions. Keep state transitions and key dispatch in `app/`.
+- Send HTTP and WebSocket work through `api/`; do not construct client requests from UI modules.
+- Always restore the terminal on exit or error paths.
+
+## Verification
+
+```bash
+cargo test -p fido
+just e2e-tui-startup
+just e2e-tui
+```
+
+## Child DOX Index
+
+- [`api/AGENTS.md`](api/AGENTS.md): server client and realtime connection.
+- [`app/AGENTS.md`](app/AGENTS.md): application state and input behavior.
+- [`ui/AGENTS.md`](ui/AGENTS.md): Ratatui rendering and visual components.

--- a/fido-tui/src/api/AGENTS.md
+++ b/fido-tui/src/api/AGENTS.md
@@ -1,0 +1,29 @@
+# fido-tui/src/api
+
+## Purpose
+
+Typed HTTP client, API errors, and WebSocket realtime client for the Fido server.
+
+## Ownership
+
+- `client.rs` owns request and response types plus HTTP calls.
+- `realtime.rs` owns WebSocket connection state and event delivery.
+- `error.rs` owns client-facing API error types.
+
+## Local Contracts
+
+- Keep server paths, request payloads, and response types aligned with `fido-server` handlers and `fido-types` models.
+- Surface server failures as `ApiError`; do not silently discard failed mutations.
+- Realtime work must communicate through its event channel. Do not mutate `App` directly from background tasks.
+- Apply timeouts to network work and keep it off the render path.
+
+## Verification
+
+```bash
+cargo test -p fido
+just e2e-tui
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-tui/src/app/AGENTS.md
+++ b/fido-tui/src/app/AGENTS.md
@@ -1,0 +1,31 @@
+# fido-tui/src/app
+
+## Purpose
+
+Application state, feature methods, navigation, and keyboard event dispatch.
+
+## Ownership
+
+- `state.rs` owns `App` and the durable UI state types.
+- `mod.rs` exposes state and composes feature modules.
+- Feature modules own state transitions for their area.
+- `handlers/` owns ordered keyboard dispatch and modal routing.
+
+## Local Contracts
+
+- Treat `App` as the single owner of UI state.
+- Keep input priority explicit. Global quit, help, overlays, modals, detail views, and screen-specific keys must continue to resolve in their current order.
+- Keep user-visible async failures in app state so rendering can report them.
+- Preserve Home behavior outside a repository and board behavior inside a GitHub-backed repository.
+- Add or adjust tests in `tests.rs` when a state transition can be checked without a terminal.
+
+## Verification
+
+```bash
+cargo test -p fido
+just e2e-tui
+```
+
+## Child DOX Index
+
+- [`handlers/AGENTS.md`](handlers/AGENTS.md): keyboard event priority and feature dispatch.

--- a/fido-tui/src/app/handlers/AGENTS.md
+++ b/fido-tui/src/app/handlers/AGENTS.md
@@ -1,0 +1,26 @@
+# fido-tui/src/app/handlers
+
+## Purpose
+
+Keyboard event dispatch for global navigation, modals, posts, profiles, DMs, and settings.
+
+## Ownership
+
+`mod.rs` owns dispatch order. Feature files own their named key handling.
+
+## Local Contracts
+
+- Handle only `KeyEventKind::Press`.
+- Preserve priority: quit, help, overlays, confirmations, modals, detail views, global keys, then screen-specific handlers.
+- Do not let a new key path bypass an open modal or unsaved-settings confirmation.
+- Keep shortcut behavior discoverable in the help UI when adding a user-facing command.
+
+## Verification
+
+```bash
+just e2e-tui
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-tui/src/ui/AGENTS.md
+++ b/fido-tui/src/ui/AGENTS.md
@@ -1,0 +1,32 @@
+# fido-tui/src/ui
+
+## Purpose
+
+Pure Ratatui rendering for screens, tabs, modals, formatting, themes, and reusable widgets.
+
+## Ownership
+
+- `../ui.rs` owns the top-level render function and minimum terminal size fallback.
+- `tabs.rs` owns auth and main-screen composition.
+- `theme.rs` owns color selection.
+- `components/` owns reusable widgets.
+- `modals/` owns overlay rendering.
+
+## Local Contracts
+
+- Render from `App` state without network, database, or filesystem side effects.
+- Keep the terminal usable at the documented minimum size of 60 by 20.
+- Reuse theme colors and shared components. Avoid hard-coded colors and duplicate layout logic.
+- Keep content text-only and keyboard-oriented. A visual change must not hide an available keyboard path.
+
+## Verification
+
+```bash
+cargo test -p fido
+just e2e-tui
+```
+
+## Child DOX Index
+
+- [`components/AGENTS.md`](components/AGENTS.md): reusable UI widgets and layouts.
+- [`modals/AGENTS.md`](modals/AGENTS.md): modal rendering and modal-specific composition.

--- a/fido-tui/src/ui/components/AGENTS.md
+++ b/fido-tui/src/ui/components/AGENTS.md
@@ -1,0 +1,26 @@
+# fido-tui/src/ui/components
+
+## Purpose
+
+Reusable Ratatui widgets for layout, panels, lists, navigation, modal frames, banners, and empty states.
+
+## Ownership
+
+Each module owns one visual primitive. Callers supply state and layout bounds; components render without side effects.
+
+## Local Contracts
+
+- Use the active theme and the supplied `Rect`.
+- Keep components small and composable. Screen-level state selection belongs in the caller.
+- Preserve focus and selection styling so keyboard navigation remains legible.
+- Avoid terminal-size assumptions that conflict with the 60 by 20 fallback.
+
+## Verification
+
+```bash
+just e2e-tui
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-tui/src/ui/modals/AGENTS.md
+++ b/fido-tui/src/ui/modals/AGENTS.md
@@ -1,0 +1,25 @@
+# fido-tui/src/ui/modals
+
+## Purpose
+
+Rendering and composition for community, composer, help, notifications, post, and social overlays.
+
+## Ownership
+
+Each module renders its modal family. `mod.rs` exports modal renderers used by the screen composition layer.
+
+## Local Contracts
+
+- Modal state and key handling live in `app/`; this directory renders the state it receives.
+- Keep modal layout within the current terminal bounds and preserve Escape-based dismissal behavior.
+- Put a new modal's user-visible shortcuts in the help surface and its key handling in `app/handlers/`.
+
+## Verification
+
+```bash
+just e2e-tui
+```
+
+## Child DOX Index
+
+No child instruction files.

--- a/fido-types/AGENTS.md
+++ b/fido-types/AGENTS.md
@@ -1,0 +1,30 @@
+# fido-types
+
+## Purpose
+
+Shared serializable models, events, and enums used by the server and terminal client.
+
+## Ownership
+
+- `src/models.rs` owns domain entities and API payload types.
+- `src/events.rs` owns realtime event types.
+- `src/enums.rs` owns shared enum types.
+- `src/lib.rs` defines the public export surface.
+
+## Local Contracts
+
+- This crate is a public contract for both workspace consumers and crates.io users.
+- Preserve serde field names and enum encodings unless the server and client migration is deliberate and tested.
+- Prefer additive, backward-compatible changes. Document or version any unavoidable wire-format break.
+- Keep transport types free of server, terminal, database, or UI dependencies.
+
+## Verification
+
+```bash
+cargo test -p fido-types
+cargo package -p fido-types
+```
+
+## Child DOX Index
+
+- [`src/AGENTS.md`](src/AGENTS.md): source-level public type contracts.

--- a/fido-types/src/AGENTS.md
+++ b/fido-types/src/AGENTS.md
@@ -1,0 +1,30 @@
+# fido-types/src
+
+## Purpose
+
+Public shared domain types for HTTP payloads, persisted data projections, and realtime events.
+
+## Ownership
+
+- `models.rs` defines core entities and request or response payloads.
+- `events.rs` defines shared realtime messages.
+- `enums.rs` defines reusable enum values.
+- `lib.rs` re-exports the supported public surface.
+
+## Local Contracts
+
+- Derive and maintain the serialization traits required by both clients.
+- Keep identifiers, timestamps, optionals, and collection fields semantically consistent across server and TUI.
+- Add tests for changed serde behavior or enum representation.
+- Avoid exposing internal server persistence details as public types.
+
+## Verification
+
+```bash
+cargo test -p fido-types
+cargo package -p fido-types
+```
+
+## Child DOX Index
+
+No child instruction files.


### PR DESCRIPTION
## Summary

- add the DOX traversal contract and top-level index to the root guide
- add scoped AGENTS.md files for server, TUI, shared types, and their durable submodules
- record task 0018 as in progress

## Validation

- cargo fmt --check
- stint check
- just e2e-tui

No product behavior, release, or deployment changes.