### PR TITLE
Security & quality hardening sweep (stints 0025-0043)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: fmt + clippy + test
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout publishes major-version aliases; v4 is verified to exist.
+      - uses: actions/checkout@v4
+
+      - name: Install clippy and rustfmt
+        run: rustup component add clippy rustfmt
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace --features sqlite-tests

--- a/.stint/tasks/0025-authenticate-user-search-and-profile-read-endpoints.md
+++ b/.stint/tasks/0025-authenticate-user-search-and-profile-read-endpoints.md
@@ -1,0 +1,36 @@
+---
+id: "0025"
+title: "Authenticate user search and profile-read endpoints"
+status: todo
+priority: p2
+size: s
+created_at: "2026-07-11T05:26:19Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/api"
+tags:
+  - "security"
+---
+
+
+## Why
+
+Authentication is enforced per-handler via the `AuthenticatedUser` extractor; there is no global auth middleware (`fido-server/src/lib.rs:59-217`). Two read handlers forgot the extractor and are therefore fully anonymous:
+
+- `search_users` takes only `State` + `Query` (`fido-server/src/api/friends.rs:28`, routed `lib.rs:191`). `GET /users/search?q=a` substring-matches over `users.list_all()` (`services/friends.rs:52-78`) and returns id+username for every match. An anonymous client can dump the entire user table by iterating letters.
+- `get_profile` takes only `State` + `Path` (`fido-server/src/api/profile.rs:19`, routed `lib.rs:129`) and returns username, bio, karma, post_count, join_date for any user id with no login.
+
+Every other read endpoint (posts/chat/dms) enforces `AuthenticatedUser` plus membership. The deliberately-public profile variant already exists as `/users/:id/profile-view` using `OptionalUser` (`friends.rs:74`), which is what confirms these two were meant to be authenticated.
+
+## Done When
+
+- `search_users` requires `AuthenticatedUser`.
+- `get_profile` either requires `AuthenticatedUser`, or is deleted in favor of the existing `OptionalUser` `profile-view` handler (pick one; do not keep two profile endpoints with different auth).
+- A regression test asserts both endpoints return 401 without a valid `X-Session-Token`.
+- `cargo test -p fido-server --features sqlite-tests` passes.
+
+## References
+
+- Security audit 2026-07-11 (access-control + fido-server sweep), finding: unauthenticated user enumeration / profile disclosure.
+- `fido-server/src/api/friends.rs:28`, `fido-server/src/api/profile.rs:19`, routes at `fido-server/src/lib.rs:129,191`.

--- a/.stint/tasks/0026-fail-closed-library-router-drop-development-default.md
+++ b/.stint/tasks/0026-fail-closed-library-router-drop-development-default.md
@@ -1,0 +1,32 @@
+---
+id: "0026"
+title: "Fail-closed library router (drop Development default)"
+status: todo
+priority: p2
+size: s
+created_at: "2026-07-11T05:26:19Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server"
+tags:
+  - "security"
+---
+
+
+## Why
+
+`create_router()` does `SecurityConfig::from_env().unwrap_or_else(|_| SecurityConfig::default())` (`fido-server/src/lib.rs:33-38`). The default is `Environment::Development`, and `lib.rs:69-73` mounts the passwordless `/auth/login` and `/users/test` credential-free login routes whenever the environment is not production. So any consumer of this `pub` library function that runs without a valid `ENVIRONMENT` var silently gets the login bypass mounted.
+
+The shipped binary is safe (`main.rs:42-52` uses `create_router_with_security_config` and hard-exits on config failure), but this fail-open path directly contradicts the fail-closed design used everywhere else — `is_production_runtime` (`security/mod.rs:80-87`) treats unknown environments as production. The only current guard is a doc comment saying it is "for testing".
+
+## Done When
+
+- `create_router` no longer defaults to `Development` on config error: it either returns `Result<Router>` and propagates the error, or is gated behind `#[cfg(test)]` / a test-only feature so it cannot be reached in a normal build.
+- No non-test entry point can mount the passwordless login routes outside an explicitly-development environment.
+- `cargo test -p fido-server` passes; `cargo clippy --workspace --all-targets -- -D warnings` clean.
+
+## References
+
+- Security audit 2026-07-11 (auth), finding: library router falls back to Development security config (fail-open).
+- `fido-server/src/lib.rs:33-38`, test-route mount `fido-server/src/lib.rs:69-73`, fail-closed contrast `fido-server/src/security/mod.rs:80-87`.

--- a/.stint/tasks/0027-trustworthy-and-consistent-client-ip-resolution.md
+++ b/.stint/tasks/0027-trustworthy-and-consistent-client-ip-resolution.md
@@ -1,0 +1,38 @@
+---
+id: "0027"
+title: "Trustworthy and consistent client-IP resolution"
+status: todo
+priority: p2
+size: m
+created_at: "2026-07-11T05:26:19Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/http"
+  - "infra"
+tags:
+  - "security"
+---
+
+
+## Why
+
+The deploy path is client -> Railway edge -> nginx -> fido-server (two proxy hops), but IP handling assumes one, and two different extractors disagree:
+
+- nginx `limit_req_zone $binary_remote_addr` (`nginx.conf:17`) sees the Railway edge IP, so every external visitor shares one 10r/s bucket: a single abuser trips 503s site-wide, and there is no real per-client edge limiting.
+- `http::extract_client_ip` takes the right-most XFF entry (`fido-server/src/http/headers.rs:17-42`), which under two hops is the nginx-appended Railway edge IP. So all anonymous app-level rate keys and audit IPs collapse to the proxy IP. The "single trusted proxy" comment is wrong.
+- `security/admin.rs:19-30` takes the left-most XFF entry, which is fully attacker-forgeable, and it feeds admin-endpoint audit logs, so admin-action IP attribution can be spoofed.
+- If the app process is ever directly reachable, XFF is attacker-forgeable end to end and the anonymous IP rate limit is bypassable by rotating the header.
+
+## Done When
+
+- nginx resolves the real client IP from Railway's XFF (`set_real_ip_from <railway range>`, `real_ip_header X-Forwarded-For`, `real_ip_recursive on`) and keys `limit_req_zone` on the resolved IP.
+- All in-app IP extraction goes through one helper (`http::extract_client_ip`); `security/admin.rs` no longer uses the spoofable left-most entry. The helper reads only the nginx-validated hop (e.g. `X-Real-IP`) or counts hops against a trusted-proxy allowlist.
+- The single-instance assumption of the in-process HTTP limiter (`rate_limit.rs`) is documented, or the limiter is moved behind nginx `limit_req`; note that with >1 replica the in-process limit multiplies.
+- Verified the app port is not publicly reachable (only nginx listens externally).
+- Tests cover: forged left-most XFF does not change the resolved IP; audit log records the real client IP.
+
+## References
+
+- Security audit 2026-07-11 (deploy + HTTP + fido-server sweep), findings: rate limiting keyed to wrong hop; inconsistent/spoofable client-IP extraction; in-process limiter scope.
+- `nginx.conf:17`, `fido-server/src/http/headers.rs:17-42`, `fido-server/src/security/admin.rs:19-30`, `fido-server/src/rate_limit.rs:26-53`.

--- a/.stint/tasks/0028-split-demo-and-production-into-separate-deployments.md
+++ b/.stint/tasks/0028-split-demo-and-production-into-separate-deployments.md
@@ -1,0 +1,43 @@
+---
+id: "0028"
+title: "Split demo and production into separate deployments"
+status: todo
+priority: p2
+size: l
+created_at: "2026-07-11T05:26:19Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "infra"
+tags:
+  - "security"
+---
+
+
+## Why
+
+The installed TUI default server URL is `https://fido-web-production.up.railway.app` (`fido-tui/src/api/client.rs:70`) — the same deployment that runs the anonymous web-terminal demo. `start.sh:123-127` deletes the DB on every boot unless `FIDO_DEMO_EPHEMERAL=false`. So either:
+
+- Railway keeps the ephemeral default, and real users' accounts plus encrypted GitHub tokens are wiped on every deploy; or
+- Railway sets it false, and anonymous ttyd visitors drive a TUI against the persistent production DB.
+
+Both are wrong, and which one is live depends on unverifiable Railway env vars. The demo and the production API must not be the same service.
+
+## Scope
+
+- Demo deployment: hardcoded ephemeral DB, web mode, ttyd + nginx, no real user data.
+- Production API deployment: persistent volume, no ttyd, no anonymous terminal.
+- Point `DEFAULT_PUBLIC_SERVER_URL` / `client.rs` default at the API service, not the demo host.
+
+## Done When
+
+- Two distinct Railway services (or equivalent) exist: demo (ephemeral, ttyd) and production API (persistent `/data`, no ttyd).
+- Installed TUI default server URL points at the persistent API service.
+- Anonymous web-terminal visitors provably cannot reach the persistent production DB.
+- Deploy of the API service does not wipe the DB.
+- README/QUICKSTART/deploy docs updated to describe the two-service topology.
+
+## References
+
+- Security audit 2026-07-11 (deploy), finding: demo host doubles as production API; DB persistence env-dependent.
+- `start.sh:123-127`, `fido-tui/src/api/client.rs:70`, `start.sh:285-292` (ttyd).

--- a/.stint/tasks/0029-bound-websocket-resource-usage-per-user.md
+++ b/.stint/tasks/0029-bound-websocket-resource-usage-per-user.md
@@ -1,0 +1,34 @@
+---
+id: "0029"
+title: "Bound WebSocket resource usage per user"
+status: todo
+priority: p2
+size: m
+created_at: "2026-07-11T05:26:19Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/realtime"
+tags:
+  - "security"
+---
+
+
+## Why
+
+An authenticated user can exhaust server resources over WebSockets:
+
+- No per-user connection cap. `ConnectionRegistry::connect` only increments a counter (`fido-server/src/realtime.rs:48-72`); nothing rejects a user opening many simultaneous `/ws` connections. Each connection spawns a task plus a 256-slot broadcast receiver (`api/ws.rs:60-61`), so thousands of sockets exhaust memory/FDs. The global 100/min HTTP limiter counts the upgrade GET but not concurrent long-lived sockets.
+- No inbound message throttle or size bound. The server is send-only and silently discards inbound frames (`api/ws.rs:94-109`), but there is no rate limit or per-message size cap, so a client can stream large/rapid frames that the runtime still buffers and decodes (CPU/bandwidth DoS) before discarding them.
+
+## Done When
+
+- `ConnectionRegistry::connect` enforces a max concurrent connections per user (e.g. 5-10); over the limit, the upgrade is rejected / the socket closed with a policy-violation frame.
+- The upgrade sets `max_message_size`/`max_frame_size`, and the read loop closes the connection if inbound frame rate exceeds a threshold.
+- Tests cover: connection cap rejection; oversized/flooding inbound frames close the socket without unbounded buffering.
+- `cargo test -p fido-server --features sqlite-tests` passes.
+
+## References
+
+- Security audit 2026-07-11 (HTTP), findings: no per-connection cap on WebSocket clients; no inbound WS message throttle or size bound.
+- `fido-server/src/realtime.rs:48-72`, `fido-server/src/api/ws.rs:60-61,94-109`.

--- a/.stint/tasks/0030-add-missing-db-indexes-on-hot-query-paths.md
+++ b/.stint/tasks/0030-add-missing-db-indexes-on-hot-query-paths.md
@@ -1,0 +1,38 @@
+---
+id: "0030"
+title: "Add missing DB indexes on hot query paths"
+status: todo
+priority: p2
+size: s
+created_at: "2026-07-11T05:26:19Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/db"
+tags:
+  - "performance"
+---
+
+
+## Why
+
+Three hot queries full-scan as data grows because the supporting index is missing:
+
+- memberships: PK is `(community_id, user_id)`, so `WHERE user_id = ?` cannot use it. `list_for_user` and `users_share_community` full-scan `memberships` (`fido-server/src/db/repositories/membership_repository.rs:100-101,113-116`); the latter runs on every DM send (`services/dms.rs:287`).
+- posts: `get_post_count` and `calculate_karma` filter on `author_id` with no index (`post_repository.rs:207`, `vote_repository.rs:78-81`); both run per profile view. `posts` is the largest table and every FK is indexed except `author_id`.
+- notifications: pagination `ORDER BY created_at DESC LIMIT ? OFFSET ?` (`notification_repository.rs:52-55`) has only `idx_notifications_user_read (user_id, read)`, so every page temp-sorts the user's notifications; deep OFFSET pages get progressively worse.
+
+## Done When
+
+- `SCHEMA` adds: `idx_memberships_user_id ON memberships(user_id)`, `idx_posts_author_id ON posts(author_id)`, `idx_notifications_user_created ON notifications(user_id, created_at DESC)`.
+- An `EXPLAIN QUERY PLAN` test (matching the existing feed test at `post_repository.rs:492-535`) asserts these queries use the new indexes and do no temp B-tree sort.
+- `cargo test -p fido-server --features sqlite-tests` passes.
+
+## Gotchas
+
+- Consider cursor pagination for notifications (as `MessageRepository` already does) instead of OFFSET, but the index is the minimum fix.
+
+## References
+
+- Performance audit 2026-07-11 (DB), findings: missing indexes on memberships(user_id), posts(author_id), notifications ordering.
+- `fido-server/src/db/schema.rs:93-101,118`.

--- a/.stint/tasks/0031-eliminate-feed-and-dm-n-1-query-patterns.md
+++ b/.stint/tasks/0031-eliminate-feed-and-dm-n-1-query-patterns.md
@@ -1,0 +1,39 @@
+---
+id: "0031"
+title: "Eliminate feed and DM N+1 query patterns"
+status: todo
+priority: p2
+size: m
+created_at: "2026-07-11T05:26:19Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/db"
+tags:
+  - "performance"
+---
+
+
+## Why
+
+List endpoints issue one query per row:
+
+- Feed vote lookups: `populate_posts` loops `get_vote(uid, post.id)` per post (`fido-server/src/services/posts.rs:445-450` over `vote_repository.rs:47-72`). A 50-post feed issues 50 queries, each checking out its own pooled connection. Same for reply trees.
+- DM conversation list: `get_conversation_summaries` returns only `other_user_id`, then the service loops `users.get_by_id` + `dm_conversations.get` per conversation (`services/dms.rs:44-57` over `dm_repository.rs:110-172`) — 2 extra queries each.
+
+## Done When
+
+- A batch vote method (`get_votes_for_posts(user_id, &[Uuid])`, one query with a generated `IN (?, ?, ...)` placeholder list, values bound) or a LEFT JOIN on the authenticated user replaces the per-post loop in `populate_posts` (and reply trees).
+- `get_conversation_summaries` JOINs `users.username` and `dm_conversations.state` so the service no longer loops.
+- A test asserts feed/conversation-list render issues O(1) queries, not O(n).
+- `cargo test -p fido-server --features sqlite-tests` passes.
+
+## Gotchas
+
+- Keep placeholders generated but values bound — do not interpolate ids into SQL.
+- Batchable with the index task (both touch the DB layer); can land in one PR.
+
+## References
+
+- Performance audit 2026-07-11 (DB), findings: N+1 vote lookups on feed; N+1 in DM conversation list.
+- `fido-server/src/services/posts.rs:445-450`, `fido-server/src/services/dms.rs:44-57`.

--- a/.stint/tasks/0032-enforce-membership-on-community-roster-and-metadata-reads.md
+++ b/.stint/tasks/0032-enforce-membership-on-community-roster-and-metadata-reads.md
@@ -1,0 +1,40 @@
+---
+id: "0032"
+title: "Enforce membership on community roster and metadata reads"
+status: todo
+priority: p3
+size: s
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/api"
+tags:
+  - "security"
+---
+
+
+## Why
+
+Any authenticated user can read a community's full member roster (with roles) and metadata for a community they do not belong to:
+
+- `list_members` binds `AuthenticatedUser(_user_id)` but discards the id and never checks membership (`fido-server/src/api/communities.rs:146`).
+- `get_community` -> `get_view` returns roster + metadata + channel names with no membership check (`api/communities.rs:120` -> `services/communities.rs:99`).
+
+Impact is bounded (communities map to public GitHub repos; channel messages still require membership via `chat.rs`), so this is roster/metadata disclosure, not message access.
+
+## Done When
+
+- `list_members` calls `require_membership(user_id, community_id)` (stop discarding the id).
+- `get_view` (or `get_community`) checks membership before returning roster/channels.
+- Tests assert a non-member gets 403 on both endpoints and a member gets 200.
+- `cargo test -p fido-server --features sqlite-tests` passes.
+
+## Gotchas
+
+- Batchable with the "Authenticate user search and profile-read endpoints" task (same api layer, same `require_*` pattern).
+
+## References
+
+- Security audit 2026-07-11 (access-control), finding: community metadata and member roster exposed to non-members.
+- `fido-server/src/api/communities.rs:120,146`, `fido-server/src/services/communities.rs:99`.

--- a/.stint/tasks/0033-reject-self-votes-and-scope-mention-notifications-to-members.md
+++ b/.stint/tasks/0033-reject-self-votes-and-scope-mention-notifications-to-members.md
@@ -1,0 +1,34 @@
+---
+id: "0033"
+title: "Reject self-votes and scope mention notifications to members"
+status: todo
+priority: p3
+size: s
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/posts"
+tags:
+  - "security"
+---
+
+
+## Why
+
+Two content-integrity gaps in the posts service:
+
+- Self-voting inflates karma. `record_vote` checks visibility/membership but never compares `post.author_id` to the voter (`fido-server/src/services/posts.rs:357-374`); `calculate_karma` counts all up-votes on a user's posts (`vote_repository.rs:75-86`), so a user can upvote their own posts to inflate karma. (Counts cannot be forged and multi-vote is deduped by the upsert.)
+- Mentions notify arbitrary users. `notify_mentions` resolves every `@username` to any existing user regardless of community membership (`services/posts.rs:507-521`, called from `create_post` `posts.rs:343`), so a member can @-mention users outside the community and generate cross-community notification spam.
+
+## Done When
+
+- `record_vote` rejects a vote where `post.author_id == user_id` (BadRequest), or `calculate_karma` excludes self-votes.
+- `notify_mentions` only notifies mentioned users who are members of `post.community_id`.
+- Tests cover: self-upvote rejected/uncounted; mention of a non-member produces no notification.
+- `cargo test -p fido-server --features sqlite-tests` passes.
+
+## References
+
+- Security audit 2026-07-11 (access-control), findings: self-voting inflates karma; mention notifications not scoped to community membership.
+- `fido-server/src/services/posts.rs:357-374,507-521`.

--- a/.stint/tasks/0034-harden-tui-session-token-handling.md
+++ b/.stint/tasks/0034-harden-tui-session-token-handling.md
@@ -1,0 +1,36 @@
+---
+id: "0034"
+title: "Harden TUI session-token handling"
+status: todo
+priority: p3
+size: s
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "tui"
+tags:
+  - "security"
+---
+
+
+## Why
+
+The terminal client leaks or under-protects the session token in three ways:
+
+- Temp-file permission window. `session.rs:save` creates the temp file with `fs::File::create` (process umask, typically 0644), writes the plaintext token, and only sets 0600 before the atomic rename (`fido-tui/src/session.rs:145-170`). On a shared host the token is briefly world-readable.
+- No HTTPS enforcement. The token is sent in `X-Session-Token` over whatever scheme the base URL uses; the built-in default is HTTPS (`api/client.rs:70`) but `FIDO_SERVER_URL` / `~/.fido/server_url` can point at plaintext `http://` with no guard (`api/client.rs:155-161`), leaking the token on the wire.
+- Verbose logging writes the token to a plaintext file. With `--verbose`, tungstenite's TRACE handshake dump includes `x-session-token: <uuid>` written to `fido_debug.log` in the cwd (`fido-tui/src/logging.rs:39`). A stray `fido_debug.log` containing a real token already exists in the repo working dir (untracked).
+
+## Done When
+
+- The session temp file is created with `OpenOptions::new().write(true).create_new(true).mode(0o600)` so it is never group/other-readable.
+- Attaching the token to a non-loopback, non-`https://` base URL is refused (or warns loudly and requires opt-in).
+- Third-party crates are capped below TRACE (e.g. `tungstenite=info`) or the auth header is redacted; the log file is created 0600.
+- The stray working-dir `fido_debug.log` is deleted (it is gitignored, so cleanup only).
+- `cargo test -p fido-tui` passes.
+
+## References
+
+- Security audit 2026-07-11 (access-control + deploy), findings: session-token temp file window; no HTTPS enforcement; verbose logging leaks token.
+- `fido-tui/src/session.rs:145-170`, `fido-tui/src/api/client.rs:70,155-161`, `fido-tui/src/logging.rs:39`.

--- a/.stint/tasks/0035-make-multi-statement-writes-transactional-and-user-creation-idempotent.md
+++ b/.stint/tasks/0035-make-multi-statement-writes-transactional-and-user-creation-idempotent.md
@@ -1,0 +1,36 @@
+---
+id: "0035"
+title: "Make multi-statement writes transactional and user creation idempotent"
+status: todo
+priority: p3
+size: m
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/db"
+tags:
+  - "reliability"
+---
+
+
+## Why
+
+No repository exposes a transaction; every multi-step write runs on separately-checked-out pool connections, so a crash mid-sequence corrupts state:
+
+- Vote write: `upsert_vote` then `update_vote_counts` on two connections (`fido-server/src/services/posts.rs:370-371`). A crash between them leaves `posts.upvotes/downvotes` permanently stale — nothing reconciles.
+- DM soft-delete: two sequential `UPDATE`s (`dm_repository.rs:188-211`); failure between them leaves the conversation half-hidden.
+- User creation: `get_or_create_system_user` and `create_or_update_from_github` do SELECT-then-INSERT on separate connections (`user_repository.rs:99-114,147-184`). Concurrent OAuth callbacks for a new user hit the `username UNIQUE` / `github_id` constraint and 500 instead of returning the existing user; separately, a new GitHub login that collides with an existing (stale) username can never sign up.
+
+## Done When
+
+- A repository transaction primitive exists (`conn.transaction()`), and the vote write and DM soft-delete each run both statements in one transaction.
+- User creation uses `INSERT ... ON CONFLICT DO NOTHING` then re-select (matching the existing upsert pattern for votes/configs/tokens); username collisions are disambiguated instead of 500ing.
+- The misleading DM request-state error message ("Only the request recipient...") at `services/dms.rs:231-235` is corrected to match the actual guard.
+- Tests cover: crash/rollback leaves no half-written vote or DM state; concurrent new-user creation returns one row, no 500.
+- `cargo test -p fido-server --features sqlite-tests` passes.
+
+## References
+
+- Security/DB audit 2026-07-11, findings: non-atomic vote write; non-atomic DM soft-delete; check-then-insert user races; signup 500 on username collision; DM error message mismatch.
+- `fido-server/src/services/posts.rs:370-371`, `fido-server/src/db/repositories/dm_repository.rs:188-211`, `fido-server/src/db/repositories/user_repository.rs:99-114,147-184`.

--- a/.stint/tasks/0036-fix-in-memory-test-pool-and-stop-swallowing-migration-errors.md
+++ b/.stint/tasks/0036-fix-in-memory-test-pool-and-stop-swallowing-migration-errors.md
@@ -1,0 +1,34 @@
+---
+id: "0036"
+title: "Fix in-memory test pool and stop swallowing migration errors"
+status: todo
+priority: p3
+size: s
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/db"
+tags:
+  - "reliability"
+---
+
+
+## Why
+
+Two connection-setup defects in `fido-server/src/db/connection.rs`:
+
+- `SqliteConnectionManager::memory()` (`connection.rs:130-131`) opens an independent `:memory:` database per pooled connection. `initialize()` runs the schema on one connection; tests pass only because single-threaded r2d2 hands back the same idle connection. Any concurrent use of `Database::in_memory()` sees empty databases.
+- Every migration is `let _ = conn.execute(...)` to tolerate "duplicate column" on re-run (`connection.rs:151-218`), which also masks genuine failures (disk full, locked DB, malformed schema), surfacing later as confusing errors far from the cause.
+
+## Done When
+
+- The in-memory pool shares one database across connections (`file:fido_mem?mode=memory&cache=shared` with URI flags) or is capped at `max_size(1)`.
+- Migrations inspect the error and ignore only `duplicate column name`, propagating everything else; longer term gate on `PRAGMA user_version`.
+- A test exercises the in-memory pool across >1 connection and sees the schema.
+- `cargo test -p fido-server --features sqlite-tests` passes.
+
+## References
+
+- DB audit 2026-07-11, findings: in-memory pool gives each connection a distinct database; migration errors silently swallowed.
+- `fido-server/src/db/connection.rs:130-131,151-218`.

--- a/.stint/tasks/0037-harden-github-integration-token-revocation-contributor-check-username-drift.md
+++ b/.stint/tasks/0037-harden-github-integration-token-revocation-contributor-check-username-drift.md
@@ -1,0 +1,36 @@
+---
+id: "0037"
+title: "Harden GitHub integration: token revocation, contributor check, username drift"
+status: todo
+priority: p3
+size: s
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server"
+tags:
+  - "security"
+---
+
+
+## Why
+
+Three GitHub-identity gaps:
+
+- Token revocation silently skipped. `try_revoke_remote_token` returns early with only a `tracing::debug!` if `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` are missing (`fido-server/src/services/github.rs:373-383`). Production startup never requires the client secret, so logout deletes the local ciphertext but leaves the GitHub grant live indefinitely, with nothing above debug level saying so.
+- Contributor check on stale, case-sensitive username. Community-join Contributor role compares the repo contributors list against the local `users.username` (`github.rs:257-274`, `user_repository.rs:156-165`), but `username` is frozen at first signup while only `github_login` updates on re-login, and the compare is case-sensitive though GitHub logins are not. After a rename+recycle the wrong user can match.
+- `username` never updated on GitHub rename (`user_repository.rs:147-165`), the root cause of the above and of stale display identity.
+
+## Done When
+
+- Production startup requires `GITHUB_CLIENT_SECRET` (same fail-fast block as `validate_token_key`), or at minimum the revocation skip logs at warn level.
+- The contributor check compares against the current `github_login` case-insensitively (or verifies via an authenticated GitHub collaborators call).
+- `create_or_update_from_github` updates `username`/display identity on GitHub rename.
+- Tests cover: revocation attempted when secret present; case-insensitive contributor match; rename updates the stored login.
+- `cargo test -p fido-server` passes.
+
+## References
+
+- Security audit 2026-07-11 (auth + fido-server sweep), findings: token revocation skipped when secret unset; is_contributor trusts stale case-sensitive username; username drift on rename.
+- `fido-server/src/services/github.rs:257-274,373-383`, `fido-server/src/db/repositories/user_repository.rs:147-165`.

--- a/.stint/tasks/0038-resolve-dead-and-vestigial-server-config-and-endpoints.md
+++ b/.stint/tasks/0038-resolve-dead-and-vestigial-server-config-and-endpoints.md
@@ -1,0 +1,37 @@
+---
+id: "0038"
+title: "Resolve dead and vestigial server config and endpoints"
+status: todo
+priority: p3
+size: s
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server"
+tags:
+  - "security"
+---
+
+
+## Why
+
+Three pieces of the server are half-wired: present but unused, which is misleading attack surface and dead config.
+
+- Session cookie set but never read. Login sets an `HttpOnly; SameSite=Strict; Secure` cookie (`fido-server/src/security/cookies.rs:62-74`, `api/auth.rs:149-150,423-424`), but every extractor authenticates only from `X-Session-Token` (`http/auth.rs`, `api/ws.rs`). The cookie is a real session token that no code trusts today — dead surface if any future handler starts reading it, and it means browser clients keep the token in JS-accessible storage anyway.
+- `max_request_size` config ignored. `SecurityConfig.max_request_size` is parsed/validated (`security/mod.rs:162-165,244-249`) but the router hardcodes `RequestBodyLimitLayer::new(1024*1024)` (`lib.rs:216`). Tuning `MAX_REQUEST_SIZE` silently does nothing.
+- Global-admin endpoints unreachable in prod. `is_admin` is only ever set by seed data for `alice` (`db/schema.rs:264-265`), and seeding is skipped in production, so `/auth/cleanup-sessions` and `/admin/config/validate` (`lib.rs:79-95`) have no reachable caller in prod. Fail-closed (safe) but the admin surface is dead with no supported grant path.
+
+## Done When
+
+- Decide per item: either wire it up or remove it, no vestigial middle state.
+  - Cookie: either the server also accepts the session cookie (CSRF covered by SameSite=Strict + header requirement) so browser clients never touch the raw token, or the cookie is removed.
+  - `max_request_size`: the body-limit layer uses the configured value.
+  - Global admin: either a supported production grant path exists, or the dead endpoints are removed.
+- Tests reflect the chosen behavior.
+- `cargo test -p fido-server` passes; clippy clean.
+
+## References
+
+- Security audit 2026-07-11 (auth + fido-server sweep), findings: unused session cookie; ignored max_request_size; dead global-admin endpoints.
+- `fido-server/src/security/cookies.rs:62-74`, `fido-server/src/lib.rs:79-95,216`, `fido-server/src/security/mod.rs:162-165`.

--- a/.stint/tasks/0039-pin-dockerfile-base-images-by-digest.md
+++ b/.stint/tasks/0039-pin-dockerfile-base-images-by-digest.md
@@ -1,0 +1,30 @@
+---
+id: "0039"
+title: "Pin Dockerfile base images by digest"
+status: todo
+priority: p3
+size: s
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "infra"
+tags:
+  - "security"
+---
+
+
+## Why
+
+The runtime `FROM` lines use mutable tags: `rust:1.91-bookworm` and `debian:bookworm-slim` (`Dockerfile:6,20`). Builds are not reproducible and a registry-side tag change silently alters the deployed image. This is inconsistent with the care already taken to SHA-256-pin the ttyd binary in the same Dockerfile.
+
+## Done When
+
+- Both `FROM` lines are pinned with `@sha256:` digests.
+- A comment records how to refresh the digest (or a justfile target does it).
+- The image still builds and deploys.
+
+## References
+
+- Security audit 2026-07-11 (deploy), finding: runtime base images pinned by tag, not digest.
+- `Dockerfile:6,20`.

--- a/.stint/tasks/0040-xss-defense-in-depth-output-encoding-over-input-denylist.md
+++ b/.stint/tasks/0040-xss-defense-in-depth-output-encoding-over-input-denylist.md
@@ -1,0 +1,30 @@
+---
+id: "0040"
+title: "XSS defense-in-depth: output encoding over input denylist"
+status: todo
+priority: p4
+size: s
+created_at: "2026-07-11T05:26:20Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/security"
+tags:
+  - "security"
+---
+
+
+## Why
+
+`contains_dangerous_patterns` (`fido-server/src/security/validation.rs:216-267`) is an input denylist (script tags, `on*=`, `javascript:`). Denylists are trivially bypassable (`<svg>`, `<iframe>`, `<img src=x>`, mixed encodings, HTML injection without an event handler). It is safe today only because the server never renders user content into HTML/SVG (the badge interpolates only an `i64`). The risk is false confidence: any future server- or client-side HTML render of stored content would be XSS-prone despite this check.
+
+## Done When
+
+- The denylist is documented in-code as non-authoritative defense-in-depth, not the XSS boundary.
+- XSS safety is guaranteed by contextual output encoding at every render sink (the web client escapes on insert); this is verified for the current `../web` client.
+- A short note in the security AGENTS.md states: do not add render paths that trust the input filter.
+
+## References
+
+- Security audit 2026-07-11 (HTTP), finding: XSS protection is an input blocklist, not output encoding.
+- `fido-server/src/security/validation.rs:216-267`.

--- a/.stint/tasks/0041-enforce-rust-lints-via-workspace-lints-and-ci.md
+++ b/.stint/tasks/0041-enforce-rust-lints-via-workspace-lints-and-ci.md
@@ -1,0 +1,37 @@
+---
+id: "0041"
+title: "Enforce Rust lints via workspace.lints and CI"
+status: todo
+priority: p2
+size: s
+created_at: "2026-07-11T05:29:08Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "workspace"
+  - "ci"
+tags:
+  - "code-quality"
+---
+
+
+## Why
+
+README documents `cargo clippy --workspace --all-targets --all-features -- -D warnings`, but there is no `[workspace.lints]` table in any `Cargo.toml` and `.github/` is empty, so nothing enforces it: the "clippy-clean" state rests entirely on manual discipline, and pedantic/nursery lints never run. A README command nobody runs is not enforcement. Clippy does currently pass clean, so this locks in a good state rather than fixing a broken one.
+
+## Done When
+
+- Root `Cargo.toml` has `[workspace.lints.clippy]` (at least `all = "deny"`, `pedantic = "warn"`), and each crate opts in with `[lints] workspace = true`.
+- The `redundant_clone` and (optionally) `unwrap_used` restriction lints are enabled at warn so real needless clones / prod unwraps surface (see the clone-density note in the Rust audit).
+- A CI workflow (`.github/workflows/`) runs `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace` on push and PR.
+- CI is green on `main`.
+
+## Gotchas
+
+- Turning on pedantic may surface existing nits; cherry-pick/allow the noisy ones rather than blanket-disabling the group.
+- Pin GitHub Action versions by verified tag (per repo convention: not all actions publish major-version aliases).
+
+## References
+
+- Rust conventions audit 2026-07-11, finding: no lint enforcement (Cargo.toml + missing .github/).
+- Updated skill: /Users/ianburke/.claude/skills/rust-best-practices/SKILL.md (Linting section).

--- a/.stint/tasks/0042-remove-allow-dead-code-on-the-unwired-v2-repository-layer.md
+++ b/.stint/tasks/0042-remove-allow-dead-code-on-the-unwired-v2-repository-layer.md
@@ -1,0 +1,35 @@
+---
+id: "0042"
+title: "Remove allow(dead_code) on the unwired v2 repository layer"
+status: todo
+priority: p3
+size: s
+created_at: "2026-07-11T05:29:08Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server/db"
+tags:
+  - "code-quality"
+---
+
+
+## Why
+
+Seven repository files crate-suppress dead-code warnings for an unwired "v2 repository" API:
+
+`#![allow(dead_code)]` at line 1 of `fido-server/src/db/repositories/{mod,community,membership,dm_conversation,channel,message,notification}_repository.rs`.
+
+This directly violates the project's own convention (no `#[allow(dead_code)]`: delete, wire up, or feature-flag). The suppression hides how much of the v2 layer is actually reachable and lets genuinely-dead code accumulate silently.
+
+## Done When
+
+- Every `#![allow(dead_code)]` in those seven files is removed.
+- Each item is resolved: wired into a real call path, deleted, or gated behind an explicit feature flag (e.g. `#[cfg(feature = "v2-repos")]`) that is documented.
+- `cargo build --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` are clean with no dead-code allow.
+- `cargo test --workspace` passes.
+
+## References
+
+- Rust conventions audit 2026-07-11, finding: `#![allow(dead_code)]` papering over unfinished v2 layer.
+- `fido-server/src/db/repositories/mod.rs:1` and six sibling `_repository.rs` files.

--- a/.stint/tasks/0043-rust-idiom-cleanup-real-error-types-and-infallible-header-values.md
+++ b/.stint/tasks/0043-rust-idiom-cleanup-real-error-types-and-infallible-header-values.md
@@ -1,0 +1,36 @@
+---
+id: "0043"
+title: "Rust idiom cleanup: real error types and infallible header values"
+status: todo
+priority: p4
+size: s
+created_at: "2026-07-11T05:29:08Z"
+blocked_by: []
+gh_issue: []
+area:
+  - "server"
+  - "tui"
+tags:
+  - "code-quality"
+---
+
+
+## Why
+
+A few non-idiomatic spots flagged by the Rust audit (no crashes today, but they cost composability and route infallible work through fallible paths):
+
+- Server `ApiError` is not a real error type. `pub enum ApiError` derives only `Debug` (`fido-server/src/api/error.rs:15`) — no `Display`/`std::error::Error` — so it cannot compose with `?` / `Box<dyn Error>`. The TUI's `ApiError` already uses `thiserror` correctly, so this is inconsistent.
+- Stringly-typed error. `session_restore_task: Option<JoinHandle<Result<Option<RestoredSession>, String>>>` (`fido-tui/src/event_loop.rs:21`) uses `String` as the error type instead of the existing error enum.
+- Infallible conversions via `.parse().unwrap()`. Static security-header values are built with `"DENY".parse().unwrap()` etc. (`fido-server/src/security/headers.rs:54,58,62,70,77,85`).
+
+## Done When
+
+- Server `ApiError` derives `#[derive(Debug, thiserror::Error)]` with a `#[error(...)]` per variant, and `#[non_exhaustive]`; existing conversions/usages still compile.
+- `event_loop.rs` session-restore error type is the real error enum, not `String`.
+- The static header inserts use `HeaderValue::from_static(...)` (no `parse`, no `unwrap`).
+- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` passes.
+
+## References
+
+- Rust conventions audit 2026-07-11, findings: server ApiError not a real error type; stringly-typed error; static header values via `.parse().unwrap()`.
+- `fido-server/src/api/error.rs:15`, `fido-tui/src/event_loop.rs:21`, `fido-server/src/security/headers.rs:54-85`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,63 @@ aes-gcm-siv = "0.11"
 
 # Internal workspace crates
 fido-types = { path = "fido-types", version = "0.5.4" }
+
+# Workspace-wide lint policy. Each crate opts in with `[lints] workspace = true`.
+# CI runs `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
+# so anything at `warn` here is a hard failure in CI.
+[workspace.lints.clippy]
+# The core groups (correctness/suspicious/style/complexity/perf) are denied: the
+# codebase is already clean against them, so this locks that state in.
+all = { level = "deny", priority = -1 }
+# Pedantic is enabled at warn to surface higher-signal issues in new code. The
+# group has lower priority so the individual `allow`s below win. The allowed
+# lints are the opinionated/stylistic ones that currently fire across the tree;
+# they were reviewed and judged not worth the churn, per the lint-enforcement
+# stint. Prefer fixing a new pedantic hit over adding it here.
+pedantic = { level = "warn", priority = -1 }
+# Surface real needless clones (0 today, so this is free and forward-looking).
+redundant_clone = "warn"
+# --- Allowed pedantic lints (noise / opinionated) ---
+assigning_clones = "allow"
+bool_to_int_with_if = "allow"
+cast_lossless = "allow"
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_precision_loss = "allow"
+cast_sign_loss = "allow"
+case_sensitive_file_extension_comparisons = "allow"
+doc_markdown = "allow"
+explicit_iter_loop = "allow"
+format_collect = "allow"
+if_not_else = "allow"
+ignored_unit_patterns = "allow"
+items_after_statements = "allow"
+manual_let_else = "allow"
+map_unwrap_or = "allow"
+match_same_arms = "allow"
+match_wildcard_for_single_variants = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+needless_continue = "allow"
+needless_pass_by_value = "allow"
+needless_raw_string_hashes = "allow"
+range_plus_one = "allow"
+redundant_closure_for_method_calls = "allow"
+redundant_else = "allow"
+return_self_not_must_use = "allow"
+semicolon_if_nothing_returned = "allow"
+similar_names = "allow"
+single_match_else = "allow"
+struct_excessive_bools = "allow"
+too_many_lines = "allow"
+trivially_copy_pass_by_ref = "allow"
+uninlined_format_args = "allow"
+unnecessary_debug_formatting = "allow"
+unnecessary_wraps = "allow"
+unnested_or_patterns = "allow"
+unreadable_literal = "allow"
+unused_async = "allow"
+unused_self = "allow"
+wildcard_imports = "allow"

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ COPY --from=builder /app/target/release/fido /usr/local/bin/fido
 
 # Copy configuration files
 COPY nginx.conf /etc/nginx/nginx.conf.template
+COPY nginx-api.conf /etc/nginx/nginx-api.conf.template
 COPY start.sh /usr/local/bin/start.sh
 
 # Copy web assets
@@ -70,6 +71,10 @@ ENV PORT=8080
 # Internal API listener (fido-server) behind nginx.
 ENV FIDO_SERVER_PORT=3000
 ENV TTYD_PORT=7681
+# Deployment mode: `demo` (default) runs the public web terminal; the persistent
+# API service overrides this to `api` (and mounts a volume at /data). One image,
+# two Railway services — see docs/DEPLOY.md.
+ENV FIDO_DEPLOY_MODE=demo
 ENV DATABASE_PATH=/tmp/fido-web-demo.db
 ENV LOG_DIR=/var/log/fido
 ENV RUST_LOG=info

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,16 @@
 
 # Stage 1: Build Rust binaries
 # Keep builder/runtime on the same Debian generation to avoid glibc ABI mismatch.
-FROM rust:1.91-bookworm as builder
+#
+# Base images are pinned by multi-arch manifest digest so builds are reproducible
+# and a registry-side tag change cannot silently alter the deployed image (same
+# care as the ttyd SHA-256 pin below). To refresh a digest, query the registry:
+#   TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/rust:pull" | sed -E 's/.*"token":"([^"]+)".*/\1/')
+#   curl -sI -H "Authorization: Bearer $TOKEN" \
+#     -H "Accept: application/vnd.oci.image.index.v1+json" \
+#     https://registry-1.docker.io/v2/library/rust/manifests/1.91-bookworm \
+#     | tr -d '\r' | grep -i '^docker-content-digest:'
+FROM rust:1.91-bookworm@sha256:c1e5f19e773b7878c3f7a805dd00a495e747acbdc76fb2337a4ebf0418896b33 as builder
 
 WORKDIR /app
 
@@ -17,7 +26,9 @@ COPY fido-tui ./fido-tui
 RUN cargo build --release --bin fido-server --bin fido
 
 # Stage 2: Runtime image
-FROM debian:bookworm-slim
+# Pinned by digest (see the refresh command above; use repository library/debian
+# and tag bookworm-slim).
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 
 # Install runtime dependencies
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -157,7 +157,20 @@ just e2e-tui
 
 ## Deploy
 
-Fido deploys on Railway from `main`. The web deployment runs nginx, ttyd, the TUI, and the API server. SQLite lives on a persistent Railway volume.
+Fido deploys on Railway from `main` as **two separate services** built from the
+same image, selected by `FIDO_DEPLOY_MODE`:
+
+- **demo** (`FIDO_DEPLOY_MODE=demo`, the default): the public web terminal —
+  nginx, ttyd, the TUI, and fido-server against an **ephemeral** SQLite DB that
+  is reset on every boot. No real user data ever lives here.
+- **api** (`FIDO_DEPLOY_MODE=api`): the persistent API service — fido-server
+  behind an API-only nginx, backed by a persistent volume at `/data`, with **no
+  ttyd and no anonymous terminal**. The installed TUI's default server URL
+  points here.
+
+Keeping them separate means a demo redeploy never wipes real accounts, and
+anonymous demo visitors can never reach the persistent DB. See
+[docs/DEPLOY.md](docs/DEPLOY.md) for the full topology and per-service variables.
 
 Manual deploy:
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -40,6 +40,11 @@ Variables:
 - `FIDO_TOKEN_KEY`
 - `ENVIRONMENT=production`
 - `RUST_LOG`
+- `MAX_REQUEST_SIZE` (optional, bytes; defaults to 1 MiB) — the request body
+  limit is enforced from this value.
+- `FIDO_ADMIN_LOGINS` (optional) — comma-separated GitHub logins granted access
+  to the admin endpoints (`/auth/cleanup-sessions`, `/admin/config/validate`).
+  This is the supported production grant path; seed-data admins are dev-only.
 - Persistent volume mounted at `/data`.
 
 ## Client default

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,63 @@
+# Deployment topology
+
+Fido runs as **two separate Railway services** built from the same Docker image.
+The service's role is selected at runtime by the `FIDO_DEPLOY_MODE` environment
+variable, read by `start.sh`.
+
+Splitting them is a security requirement, not an optimization: the demo resets
+its database on every boot, so if the demo and the persistent API shared one
+service, either real accounts (and their encrypted GitHub tokens) would be wiped
+on every deploy, or anonymous web-terminal visitors would be driving a TUI
+against the production database. Neither is acceptable.
+
+## Service 1 — Demo web terminal (`FIDO_DEPLOY_MODE=demo`)
+
+- Runs nginx + ttyd + the TUI + fido-server (see `nginx.conf`).
+- Database is **ephemeral**: `start.sh` deletes it on every boot unless
+  `FIDO_DEMO_EPHEMERAL=false` (do **not** set that here).
+- Serves the landing page and the anonymous browser terminal.
+- Holds **no real user data**. No persistent volume.
+- This is the default mode, so no `FIDO_DEPLOY_MODE` override is required, though
+  setting it explicitly to `demo` is recommended for clarity.
+
+Variables: `GITHUB_CLIENT_ID`, `FIDO_TOKEN_KEY`, `RUST_LOG`.
+
+## Service 2 — Persistent API (`FIDO_DEPLOY_MODE=api`)
+
+- Runs fido-server behind an **API-only** nginx (`nginx-api.conf`): real
+  client-IP resolution and edge rate limiting, but **no ttyd**, no anonymous
+  terminal, and no static demo site.
+- Mounts a **persistent Railway volume at `/data`**; the SQLite DB lives at
+  `/data/fido.db` and is **never wiped** on deploy.
+- This is the host the installed TUI talks to by default
+  (`DEFAULT_PUBLIC_SERVER_URL` in `fido-tui/src/api/client.rs`).
+
+Variables:
+
+- `FIDO_DEPLOY_MODE=api`
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET` (required in production; see the GitHub integration)
+- `FIDO_TOKEN_KEY`
+- `ENVIRONMENT=production`
+- `RUST_LOG`
+- Persistent volume mounted at `/data`.
+
+## Client default
+
+The installed TUI defaults to the **API** service
+(`https://fido-api-production.up.railway.app`), not the demo host. Override with
+`FIDO_SERVER_URL` or `~/.fido/server_url`.
+
+## MANUAL FOLLOW-UP (cannot be done from the repo)
+
+The second Railway service must be created in the Railway dashboard:
+
+1. Create a new Railway service from the same repo/image as the demo.
+2. Set `FIDO_DEPLOY_MODE=api`, `ENVIRONMENT=production`, `GITHUB_CLIENT_ID`,
+   `GITHUB_CLIENT_SECRET`, and `FIDO_TOKEN_KEY`.
+3. Attach a persistent volume mounted at `/data`.
+4. Point `https://fido-api-production.up.railway.app` (or the chosen API domain)
+   at this service; update `DEFAULT_PUBLIC_SERVER_URL` if the domain differs.
+5. Verify the demo service has **no** persistent volume and still resets its DB.
+6. Verify fido-server's internal port (3000) is not publicly reachable on either
+   service — only nginx listens on the external port.

--- a/fido-server/Cargo.toml
+++ b/fido-server/Cargo.toml
@@ -45,3 +45,6 @@ sha2 = "0.10"
 [dev-dependencies]
 tokio-tungstenite = "0.24"
 futures-util = "0.3"
+
+[lints]
+workspace = true

--- a/fido-server/src/api/communities.rs
+++ b/fido-server/src/api/communities.rs
@@ -145,11 +145,11 @@ pub async fn claim_community(
 /// GET /communities/:id/members - List a community's members, admins first
 pub async fn list_members(
     State(state): State<AppState>,
-    AuthenticatedUser(_user_id): AuthenticatedUser,
+    AuthenticatedUser(user_id): AuthenticatedUser,
     Path(community_id): Path<Uuid>,
 ) -> ApiResult<Json<Vec<CommunityMemberResponse>>> {
     let service = CommunityService::new(state.repos.clone(), state.github_service);
-    let members = service.list_members_with_usernames(&community_id)?;
+    let members = service.list_members_with_usernames(user_id, &community_id)?;
 
     Ok(Json(
         members

--- a/fido-server/src/api/error.rs
+++ b/fido-server/src/api/error.rs
@@ -12,14 +12,21 @@ use crate::security::errors::SecureError;
 
 pub type ApiResult<T> = Result<T, ApiError>;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ApiError {
+    #[error("{0}")]
     NotFound(String),
+    #[error("{0}")]
     BadRequest(String),
+    #[error("{0}")]
     Unauthorized(String),
+    #[error("{0}")]
     Forbidden(String),
+    #[error("{0}")]
     TooManyRequests(String),
     /// Internal errors - details are logged but never exposed to clients
+    #[error("{0}")]
     InternalError(String),
 }
 

--- a/fido-server/src/api/friends.rs
+++ b/fido-server/src/api/friends.rs
@@ -27,6 +27,7 @@ pub struct UserSearchResponse {
 
 pub async fn search_users(
     State(state): State<AppState>,
+    AuthenticatedUser(_user_id): AuthenticatedUser,
     axum::extract::Query(query): axum::extract::Query<SearchQuery>,
 ) -> ApiResult<Json<Vec<UserSearchResponse>>> {
     let service = FriendsService::new(state.repos);

--- a/fido-server/src/api/profile.rs
+++ b/fido-server/src/api/profile.rs
@@ -18,6 +18,7 @@ use fido_types::{UpdateBioRequest, UserProfile};
 /// GET /users/:id/profile - Get user profile with stats
 pub async fn get_profile(
     State(state): State<AppState>,
+    AuthenticatedUser(_user_id): AuthenticatedUser,
     Path(user_id): Path<String>,
 ) -> ApiResult<Json<UserProfile>> {
     // Parse user ID

--- a/fido-server/src/api/ws.rs
+++ b/fido-server/src/api/ws.rs
@@ -6,7 +6,7 @@
 //! query string, which would leak it into logs, proxies, and browser history.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
@@ -25,6 +25,19 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_MISSED_PONGS: u8 = 2;
 /// WebSocket close code for "going away" (RFC 6455 section 7.4.1).
 const CLOSE_GOING_AWAY: u16 = 1001;
+/// WebSocket close code for a policy violation (RFC 6455 section 7.4.1).
+const CLOSE_POLICY_VIOLATION: u16 = 1008;
+/// Upper bound on a single inbound message. The gateway is send-only, so no
+/// legitimate client frame approaches this; it caps decode/buffer work.
+const MAX_MESSAGE_SIZE: usize = 64 * 1024;
+/// Upper bound on a single inbound frame before reassembly.
+const MAX_FRAME_SIZE: usize = 16 * 1024;
+/// Sliding window over which inbound frames are counted.
+const INBOUND_WINDOW: Duration = Duration::from_secs(10);
+/// Max inbound frames per [`INBOUND_WINDOW`] before the socket is closed. A
+/// well-behaved client sends only the occasional pong/close, so this is
+/// generous while still bounding a flood.
+const MAX_INBOUND_FRAMES_PER_WINDOW: u32 = 60;
 
 pub async fn ws_handler(
     State(state): State<AppState>,
@@ -39,6 +52,9 @@ pub async fn ws_handler(
         .ok_or_else(|| ApiError::Unauthorized("Invalid session token".to_string()))?;
 
     let gateway = state.realtime;
+    let ws = ws
+        .max_message_size(MAX_MESSAGE_SIZE)
+        .max_frame_size(MAX_FRAME_SIZE);
     Ok(ws.on_upgrade(move |socket| handle_connection(socket, user_id, gateway)))
 }
 
@@ -58,7 +74,19 @@ fn extract_token(headers: &HeaderMap) -> Option<String> {
 }
 
 async fn handle_connection(mut socket: WebSocket, user_id: Uuid, gateway: Arc<RealtimeGateway>) {
-    let connections = gateway.registry().connect(user_id);
+    let connections = match gateway.registry().try_connect(user_id) {
+        Some(count) => count,
+        None => {
+            tracing::warn!(%user_id, "WebSocket per-user connection cap reached; rejecting");
+            send_close_with_code(
+                &mut socket,
+                CLOSE_POLICY_VIOLATION,
+                "connection limit reached",
+            )
+            .await;
+            return;
+        }
+    };
     tracing::info!(%user_id, connections, "WebSocket connected");
 
     let mut events = gateway.subscribe();
@@ -66,6 +94,8 @@ async fn handle_connection(mut socket: WebSocket, user_id: Uuid, gateway: Arc<Re
     let mut ping_interval =
         tokio::time::interval_at(tokio::time::Instant::now() + PING_INTERVAL, PING_INTERVAL);
     let mut missed_pongs: u8 = 0;
+    let mut inbound_count: u32 = 0;
+    let mut inbound_window_start = Instant::now();
 
     loop {
         tokio::select! {
@@ -91,20 +121,41 @@ async fn handle_connection(mut socket: WebSocket, user_id: Uuid, gateway: Arc<Re
                     break;
                 }
             },
-            frame = socket.recv() => match frame {
-                Some(Ok(Message::Pong(_))) => {
-                    missed_pongs = 0;
+            frame = socket.recv() => {
+                // Throttle inbound frames. The gateway is send-only, so a client
+                // streaming frames is buggy or hostile; bound the decode/buffer
+                // work by closing once the per-window budget is exhausted.
+                if inbound_window_start.elapsed() >= INBOUND_WINDOW {
+                    inbound_count = 0;
+                    inbound_window_start = Instant::now();
                 }
-                Some(Ok(Message::Close(_))) | None => {
+                inbound_count += 1;
+                if inbound_count > MAX_INBOUND_FRAMES_PER_WINDOW {
+                    tracing::warn!(%user_id, "WebSocket inbound frame flood; closing");
+                    send_close_with_code(
+                        &mut socket,
+                        CLOSE_POLICY_VIOLATION,
+                        "inbound rate exceeded",
+                    )
+                    .await;
                     break;
                 }
-                Some(Ok(_)) => {
-                    // Server -> client only in MVP; ignore other client frames.
-                    // Pings are answered automatically by the protocol layer.
-                }
-                Some(Err(e)) => {
-                    tracing::debug!(%user_id, error = %e, "WebSocket receive error");
-                    break;
+
+                match frame {
+                    Some(Ok(Message::Pong(_))) => {
+                        missed_pongs = 0;
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        break;
+                    }
+                    Some(Ok(_)) => {
+                        // Server -> client only in MVP; ignore other client frames.
+                        // Pings are answered automatically by the protocol layer.
+                    }
+                    Some(Err(e)) => {
+                        tracing::debug!(%user_id, error = %e, "WebSocket receive error");
+                        break;
+                    }
                 }
             },
             _ = ping_interval.tick() => {
@@ -132,9 +183,13 @@ async fn handle_connection(mut socket: WebSocket, user_id: Uuid, gateway: Arc<Re
 }
 
 async fn send_close(socket: &mut WebSocket, reason: &'static str) {
+    send_close_with_code(socket, CLOSE_GOING_AWAY, reason).await;
+}
+
+async fn send_close_with_code(socket: &mut WebSocket, code: u16, reason: &'static str) {
     let _ = socket
         .send(Message::Close(Some(CloseFrame {
-            code: CLOSE_GOING_AWAY,
+            code,
             reason: reason.into(),
         })))
         .await;

--- a/fido-server/src/db/connection.rs
+++ b/fido-server/src/db/connection.rs
@@ -2,8 +2,25 @@ use anyhow::{Context, Result};
 use r2d2::{Pool, PooledConnection};
 use r2d2_sqlite::SqliteConnectionManager;
 use std::path::Path;
+use uuid::Uuid;
 
 use super::schema::{SCHEMA, TEST_DATA};
+
+/// Run an idempotent `ALTER TABLE ... ADD COLUMN` migration, ignoring only a
+/// "duplicate column name" error (the column already exists from a prior run)
+/// and propagating every other failure (disk full, locked DB, malformed
+/// schema) instead of masking it.
+fn run_add_column(conn: &rusqlite::Connection, sql: &str) -> Result<()> {
+    match conn.execute(sql, []) {
+        Ok(_) => Ok(()),
+        Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
+            if msg.contains("duplicate column name") =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(e).with_context(|| format!("Migration failed: {sql}")),
+    }
+}
 
 /// SQLite in-memory database identifier
 const MEMORY_DB_PATH: &str = ":memory:";
@@ -128,7 +145,16 @@ impl Database {
         };
 
         if trimmed_path.eq_ignore_ascii_case(MEMORY_DB_PATH) {
-            Ok(SqliteConnectionManager::memory().with_init(init))
+            // `SqliteConnectionManager::memory()` opens an INDEPENDENT `:memory:`
+            // database per pooled connection, so schema created on one is
+            // invisible to the next (tests only pass because a single-threaded
+            // pool reuses one idle connection). A named shared-cache memory DB
+            // makes every connection in this pool see the same database. The
+            // name is unique per pool so parallel `Database::in_memory()`
+            // instances stay isolated from each other. rusqlite's default open
+            // flags include `SQLITE_OPEN_URI`, so the `file:` URI is honored.
+            let uri = format!("file:fido_mem_{}?mode=memory&cache=shared", Uuid::new_v4());
+            Ok(SqliteConnectionManager::file(uri).with_init(init))
         } else {
             Ok(SqliteConnectionManager::file(path).with_init(init))
         }
@@ -146,37 +172,40 @@ impl Database {
         conn.execute_batch(SCHEMA)
             .context("Failed to initialize database schema")?;
 
-        // Migrate existing tables - add new columns if they don't exist
-        // This is safe to run multiple times (will fail silently if columns exist)
-        let _ = conn.execute(
+        // Migrate existing tables: add new columns if they don't exist. Each
+        // ADD COLUMN ignores only "duplicate column name" (column already
+        // present) and propagates any other error. Everything else below uses
+        // IF NOT EXISTS / IF EXISTS and is a hard `?` so real failures surface.
+        run_add_column(
+            &conn,
             "ALTER TABLE direct_messages ADD COLUMN deleted_by_from_user INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute(
+        )?;
+        run_add_column(
+            &conn,
             "ALTER TABLE direct_messages ADD COLUMN deleted_by_to_user INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
+        )?;
 
         // Add threaded conversation support to posts table
-        let _ = conn.execute("ALTER TABLE posts ADD COLUMN parent_post_id TEXT NULL", []);
-        let _ = conn.execute(
+        run_add_column(&conn, "ALTER TABLE posts ADD COLUMN parent_post_id TEXT NULL")?;
+        run_add_column(
+            &conn,
             "ALTER TABLE posts ADD COLUMN reply_count INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute("ALTER TABLE posts ADD COLUMN github_id INTEGER", []);
-        let _ = conn.execute("ALTER TABLE posts ADD COLUMN github_kind TEXT", []);
-        let _ = conn.execute("ALTER TABLE posts ADD COLUMN github_state TEXT", []);
-        let _ = conn.execute("ALTER TABLE posts ADD COLUMN github_html_url TEXT", []);
+        )?;
+        run_add_column(&conn, "ALTER TABLE posts ADD COLUMN github_id INTEGER")?;
+        run_add_column(&conn, "ALTER TABLE posts ADD COLUMN github_kind TEXT")?;
+        run_add_column(&conn, "ALTER TABLE posts ADD COLUMN github_state TEXT")?;
+        run_add_column(&conn, "ALTER TABLE posts ADD COLUMN github_html_url TEXT")?;
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_posts_community_github_id ON posts(community_id, github_id)",
             [],
         )?;
 
         // Remove a legacy duplicate; SCHEMA creates idx_posts_parent_post_id.
-        let _ = conn.execute("DROP INDEX IF EXISTS idx_posts_parent_id", []);
+        conn.execute("DROP INDEX IF EXISTS idx_posts_parent_id", [])
+            .context("Failed to drop legacy index")?;
 
         // Add sessions table for authentication
-        let _ = conn.execute_batch(
+        conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS sessions (
                 token TEXT PRIMARY KEY,
                 user_id TEXT NOT NULL,
@@ -187,26 +216,29 @@ impl Database {
             );
             CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
             CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);",
-        );
+        )
+        .context("Failed to create sessions table")?;
 
-        // Migration: Add last_activity column to sessions table if it doesn't exist
-        // Default value is set to created_at for existing sessions
-        let _ = conn.execute("ALTER TABLE sessions ADD COLUMN last_activity TEXT", []);
+        // Migration: Add last_activity column to sessions table if it doesn't
+        // exist (the CREATE above already includes it, so this is a duplicate
+        // column on a fresh DB and a no-op on an older one).
+        run_add_column(&conn, "ALTER TABLE sessions ADD COLUMN last_activity TEXT")?;
         // Update existing sessions to set last_activity = created_at where NULL
-        let _ = conn.execute(
+        conn.execute(
             "UPDATE sessions SET last_activity = created_at WHERE last_activity IS NULL",
             [],
-        );
+        )
+        .context("Failed to backfill session last_activity")?;
 
         // Add GitHub authentication fields to users table
-        let _ = conn.execute("ALTER TABLE users ADD COLUMN github_id INTEGER", []);
-        let _ = conn.execute("ALTER TABLE users ADD COLUMN github_login TEXT", []);
-        let _ = conn.execute(
+        run_add_column(&conn, "ALTER TABLE users ADD COLUMN github_id INTEGER")?;
+        run_add_column(&conn, "ALTER TABLE users ADD COLUMN github_login TEXT")?;
+        conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_users_github_id ON users(github_id)",
             [],
-        );
+        )?;
 
-        let _ = conn.execute_batch(
+        conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS github_tokens (
                 user_id TEXT PRIMARY KEY,
                 encrypted_token TEXT NOT NULL,
@@ -215,7 +247,8 @@ impl Database {
                 FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
             );
             CREATE INDEX IF NOT EXISTS idx_github_tokens_updated_at ON github_tokens(updated_at);",
-        );
+        )
+        .context("Failed to create github_tokens table")?;
 
         conn.pragma_update(None, "user_version", SCHEMA_VERSION)
             .context("Failed to stamp schema version")?;
@@ -242,6 +275,35 @@ impl Database {
 #[cfg(all(test, feature = "sqlite-tests"))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn in_memory_pool_is_shared_across_connections() {
+        let db = Database::in_memory().expect("Failed to create database");
+        db.initialize().expect("Failed to initialize schema");
+
+        // Write through one pooled connection.
+        let writer = db.connection().expect("first connection");
+        writer
+            .execute(
+                "INSERT INTO users (id, username, bio, join_date, is_test_user, is_admin)
+                 VALUES (?, 'shared-user', NULL, ?, 1, 0)",
+                (Uuid::new_v4().to_string(), chrono::Utc::now().to_rfc3339()),
+            )
+            .expect("insert on writer");
+
+        // Hold `writer` checked out so the pool must hand back a DISTINCT second
+        // connection. It must observe the same database; with the old
+        // per-connection `:memory:` manager this read saw an empty schema.
+        let reader = db.connection().expect("second connection");
+        let count: i64 = reader
+            .query_row(
+                "SELECT COUNT(*) FROM users WHERE username = 'shared-user'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read on reader");
+        assert_eq!(count, 1, "connections in the pool must share one database");
+    }
 
     #[test]
     fn test_database_creation() {

--- a/fido-server/src/db/connection.rs
+++ b/fido-server/src/db/connection.rs
@@ -186,7 +186,10 @@ impl Database {
         )?;
 
         // Add threaded conversation support to posts table
-        run_add_column(&conn, "ALTER TABLE posts ADD COLUMN parent_post_id TEXT NULL")?;
+        run_add_column(
+            &conn,
+            "ALTER TABLE posts ADD COLUMN parent_post_id TEXT NULL",
+        )?;
         run_add_column(
             &conn,
             "ALTER TABLE posts ADD COLUMN reply_count INTEGER NOT NULL DEFAULT 0",

--- a/fido-server/src/db/repositories/channel_repository.rs
+++ b/fido-server/src/db/repositories/channel_repository.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use rusqlite::OptionalExtension;
 use uuid::Uuid;

--- a/fido-server/src/db/repositories/channel_repository.rs
+++ b/fido-server/src/db/repositories/channel_repository.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // v2 repository is covered by sqlite-tests before its API surface is wired.
 
 use anyhow::{Context, Result};
 use rusqlite::OptionalExtension;

--- a/fido-server/src/db/repositories/community_repository.rs
+++ b/fido-server/src/db/repositories/community_repository.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use rusqlite::OptionalExtension;
 use uuid::Uuid;

--- a/fido-server/src/db/repositories/community_repository.rs
+++ b/fido-server/src/db/repositories/community_repository.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // v2 repository is covered by sqlite-tests before its API surface is wired.
 
 use anyhow::{Context, Result};
 use rusqlite::OptionalExtension;

--- a/fido-server/src/db/repositories/dm_conversation_repository.rs
+++ b/fido-server/src/db/repositories/dm_conversation_repository.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use chrono::Utc;
 use rusqlite::types::Type;

--- a/fido-server/src/db/repositories/dm_conversation_repository.rs
+++ b/fido-server/src/db/repositories/dm_conversation_repository.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // v2 repository is covered by sqlite-tests before its API surface is wired.
 
 use anyhow::{Context, Result};
 use chrono::Utc;

--- a/fido-server/src/db/repositories/dm_repository.rs
+++ b/fido-server/src/db/repositories/dm_repository.rs
@@ -230,12 +230,17 @@ impl DirectMessageRepository {
 
     /// Delete conversation for a specific user (soft delete - hides from their view only)
     pub fn delete_conversation(&self, user_id: &Uuid, other_user_id: &Uuid) -> Result<()> {
-        let conn = self.pool.get()?;
+        let mut conn = self.pool.get()?;
+        // Both soft-delete UPDATEs run in one transaction so a crash between them
+        // cannot leave the conversation half-hidden (one direction deleted).
+        let tx = conn
+            .transaction()
+            .context("Failed to begin DM soft-delete transaction")?;
 
         // Mark messages as deleted for this user only
         // For messages where user is the sender: set deleted_by_from_user = 1
-        conn.execute(
-            "UPDATE direct_messages 
+        tx.execute(
+            "UPDATE direct_messages
              SET deleted_by_from_user = 1
              WHERE from_user_id = ? AND to_user_id = ?",
             (user_id.to_string(), other_user_id.to_string()),
@@ -243,14 +248,16 @@ impl DirectMessageRepository {
         .context("Failed to mark sent messages as deleted")?;
 
         // For messages where user is the receiver: set deleted_by_to_user = 1
-        conn.execute(
-            "UPDATE direct_messages 
+        tx.execute(
+            "UPDATE direct_messages
              SET deleted_by_to_user = 1
              WHERE to_user_id = ? AND from_user_id = ?",
             (user_id.to_string(), other_user_id.to_string()),
         )
         .context("Failed to mark received messages as deleted")?;
 
+        tx.commit()
+            .context("Failed to commit DM soft-delete transaction")?;
         Ok(())
     }
 }

--- a/fido-server/src/db/repositories/dm_repository.rs
+++ b/fido-server/src/db/repositories/dm_repository.rs
@@ -2,17 +2,24 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-use fido_types::DirectMessage;
+use fido_types::{DirectMessage, DmConversationState};
 
 use crate::db::{row, DbPool};
 
 /// Summary of a direct message conversation, without the full message history.
+///
+/// The other user's username and the conversation's state/initiator are joined
+/// in by `get_conversation_summaries` so the service layer renders the list
+/// without a per-conversation `users.get_by_id` + `dm_conversations.get` (N+1).
 #[derive(Debug, Clone)]
 pub struct DirectMessageConversationSummary {
     pub other_user_id: Uuid,
+    pub other_username: String,
     pub last_message: String,
     pub last_message_time: DateTime<Utc>,
     pub unread_count: usize,
+    pub state: DmConversationState,
+    pub initiator_id: Uuid,
 }
 
 #[derive(Clone)]
@@ -141,28 +148,65 @@ impl DirectMessageRepository {
                         ORDER BY created_at DESC
                     ) AS recency_rank
                 FROM visible_messages
+             ),
+             summary AS (
+                SELECT
+                    other_user_id,
+                    MAX(CASE WHEN recency_rank = 1 THEN content END) AS last_message,
+                    MAX(CASE WHEN recency_rank = 1 THEN created_at END) AS last_message_time,
+                    SUM(unread) AS unread_count
+                FROM ranked_messages
+                GROUP BY other_user_id
              )
              SELECT
-                other_user_id,
-                MAX(CASE WHEN recency_rank = 1 THEN content END) AS last_message,
-                MAX(CASE WHEN recency_rank = 1 THEN created_at END) AS last_message_time,
-                SUM(unread) AS unread_count
-             FROM ranked_messages
-             GROUP BY other_user_id
-             ORDER BY last_message_time DESC",
+                s.other_user_id,
+                s.last_message,
+                s.last_message_time,
+                s.unread_count,
+                u.username,
+                dc.state,
+                dc.initiator_id
+             FROM summary s
+             JOIN users u ON u.id = s.other_user_id
+             JOIN dm_conversations dc
+                ON dc.user_a = MIN(?, s.other_user_id)
+               AND dc.user_b = MAX(?, s.other_user_id)
+             ORDER BY s.last_message_time DESC",
         )?;
 
         let summaries = stmt
             .query_map(
-                (&user_id_str, &user_id_str, &user_id_str, &user_id_str),
+                (
+                    &user_id_str,
+                    &user_id_str,
+                    &user_id_str,
+                    &user_id_str,
+                    &user_id_str,
+                    &user_id_str,
+                ),
                 |row| {
                     let other_user_id: String = row.get(0)?;
                     let last_message_time: String = row.get(2)?;
+                    let state_str: String = row.get(5)?;
+                    let initiator_id: String = row.get(6)?;
+                    let state = DmConversationState::parse(&state_str).ok_or_else(|| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            5,
+                            rusqlite::types::Type::Text,
+                            Box::new(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                format!("Invalid dm conversation state: {state_str}"),
+                            )),
+                        )
+                    })?;
                     Ok(DirectMessageConversationSummary {
                         other_user_id: row::parse_uuid(&other_user_id, 0)?,
                         last_message: row.get(1)?,
                         last_message_time: row::parse_datetime(&last_message_time, 2)?,
                         unread_count: row.get::<_, i64>(3)? as usize,
+                        other_username: row.get(4)?,
+                        state,
+                        initiator_id: row::parse_uuid(&initiator_id, 6)?,
                     })
                 },
             )?

--- a/fido-server/src/db/repositories/membership_repository.rs
+++ b/fido-server/src/db/repositories/membership_repository.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // v2 repository is covered by sqlite-tests before its API surface is wired.
 
 use anyhow::{Context, Result};
 use rusqlite::types::Type;

--- a/fido-server/src/db/repositories/membership_repository.rs
+++ b/fido-server/src/db/repositories/membership_repository.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use rusqlite::types::Type;
 use rusqlite::OptionalExtension;

--- a/fido-server/src/db/repositories/message_repository.rs
+++ b/fido-server/src/db/repositories/message_repository.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // v2 repository is covered by sqlite-tests before its API surface is wired.
 
 use anyhow::{Context, Result};
 use rusqlite::params;

--- a/fido-server/src/db/repositories/message_repository.rs
+++ b/fido-server/src/db/repositories/message_repository.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use rusqlite::params;
 use uuid::Uuid;

--- a/fido-server/src/db/repositories/mod.rs
+++ b/fido-server/src/db/repositories/mod.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // v2 repository bundle is exported by the library before every API surface uses it.
 
 mod activity_repository;
 mod audit_repository;

--- a/fido-server/src/db/repositories/mod.rs
+++ b/fido-server/src/db/repositories/mod.rs
@@ -1,4 +1,3 @@
-
 mod activity_repository;
 mod audit_repository;
 mod channel_repository;

--- a/fido-server/src/db/repositories/notification_repository.rs
+++ b/fido-server/src/db/repositories/notification_repository.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // v2 repository is covered by sqlite-tests before its API surface is wired.
 
 use anyhow::{Context, Result};
 use rusqlite::params;

--- a/fido-server/src/db/repositories/notification_repository.rs
+++ b/fido-server/src/db/repositories/notification_repository.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use rusqlite::params;
 use rusqlite::types::Type;

--- a/fido-server/src/db/repositories/user_repository.rs
+++ b/fido-server/src/db/repositories/user_repository.rs
@@ -153,6 +153,21 @@ impl UserRepository {
         Ok(user)
     }
 
+    /// Current GitHub login for a user, if any. Unlike `username` (frozen at
+    /// first signup), this tracks GitHub renames on re-login.
+    pub fn get_github_login(&self, user_id: &Uuid) -> Result<Option<String>> {
+        let conn = self.pool.get()?;
+        let login = conn
+            .query_row(
+                "SELECT github_login FROM users WHERE id = ?",
+                [user_id.to_string()],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?
+            .flatten();
+        Ok(login)
+    }
+
     /// Derive a username not already taken, appending `-2`, `-3`, ... on
     /// collision. GitHub logins are unique, so a collision here means an
     /// existing local (possibly stale) username, which must not block signup.
@@ -185,14 +200,31 @@ impl UserRepository {
         github_login: &str,
         name: Option<&str>,
     ) -> Result<User> {
-        // Existing user: refresh the stored login and return.
-        if let Some(existing_user) = self.get_by_github_id(github_id)? {
+        // Existing user: refresh the stored login and display username on a
+        // GitHub rename. The username is only re-pointed when the new login is
+        // not held by a different local user (it has a UNIQUE constraint); the
+        // github_login always tracks the rename regardless.
+        if let Some(mut existing_user) = self.get_by_github_id(github_id)? {
+            let username_is_free = match self.get_by_username(github_login)? {
+                Some(other) => other.id == existing_user.id,
+                None => true,
+            };
+
             let conn = self.pool.get()?;
-            conn.execute(
-                "UPDATE users SET github_login = ? WHERE id = ?",
-                [github_login, &existing_user.id.to_string()],
-            )
-            .context("Failed to update user GitHub login")?;
+            if username_is_free && !existing_user.username.eq_ignore_ascii_case(github_login) {
+                conn.execute(
+                    "UPDATE users SET github_login = ?, username = ? WHERE id = ?",
+                    [github_login, github_login, &existing_user.id.to_string()],
+                )
+                .context("Failed to update user GitHub identity")?;
+                existing_user.username = github_login.to_string();
+            } else {
+                conn.execute(
+                    "UPDATE users SET github_login = ? WHERE id = ?",
+                    [github_login, &existing_user.id.to_string()],
+                )
+                .context("Failed to update user GitHub login")?;
+            }
 
             return Ok(existing_user);
         }
@@ -297,6 +329,44 @@ mod tests {
         let user = repo.create_or_update_from_github(99, "octocat", None)?;
         assert_eq!(user.username, "octocat-2");
         assert_eq!(repo.get_by_github_id(99)?.map(|u| u.username).as_deref(), Some("octocat-2"));
+        Ok(())
+    }
+
+    #[test]
+    fn github_rename_updates_login_and_username() -> Result<()> {
+        let (_db, repo) = repo()?;
+        let created = repo.create_or_update_from_github(555, "old-login", None)?;
+        assert_eq!(created.username, "old-login");
+
+        // Same github_id, new login: both github_login and the display username
+        // track the rename when the new login is free.
+        let renamed = repo.create_or_update_from_github(555, "new-login", None)?;
+        assert_eq!(renamed.id, created.id);
+        assert_eq!(renamed.username, "new-login");
+        assert_eq!(repo.get_github_login(&created.id)?.as_deref(), Some("new-login"));
+        Ok(())
+    }
+
+    #[test]
+    fn github_rename_keeps_username_when_new_login_is_taken() -> Result<()> {
+        let (_db, repo) = repo()?;
+        // Someone else already holds "taken".
+        repo.create(&User {
+            id: Uuid::new_v4(),
+            username: "taken".to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        })?;
+        let user = repo.create_or_update_from_github(556, "original", None)?;
+
+        // Rename to a login another user already holds: login updates, username
+        // stays (UNIQUE constraint) so the row is never orphaned.
+        let renamed = repo.create_or_update_from_github(556, "taken", None)?;
+        assert_eq!(renamed.id, user.id);
+        assert_eq!(renamed.username, "original");
+        assert_eq!(repo.get_github_login(&user.id)?.as_deref(), Some("taken"));
         Ok(())
     }
 

--- a/fido-server/src/db/repositories/user_repository.rs
+++ b/fido-server/src/db/repositories/user_repository.rs
@@ -328,7 +328,10 @@ mod tests {
         // A new GitHub login colliding with that username still signs up.
         let user = repo.create_or_update_from_github(99, "octocat", None)?;
         assert_eq!(user.username, "octocat-2");
-        assert_eq!(repo.get_by_github_id(99)?.map(|u| u.username).as_deref(), Some("octocat-2"));
+        assert_eq!(
+            repo.get_by_github_id(99)?.map(|u| u.username).as_deref(),
+            Some("octocat-2")
+        );
         Ok(())
     }
 
@@ -343,7 +346,10 @@ mod tests {
         let renamed = repo.create_or_update_from_github(555, "new-login", None)?;
         assert_eq!(renamed.id, created.id);
         assert_eq!(renamed.username, "new-login");
-        assert_eq!(repo.get_github_login(&created.id)?.as_deref(), Some("new-login"));
+        assert_eq!(
+            repo.get_github_login(&created.id)?.as_deref(),
+            Some("new-login")
+        );
         Ok(())
     }
 
@@ -380,7 +386,7 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("fido-user-race-{}.sqlite", Uuid::new_v4()));
         let db = Database::new(&tmp)?;
         db.initialize()?;
-        let repo = Arc::new(UserRepository::new(db.pool.clone()));
+        let repo = Arc::new(UserRepository::new(db.pool));
 
         let handles: Vec<_> = (0..8)
             .map(|_| {
@@ -395,8 +401,15 @@ mod tests {
             let user = handle.join().expect("thread panicked")?;
             ids.insert(user.id);
         }
-        assert_eq!(ids.len(), 1, "concurrent callbacks must converge on one row");
-        assert_eq!(repo.get_by_github_id(7777)?.map(|u| u.id), ids.into_iter().next());
+        assert_eq!(
+            ids.len(),
+            1,
+            "concurrent callbacks must converge on one row"
+        );
+        assert_eq!(
+            repo.get_by_github_id(7777)?.map(|u| u.id),
+            ids.into_iter().next()
+        );
 
         let _ = std::fs::remove_file(&tmp);
         Ok(())

--- a/fido-server/src/db/repositories/user_repository.rs
+++ b/fido-server/src/db/repositories/user_repository.rs
@@ -96,21 +96,31 @@ impl UserRepository {
     }
 
     /// Get a system user by name, creating it on first use.
+    ///
+    /// Uses `INSERT ... ON CONFLICT(username) DO NOTHING` then a re-select, so
+    /// concurrent callers race safely to one row instead of one of them hitting
+    /// the username UNIQUE constraint and 500ing.
     pub fn get_or_create_system_user(&self, username: &str) -> Result<User> {
         if let Some(user) = self.get_by_username(username)? {
             return Ok(user);
         }
 
-        let user = User {
-            id: Uuid::new_v4(),
-            username: username.to_string(),
-            bio: None,
-            join_date: Utc::now(),
-            is_test_user: false,
-            is_admin: false,
-        };
-        self.create(&user)?;
-        Ok(user)
+        let conn = self.pool.get()?;
+        conn.execute(
+            "INSERT INTO users (id, username, bio, join_date, is_test_user, is_admin)
+             VALUES (?, ?, NULL, ?, 0, 0)
+             ON CONFLICT(username) DO NOTHING",
+            (
+                Uuid::new_v4().to_string(),
+                username,
+                Utc::now().to_rfc3339(),
+            ),
+        )
+        .context("Failed to upsert system user")?;
+        drop(conn);
+
+        self.get_by_username(username)?
+            .with_context(|| format!("System user '{username}' missing after upsert"))
     }
 
     /// Get all users (for search)
@@ -143,18 +153,41 @@ impl UserRepository {
         Ok(user)
     }
 
-    /// Create or update user from GitHub OAuth
+    /// Derive a username not already taken, appending `-2`, `-3`, ... on
+    /// collision. GitHub logins are unique, so a collision here means an
+    /// existing local (possibly stale) username, which must not block signup.
+    fn unique_username(&self, base: &str) -> Result<String> {
+        if self.get_by_username(base)?.is_none() {
+            return Ok(base.to_string());
+        }
+        for suffix in 2..=1000 {
+            let candidate = format!("{base}-{suffix}");
+            if self.get_by_username(&candidate)?.is_none() {
+                return Ok(candidate);
+            }
+        }
+        Err(anyhow::anyhow!(
+            "Could not derive a unique username from '{base}'"
+        ))
+    }
+
+    /// Create or update user from GitHub OAuth.
+    ///
+    /// New-user creation is idempotent: `INSERT ... ON CONFLICT(github_id) DO
+    /// NOTHING` followed by a re-select, so concurrent first-time OAuth
+    /// callbacks converge on one row instead of one of them hitting the
+    /// `github_id`/`username` UNIQUE constraint and 500ing. A login that
+    /// collides with an existing local username is disambiguated rather than
+    /// rejected.
     pub fn create_or_update_from_github(
         &self,
         github_id: i64,
         github_login: &str,
         name: Option<&str>,
     ) -> Result<User> {
-        let conn = self.pool.get()?;
-
-        // Check if user already exists
+        // Existing user: refresh the stored login and return.
         if let Some(existing_user) = self.get_by_github_id(github_id)? {
-            // Update github_login if it changed
+            let conn = self.pool.get()?;
             conn.execute(
                 "UPDATE users SET github_login = ? WHERE id = ?",
                 [github_login, &existing_user.id.to_string()],
@@ -164,33 +197,39 @@ impl UserRepository {
             return Ok(existing_user);
         }
 
-        // Create new user
+        // New user: pick a free username and insert idempotently.
+        let username = self.unique_username(github_login)?;
         let user_id = Uuid::new_v4();
         let join_date = Utc::now();
         let bio = name.map(|s| s.to_string());
 
-        conn.execute(
-            "INSERT INTO users (id, username, bio, join_date, is_test_user, github_id, github_login) 
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                user_id.to_string(),
-                github_login,
-                bio.as_deref(),
-                join_date.to_rfc3339(),
-                0, // Not a test user
-                github_id,
-                github_login,
-            ),
-        ).context("Failed to create user from GitHub")?;
+        {
+            let conn = self.pool.get()?;
+            conn.execute(
+                // Bare ON CONFLICT DO NOTHING (no target) swallows a conflict on
+                // EITHER unique index: a concurrent callback for the same
+                // github_id also picked this username, so the loser would
+                // otherwise trip the username UNIQUE. The re-select below
+                // recovers the winning row.
+                "INSERT INTO users (id, username, bio, join_date, is_test_user, github_id, github_login)
+                 VALUES (?, ?, ?, ?, 0, ?, ?)
+                 ON CONFLICT DO NOTHING",
+                (
+                    user_id.to_string(),
+                    &username,
+                    bio.as_deref(),
+                    join_date.to_rfc3339(),
+                    github_id,
+                    github_login,
+                ),
+            )
+            .context("Failed to create user from GitHub")?;
+        }
 
-        Ok(User {
-            id: user_id,
-            username: github_login.to_string(),
-            bio,
-            join_date,
-            is_test_user: false,
-            is_admin: false,
-        })
+        // Re-select by github_id: returns our row, or the row a concurrent
+        // callback inserted first.
+        self.get_by_github_id(github_id)?
+            .with_context(|| format!("GitHub user {github_id} missing after upsert"))
     }
 }
 
@@ -206,4 +245,90 @@ fn map_user_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<User> {
         is_test_user: row.get::<_, i32>(4)? == 1,
         is_admin: row.get::<_, i32>(5)? == 1,
     })
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    fn repo() -> Result<(Database, UserRepository)> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repo = UserRepository::new(db.pool.clone());
+        Ok((db, repo))
+    }
+
+    #[test]
+    fn get_or_create_system_user_is_idempotent() -> Result<()> {
+        let (_db, repo) = repo()?;
+        let first = repo.get_or_create_system_user("system-bot")?;
+        let second = repo.get_or_create_system_user("system-bot")?;
+        assert_eq!(first.id, second.id);
+        assert_eq!(second.username, "system-bot");
+        Ok(())
+    }
+
+    #[test]
+    fn create_or_update_from_github_is_idempotent_by_github_id() -> Result<()> {
+        let (_db, repo) = repo()?;
+        let first = repo.create_or_update_from_github(4242, "octocat", Some("Octo Cat"))?;
+        // A repeat callback for the same github_id returns the same row, no 500.
+        let second = repo.create_or_update_from_github(4242, "octocat", Some("Octo Cat"))?;
+        assert_eq!(first.id, second.id);
+        assert_eq!(second.username, "octocat");
+        Ok(())
+    }
+
+    #[test]
+    fn github_signup_disambiguates_colliding_username() -> Result<()> {
+        let (_db, repo) = repo()?;
+        // A pre-existing local user already holds the plain login.
+        repo.create(&User {
+            id: Uuid::new_v4(),
+            username: "octocat".to_string(),
+            bio: None,
+            join_date: Utc::now(),
+            is_test_user: true,
+            is_admin: false,
+        })?;
+
+        // A new GitHub login colliding with that username still signs up.
+        let user = repo.create_or_update_from_github(99, "octocat", None)?;
+        assert_eq!(user.username, "octocat-2");
+        assert_eq!(repo.get_by_github_id(99)?.map(|u| u.username).as_deref(), Some("octocat-2"));
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_github_signup_returns_one_row() -> Result<()> {
+        use std::collections::HashSet;
+        use std::sync::Arc;
+        use std::thread;
+
+        // Real file DB so a pool shared across threads sees one database.
+        let tmp = std::env::temp_dir().join(format!("fido-user-race-{}.sqlite", Uuid::new_v4()));
+        let db = Database::new(&tmp)?;
+        db.initialize()?;
+        let repo = Arc::new(UserRepository::new(db.pool.clone()));
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let r = Arc::clone(&repo);
+                thread::spawn(move || r.create_or_update_from_github(7777, "racecat", None))
+            })
+            .collect();
+
+        let mut ids = HashSet::new();
+        for handle in handles {
+            // No callback may 500; each returns the shared row.
+            let user = handle.join().expect("thread panicked")?;
+            ids.insert(user.id);
+        }
+        assert_eq!(ids.len(), 1, "concurrent callbacks must converge on one row");
+        assert_eq!(repo.get_by_github_id(7777)?.map(|u| u.id), ids.into_iter().next());
+
+        let _ = std::fs::remove_file(&tmp);
+        Ok(())
+    }
 }

--- a/fido-server/src/db/repositories/vote_repository.rs
+++ b/fido-server/src/db/repositories/vote_repository.rs
@@ -45,6 +45,52 @@ impl VoteRepository {
         Ok(())
     }
 
+    /// Upsert a vote and recompute the post's cached vote counts atomically.
+    ///
+    /// The two statements previously ran on separate pooled connections, so a
+    /// crash between them left `posts.upvotes/downvotes` permanently stale with
+    /// nothing to reconcile. Running both in one transaction makes the write
+    /// all-or-nothing.
+    pub fn upsert_vote_with_recount(
+        &self,
+        user_id: &Uuid,
+        post_id: &Uuid,
+        direction: VoteDirection,
+    ) -> Result<()> {
+        let mut conn = self.pool.get()?;
+        let tx = conn.transaction().context("Failed to begin vote transaction")?;
+
+        tx.execute(
+            "INSERT INTO votes (user_id, post_id, direction, created_at)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(user_id, post_id)
+             DO UPDATE SET direction = excluded.direction, created_at = excluded.created_at",
+            (
+                user_id.to_string(),
+                post_id.to_string(),
+                direction.as_str(),
+                Utc::now().to_rfc3339(),
+            ),
+        )
+        .context("Failed to upsert vote")?;
+
+        tx.execute(
+            "UPDATE posts
+             SET upvotes = (SELECT COUNT(*) FROM votes WHERE post_id = ? AND direction = 'up'),
+                 downvotes = (SELECT COUNT(*) FROM votes WHERE post_id = ? AND direction = 'down')
+             WHERE id = ?",
+            (
+                post_id.to_string(),
+                post_id.to_string(),
+                post_id.to_string(),
+            ),
+        )
+        .context("Failed to update vote counts")?;
+
+        tx.commit().context("Failed to commit vote transaction")?;
+        Ok(())
+    }
+
     /// Get a user's vote on a post
     pub fn get_vote(&self, user_id: &Uuid, post_id: &Uuid) -> Result<Option<Vote>> {
         let conn = self.pool.get()?;
@@ -206,6 +252,52 @@ mod tests {
         let repo = VoteRepository::new(db.pool.clone());
         let votes = repo.get_votes_for_posts(&Uuid::new_v4(), &[])?;
         assert!(votes.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn upsert_vote_with_recount_is_atomic() -> Result<()> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let (user_id, posts) = seed(&db, 1)?;
+        let repo = VoteRepository::new(db.pool.clone());
+        let conn = db.connection()?;
+
+        let count = |conn: &rusqlite::Connection| -> Result<(i64, i64)> {
+            Ok(conn.query_row(
+                "SELECT upvotes, downvotes FROM posts WHERE id = ?",
+                [posts[0].to_string()],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )?)
+        };
+
+        repo.upsert_vote_with_recount(&user_id, &posts[0], VoteDirection::Up)?;
+        assert_eq!(count(&conn)?, (1, 0));
+        assert!(repo.get_vote(&user_id, &posts[0])?.is_some());
+
+        // Changing the vote recounts in the same transaction.
+        repo.upsert_vote_with_recount(&user_id, &posts[0], VoteDirection::Down)?;
+        assert_eq!(count(&conn)?, (0, 1));
+
+        Ok(())
+    }
+
+    #[test]
+    fn upsert_vote_with_recount_rolls_back_on_failure() -> Result<()> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let (user_id, _posts) = seed(&db, 0)?;
+        let repo = VoteRepository::new(db.pool.clone());
+
+        // Voting on a non-existent post violates the votes.post_id foreign key,
+        // so the transaction aborts and nothing is written.
+        let orphan_post = Uuid::new_v4();
+        let result = repo.upsert_vote_with_recount(&user_id, &orphan_post, VoteDirection::Up);
+        assert!(result.is_err(), "FK violation should fail the write");
+        assert!(
+            repo.get_vote(&user_id, &orphan_post)?.is_none(),
+            "no vote row may survive the rolled-back transaction"
+        );
         Ok(())
     }
 }

--- a/fido-server/src/db/repositories/vote_repository.rs
+++ b/fido-server/src/db/repositories/vote_repository.rs
@@ -58,7 +58,9 @@ impl VoteRepository {
         direction: VoteDirection,
     ) -> Result<()> {
         let mut conn = self.pool.get()?;
-        let tx = conn.transaction().context("Failed to begin vote transaction")?;
+        let tx = conn
+            .transaction()
+            .context("Failed to begin vote transaction")?;
 
         tx.execute(
             "INSERT INTO votes (user_id, post_id, direction, created_at)
@@ -225,7 +227,7 @@ mod tests {
         let db = Database::in_memory()?;
         db.initialize()?;
         let (user_id, posts) = seed(&db, 5)?;
-        let repo = VoteRepository::new(db.pool.clone());
+        let repo = VoteRepository::new(db.pool);
 
         // Vote on a subset; leave the rest unvoted.
         repo.upsert_vote(&user_id, &posts[0], VoteDirection::Up)?;
@@ -249,7 +251,7 @@ mod tests {
     fn get_votes_for_posts_empty_input_is_noop() -> Result<()> {
         let db = Database::in_memory()?;
         db.initialize()?;
-        let repo = VoteRepository::new(db.pool.clone());
+        let repo = VoteRepository::new(db.pool);
         let votes = repo.get_votes_for_posts(&Uuid::new_v4(), &[])?;
         assert!(votes.is_empty());
         Ok(())
@@ -287,7 +289,7 @@ mod tests {
         let db = Database::in_memory()?;
         db.initialize()?;
         let (user_id, _posts) = seed(&db, 0)?;
-        let repo = VoteRepository::new(db.pool.clone());
+        let repo = VoteRepository::new(db.pool);
 
         // Voting on a non-existent post violates the votes.post_id foreign key,
         // so the transaction aborts and nothing is written.

--- a/fido-server/src/db/repositories/vote_repository.rs
+++ b/fido-server/src/db/repositories/vote_repository.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use chrono::Utc;
 use rusqlite::OptionalExtension;
@@ -71,6 +73,51 @@ impl VoteRepository {
         Ok(vote)
     }
 
+    /// Batch-fetch a user's votes for many posts in a single query.
+    ///
+    /// Replaces the per-post `get_vote` loop in feed/reply-tree rendering (an
+    /// N+1). Placeholders are generated to match the id count; the ids are
+    /// bound as parameters, never interpolated into the SQL.
+    pub fn get_votes_for_posts(
+        &self,
+        user_id: &Uuid,
+        post_ids: &[Uuid],
+    ) -> Result<HashMap<Uuid, VoteDirection>> {
+        if post_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let conn = self.pool.get()?;
+        let placeholders = vec!["?"; post_ids.len()].join(", ");
+        let sql = format!(
+            "SELECT post_id, direction FROM votes
+             WHERE user_id = ? AND post_id IN ({placeholders})"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+
+        let mut params: Vec<String> = Vec::with_capacity(post_ids.len() + 1);
+        params.push(user_id.to_string());
+        params.extend(post_ids.iter().map(Uuid::to_string));
+        let param_refs: Vec<&dyn rusqlite::ToSql> =
+            params.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            let post_id_str: String = row.get(0)?;
+            let direction_str: String = row.get(1)?;
+            Ok((
+                row::parse_uuid(&post_id_str, 0)?,
+                row::parse_vote_direction(&direction_str, 1)?,
+            ))
+        })?;
+
+        let mut votes = HashMap::with_capacity(post_ids.len());
+        for row in rows {
+            let (post_id, direction) = row?;
+            votes.insert(post_id, direction);
+        }
+        Ok(votes)
+    }
+
     /// Calculate karma for a user (sum of upvotes on their posts)
     pub fn calculate_karma(&self, user_id: &Uuid) -> Result<i32> {
         let conn = self.pool.get()?;
@@ -83,5 +130,82 @@ impl VoteRepository {
             |row| row.get(0),
         )?;
         Ok(karma)
+    }
+}
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use chrono::Utc;
+
+    /// Seed one user, one community, and `n` posts by that user; return their ids.
+    fn seed(db: &Database, n: usize) -> Result<(Uuid, Vec<Uuid>)> {
+        let user_id = Uuid::new_v4();
+        let community_id = Uuid::new_v4();
+        let now = Utc::now().to_rfc3339();
+        let conn = db.connection()?;
+        conn.execute(
+            "INSERT INTO users (id, username, bio, join_date, is_test_user, is_admin)
+             VALUES (?, 'voter', NULL, ?, 1, 0)",
+            (user_id.to_string(), &now),
+        )?;
+        conn.execute(
+            "INSERT INTO communities (id, github_repo_id, owner, name, require_thread_approval, created_at)
+             VALUES (?, 1, 'octocat', 'hello', 0, ?)",
+            (community_id.to_string(), &now),
+        )?;
+        let mut post_ids = Vec::with_capacity(n);
+        for i in 0..n {
+            let post_id = Uuid::new_v4();
+            conn.execute(
+                "INSERT INTO posts (id, author_id, community_id, content, created_at)
+                 VALUES (?, ?, ?, ?, ?)",
+                (
+                    post_id.to_string(),
+                    user_id.to_string(),
+                    community_id.to_string(),
+                    format!("post {i}"),
+                    &now,
+                ),
+            )?;
+            post_ids.push(post_id);
+        }
+        Ok((user_id, post_ids))
+    }
+
+    #[test]
+    fn get_votes_for_posts_batches_lookup_across_many_posts() -> Result<()> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let (user_id, posts) = seed(&db, 5)?;
+        let repo = VoteRepository::new(db.pool.clone());
+
+        // Vote on a subset; leave the rest unvoted.
+        repo.upsert_vote(&user_id, &posts[0], VoteDirection::Up)?;
+        repo.upsert_vote(&user_id, &posts[2], VoteDirection::Down)?;
+        repo.upsert_vote(&user_id, &posts[4], VoteDirection::Up)?;
+
+        // A single batched call resolves every post's vote (this replaces the
+        // former per-post N+1 loop in feed/reply rendering).
+        let votes = repo.get_votes_for_posts(&user_id, &posts)?;
+
+        assert_eq!(votes.len(), 3);
+        assert_eq!(votes.get(&posts[0]), Some(&VoteDirection::Up));
+        assert_eq!(votes.get(&posts[2]), Some(&VoteDirection::Down));
+        assert_eq!(votes.get(&posts[4]), Some(&VoteDirection::Up));
+        assert!(!votes.contains_key(&posts[1]));
+        assert!(!votes.contains_key(&posts[3]));
+        Ok(())
+    }
+
+    #[test]
+    fn get_votes_for_posts_empty_input_is_noop() -> Result<()> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let repo = VoteRepository::new(db.pool.clone());
+        let votes = repo.get_votes_for_posts(&Uuid::new_v4(), &[])?;
+        assert!(votes.is_empty());
+        Ok(())
     }
 }

--- a/fido-server/src/db/schema.rs
+++ b/fido-server/src/db/schema.rs
@@ -78,6 +78,10 @@ CREATE INDEX IF NOT EXISTS idx_posts_parent_post_id ON posts(parent_post_id);
 -- Create index on community_id for efficient community-scoped lookups
 CREATE INDEX IF NOT EXISTS idx_posts_community_id ON posts(community_id);
 
+-- Author lookups (profile post_count, karma) filter on author_id; without this
+-- they full-scan the largest table on every profile view.
+CREATE INDEX IF NOT EXISTS idx_posts_author_id ON posts(author_id);
+
 -- Composite feed indexes match the release-critical board query:
 -- community + top-level + approval filter, then the selected sort key.
 CREATE INDEX IF NOT EXISTS idx_posts_feed_newest
@@ -100,6 +104,10 @@ CREATE TABLE IF NOT EXISTS memberships (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
+-- The PK is (community_id, user_id), so `WHERE user_id = ?` (list_for_user,
+-- users_share_community — the latter runs on every DM send) cannot use it.
+CREATE INDEX IF NOT EXISTS idx_memberships_user_id ON memberships(user_id);
+
 -- Notifications table (generic "something happened to you" pipeline)
 CREATE TABLE IF NOT EXISTS notifications (
     id TEXT PRIMARY KEY,
@@ -116,6 +124,10 @@ CREATE TABLE IF NOT EXISTS notifications (
 
 -- Index for unread notification counts per user
 CREATE INDEX IF NOT EXISTS idx_notifications_user_read ON notifications(user_id, read);
+
+-- Pagination orders by created_at DESC per user; idx_notifications_user_read
+-- can't serve the sort, so every page temp-sorts without this.
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created ON notifications(user_id, created_at DESC);
 
 -- DM conversations table (server-enforced message requests)
 CREATE TABLE IF NOT EXISTS dm_conversations (
@@ -474,3 +486,82 @@ INSERT OR IGNORE INTO follows (follower_id, following_id, created_at) VALUES
     ('550e8400-e29b-41d4-a716-446655440006', '550e8400-e29b-41d4-a716-446655440004', 1705190400),
     ('550e8400-e29b-41d4-a716-446655440008', '550e8400-e29b-41d4-a716-446655440004', 1705276800);
 "#;
+
+#[cfg(all(test, feature = "sqlite-tests"))]
+mod tests {
+    use crate::db::Database;
+    use anyhow::Result;
+    use uuid::Uuid;
+
+    /// Return the EXPLAIN QUERY PLAN `detail` column rows for a single-`user_id`
+    /// (plus optional LIMIT/OFFSET) query.
+    fn plan(conn: &rusqlite::Connection, query: &str, binds: usize) -> Result<Vec<String>> {
+        let explain = format!("EXPLAIN QUERY PLAN {query}");
+        let mut stmt = conn.prepare(&explain)?;
+        let params: Vec<Box<dyn rusqlite::ToSql>> = (0..binds)
+            .map(|i| {
+                if i == 0 {
+                    Box::new(Uuid::new_v4().to_string()) as Box<dyn rusqlite::ToSql>
+                } else {
+                    Box::new(50_i64) as Box<dyn rusqlite::ToSql>
+                }
+            })
+            .collect();
+        let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt
+            .query_map(refs.as_slice(), |row| row.get::<_, String>(3))?
+            .collect::<rusqlite::Result<Vec<String>>>()?;
+        Ok(rows)
+    }
+
+    fn assert_uses(plan: &[String], index: &str) {
+        assert!(
+            plan.iter().any(|r| r.contains(index)),
+            "expected plan to use {index}; plan:\n{}",
+            plan.join("\n")
+        );
+    }
+
+    fn assert_no_temp_sort(plan: &[String]) {
+        assert!(
+            plan.iter().all(|r| !r.contains("USE TEMP B-TREE")),
+            "expected index-backed ordering; plan:\n{}",
+            plan.join("\n")
+        );
+    }
+
+    #[test]
+    fn hot_path_queries_use_new_indexes() -> Result<()> {
+        let db = Database::in_memory()?;
+        db.initialize()?;
+        let conn = db.connection()?;
+
+        // memberships.user_id: the DM-send hotpath join filters on user_id, which
+        // the (community_id, user_id) PK cannot serve.
+        let membership_join = plan(
+            &conn,
+            "SELECT COUNT(*) FROM memberships m1
+             INNER JOIN memberships m2 ON m1.community_id = m2.community_id
+             WHERE m1.user_id = ?",
+            1,
+        )?;
+        assert_uses(&membership_join, "idx_memberships_user_id");
+
+        // posts.author_id: profile post_count.
+        let author_count = plan(&conn, "SELECT COUNT(*) FROM posts WHERE author_id = ?", 1)?;
+        assert_uses(&author_count, "idx_posts_author_id");
+
+        // notifications: paginated fetch orders by created_at DESC per user; the
+        // (user_id, created_at DESC) index serves both filter and sort.
+        let notif_page = plan(
+            &conn,
+            "SELECT id FROM notifications WHERE user_id = ?
+             ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            3,
+        )?;
+        assert_uses(&notif_page, "idx_notifications_user_created");
+        assert_no_temp_sort(&notif_page);
+
+        Ok(())
+    }
+}

--- a/fido-server/src/http/auth.rs
+++ b/fido-server/src/http/auth.rs
@@ -14,6 +14,38 @@ pub struct AuthenticatedUser(pub Uuid);
 /// Optional authenticated user for endpoints where auth is optional.
 pub struct OptionalUser(pub Option<Uuid>);
 
+/// Resolve the session token from the request.
+///
+/// Prefers the explicit `X-Session-Token` header (the native TUI's path), then
+/// falls back to the `session_token` cookie the login handler sets. The cookie
+/// is `HttpOnly; SameSite=Strict`, so accepting it here means a browser client
+/// never has to hold the raw token in JS-accessible storage, and `SameSite=Strict`
+/// keeps it CSRF-safe.
+fn session_token_from_parts(parts: &Parts) -> Option<String> {
+    if let Some(header) = parts
+        .headers
+        .get("X-Session-Token")
+        .and_then(|v| v.to_str().ok())
+    {
+        return Some(header.to_string());
+    }
+
+    parts
+        .headers
+        .get("Cookie")
+        .and_then(|v| v.to_str().ok())
+        .and_then(session_cookie_value)
+}
+
+/// Extract the `session_token` value from a `Cookie` header, if present.
+fn session_cookie_value(cookie_header: &str) -> Option<String> {
+    cookie_header.split(';').find_map(|pair| {
+        pair.trim()
+            .strip_prefix("session_token=")
+            .map(str::to_string)
+    })
+}
+
 #[async_trait]
 impl FromRequestParts<AppState> for AuthenticatedUser {
     type Rejection = ApiError;
@@ -22,14 +54,11 @@ impl FromRequestParts<AppState> for AuthenticatedUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let token = parts
-            .headers
-            .get("X-Session-Token")
-            .and_then(|v| v.to_str().ok())
+        let token = session_token_from_parts(parts)
             .ok_or_else(|| ApiError::Unauthorized("Missing session token".to_string()))?;
 
         let user_id = state
-            .get_authenticated_user_id_from_token(token)
+            .get_authenticated_user_id_from_token(&token)
             .ok_or_else(|| ApiError::Unauthorized("Invalid session token".to_string()))?;
 
         Ok(AuthenticatedUser(user_id))
@@ -44,16 +73,29 @@ impl FromRequestParts<AppState> for OptionalUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let token = parts
-            .headers
-            .get("X-Session-Token")
-            .and_then(|v| v.to_str().ok());
-
-        if let Some(token) = token {
-            let user_id = state.get_authenticated_user_id_from_token(token);
+        if let Some(token) = session_token_from_parts(parts) {
+            let user_id = state.get_authenticated_user_id_from_token(&token);
             return Ok(OptionalUser(user_id));
         }
 
         Ok(OptionalUser(None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::session_cookie_value;
+
+    #[test]
+    fn extracts_session_token_cookie() {
+        assert_eq!(
+            session_cookie_value("session_token=abc123").as_deref(),
+            Some("abc123")
+        );
+        assert_eq!(
+            session_cookie_value("theme=dark; session_token=xyz; other=1").as_deref(),
+            Some("xyz")
+        );
+        assert_eq!(session_cookie_value("theme=dark; other=1"), None);
     }
 }

--- a/fido-server/src/http/headers.rs
+++ b/fido-server/src/http/headers.rs
@@ -2,39 +2,38 @@
 
 use axum::http::HeaderMap;
 
-/// Extract the client IP address from common proxy headers.
+/// Extract the client IP address from the reverse proxy's validated hop.
 ///
 /// # Trust model
 ///
-/// This assumes the app runs behind a **single trusted reverse proxy**
-/// (nginx / Railway). `X-Forwarded-For` is a comma-separated list where each
-/// hop appends the address it received the connection from. The entry appended
-/// by our immediate proxy is the **right-most** one, so we take that rather
-/// than the left-most, which is fully attacker-controlled and forgeable.
+/// The deploy path is `client -> Railway edge -> nginx -> fido-server` (two
+/// proxy hops). nginx runs the `real_ip` module against a trusted-proxy
+/// allowlist (see `nginx.conf`), resolves the true client address, and forwards
+/// it as `X-Real-IP` — overwriting any value the client supplied. That single
+/// header is the only trustworthy source of the client IP.
 ///
-/// If additional trusted proxies are ever introduced, this single-hop
-/// assumption must be revisited (e.g. a trusted-proxy CIDR allowlist).
+/// Raw `X-Forwarded-For` is deliberately **not** parsed here: under two hops
+/// neither end of the list is reliable (the right-most is the Railway edge, the
+/// left-most is fully attacker-forgeable), and if the app port were ever
+/// directly reachable, every XFF entry would be spoofable. Trusting only the
+/// nginx-written `X-Real-IP` keeps IP attribution consistent for both rate
+/// limiting and audit logging.
 pub fn extract_client_ip(headers: &HeaderMap) -> Option<String> {
-    if let Some(forwarded) = headers.get("X-Forwarded-For") {
-        if let Ok(value) = forwarded.to_str() {
-            // Take the right-most entry: the hop added by our trusted proxy.
-            if let Some(last) = value.split(',').next_back().map(str::trim) {
-                if !last.is_empty() {
-                    return Some(last.to_string());
-                }
-            }
-        }
-    }
-
     if let Some(real_ip) = headers.get("X-Real-IP") {
         if let Ok(value) = real_ip.to_str() {
-            return Some(value.to_string());
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
         }
     }
 
     if let Some(fly_ip) = headers.get("Fly-Client-IP") {
         if let Ok(value) = fly_ip.to_str() {
-            return Some(value.to_string());
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
         }
     }
 
@@ -47,4 +46,44 @@ pub fn extract_user_agent(headers: &HeaderMap) -> Option<String> {
         .get("User-Agent")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    #[test]
+    fn resolves_from_nginx_validated_x_real_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Real-IP", "203.0.113.9".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers).as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn forged_x_forwarded_for_does_not_change_resolved_ip() {
+        // Attacker forges XFF entries; only the nginx-written X-Real-IP is trusted.
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Real-IP", "203.0.113.9".parse().unwrap());
+        headers.insert(
+            "X-Forwarded-For",
+            "6.6.6.6, 7.7.7.7, 8.8.8.8".parse().unwrap(),
+        );
+        assert_eq!(extract_client_ip(&headers).as_deref(), Some("203.0.113.9"));
+    }
+
+    #[test]
+    fn forged_x_forwarded_for_alone_is_ignored() {
+        // Without the nginx hop, a bare forged XFF must not be trusted.
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Forwarded-For", "6.6.6.6, 7.7.7.7".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers), None);
+    }
+
+    #[test]
+    fn blank_x_real_ip_falls_through() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Real-IP", "   ".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers), None);
+    }
 }

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -201,8 +201,8 @@ pub fn create_router_with_security_config(
         .layer(middleware::from_fn(
             security::headers::create_security_headers_layer(security_config.environment),
         ))
-        // Request body size limit: 1MB (1024 * 1024 bytes)
-        .layer(RequestBodyLimitLayer::new(1024 * 1024))
+        // Request body size limit from the configured MAX_REQUEST_SIZE.
+        .layer(RequestBodyLimitLayer::new(security_config.max_request_size))
 }
 
 async fn health_check() -> &'static str {
@@ -258,6 +258,33 @@ mod tests {
         };
 
         assert_eq!(status_for(config, "/users/test").await?, StatusCode::OK);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn configured_max_request_size_is_enforced() -> Result<()> {
+        // A tiny configured limit must reject a larger body with 413 before the
+        // request ever reaches a handler.
+        let config = security::SecurityConfig {
+            environment: security::Environment::Development,
+            max_request_size: 64,
+            ..Default::default()
+        };
+        let router = create_router_with_security_config(test_state()?, &config);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.expect("test server");
+        });
+
+        let big_body = "x".repeat(4096);
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/posts"))
+            .header("content-type", "application/json")
+            .body(big_body)
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
         Ok(())
     }
 

--- a/fido-server/src/lib.rs
+++ b/fido-server/src/lib.rs
@@ -26,17 +26,6 @@ use rate_limit::RateLimiter;
 use state::AppState;
 use tower_http::limit::RequestBodyLimitLayer;
 
-/// Create the application router for testing
-///
-/// This function creates the same router used by the main server,
-/// but allows tests to create it with a custom AppState.
-pub fn create_router(state: AppState) -> Router {
-    // Configure CORS using environment-aware configuration
-    let security_config = security::SecurityConfig::from_env()
-        .unwrap_or_else(|_| security::SecurityConfig::default());
-    create_router_with_security_config(state, &security_config)
-}
-
 /// Create the shared API router used by production startup and tests.
 ///
 /// This intentionally excludes production-only static file fallback routing;

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -77,6 +77,20 @@ async fn main() {
             eprintln!("FATAL: FIDO_TOKEN_KEY validation failed: {}", e);
             std::process::exit(1);
         }
+
+        // GITHUB_CLIENT_SECRET is required to revoke GitHub grants on logout.
+        // Without it, logout deletes only the local ciphertext and leaves the
+        // upstream grant live indefinitely, so fail fast rather than silently
+        // skipping revocation in production.
+        if std::env::var("GITHUB_CLIENT_SECRET")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .is_none()
+        {
+            tracing::error!("GITHUB_CLIENT_SECRET is required in production");
+            eprintln!("FATAL: GITHUB_CLIENT_SECRET is required in production");
+            std::process::exit(1);
+        }
     }
 
     // Load settings with detailed error handling

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -84,8 +84,7 @@ async fn main() {
         // skipping revocation in production.
         if std::env::var("GITHUB_CLIENT_SECRET")
             .ok()
-            .filter(|v| !v.trim().is_empty())
-            .is_none()
+            .is_none_or(|v| v.trim().is_empty())
         {
             tracing::error!("GITHUB_CLIENT_SECRET is required in production");
             eprintln!("FATAL: GITHUB_CLIENT_SECRET is required in production");
@@ -228,7 +227,7 @@ async fn main() {
     // Start background task for periodic session cleanup
     let cleanup_state = state.clone();
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(3600)); // Run every hour
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_hours(1));
         loop {
             interval.tick().await;
             tracing::debug!("Running periodic session cleanup...");

--- a/fido-server/src/rate_limit.rs
+++ b/fido-server/src/rate_limit.rs
@@ -79,7 +79,9 @@ impl RateLimiter {
                 // Check if we're still in the same window
                 if now.duration_since(*window_start) < self.window_duration {
                     if *count >= self.max_requests {
-                        let remaining = self.window_duration - now.duration_since(*window_start);
+                        let remaining = self
+                            .window_duration
+                            .saturating_sub(now.duration_since(*window_start));
                         return RateLimitInfo {
                             exceeded: true,
                             request_count: *count,

--- a/fido-server/src/rate_limit.rs
+++ b/fido-server/src/rate_limit.rs
@@ -22,7 +22,17 @@ const MAX_TRACKED_KEYS: usize = 100_000;
 const SOFT_PRUNE_THRESHOLD: usize = 10_000;
 
 /// Simple in-memory rate limiter
-/// Tracks requests per key (session token or client IP) with a sliding window
+/// Tracks requests per key (session token or client IP) with a sliding window.
+///
+/// # Scope / single-instance assumption
+///
+/// This counter lives in the process heap, so it is per-instance. With more
+/// than one server replica behind the load balancer, a client's requests are
+/// split across replicas and the effective per-IP/token limit multiplies by the
+/// replica count. It is a secondary, app-level guard only; the authoritative
+/// per-client edge limit is nginx's `limit_req` zone (see `nginx.conf`), which
+/// keys on the real_ip-resolved client address. Anonymous IP keys here rely on
+/// `http::extract_client_ip`, which trusts only the nginx-written `X-Real-IP`.
 #[derive(Clone)]
 pub struct RateLimiter {
     // Map of rate-limit key -> (request_count, window_start)

--- a/fido-server/src/realtime.rs
+++ b/fido-server/src/realtime.rs
@@ -39,6 +39,11 @@ impl OutboundEvent {
     }
 }
 
+/// Maximum simultaneous WebSocket connections a single user may hold. Each
+/// connection costs a task and a 256-slot broadcast receiver, so an
+/// unauthenticated-per-user cap bounds memory/FD exhaustion by one account.
+pub const MAX_CONNECTIONS_PER_USER: usize = 8;
+
 /// Tracks how many live WebSocket connections each user holds.
 #[derive(Debug, Default)]
 pub struct ConnectionRegistry {
@@ -46,12 +51,29 @@ pub struct ConnectionRegistry {
 }
 
 impl ConnectionRegistry {
-    /// Record a new connection; returns the user's connection count after it.
-    pub fn connect(&self, user_id: Uuid) -> usize {
+    /// Record a new connection if the user is under [`MAX_CONNECTIONS_PER_USER`].
+    ///
+    /// Returns `Some(count)` (the count after incrementing) when accepted, or
+    /// `None` when the user is already at the cap — in which case nothing is
+    /// incremented and the caller must reject the upgrade.
+    pub fn try_connect(&self, user_id: Uuid) -> Option<usize> {
         let mut connections = self.connections.lock().unwrap_or_else(|e| e.into_inner());
         let count = connections.entry(user_id).or_insert(0);
+        if *count >= MAX_CONNECTIONS_PER_USER {
+            return None;
+        }
         *count += 1;
-        *count
+        Some(*count)
+    }
+
+    /// Current live connection count for a user (0 if none).
+    pub fn count(&self, user_id: &Uuid) -> usize {
+        self.connections
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(user_id)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Record a closed connection; returns the user's remaining count.
@@ -395,11 +417,27 @@ mod tests {
     fn registry_tracks_multiple_connections_per_user() {
         let registry = ConnectionRegistry::default();
         let user = Uuid::new_v4();
-        assert_eq!(registry.connect(user), 1);
-        assert_eq!(registry.connect(user), 2);
+        assert_eq!(registry.try_connect(user), Some(1));
+        assert_eq!(registry.try_connect(user), Some(2));
         assert_eq!(registry.disconnect(user), 1);
         assert_eq!(registry.disconnect(user), 0);
         assert_eq!(registry.disconnect(user), 0);
+    }
+
+    #[test]
+    fn registry_rejects_connections_over_per_user_cap() {
+        let registry = ConnectionRegistry::default();
+        let user = Uuid::new_v4();
+        for expected in 1..=MAX_CONNECTIONS_PER_USER {
+            assert_eq!(registry.try_connect(user), Some(expected));
+        }
+        // At the cap: further connections are refused without incrementing.
+        assert_eq!(registry.try_connect(user), None);
+        assert_eq!(registry.try_connect(user), None);
+        // Freeing one slot lets exactly one more in.
+        assert_eq!(registry.disconnect(user), MAX_CONNECTIONS_PER_USER - 1);
+        assert_eq!(registry.try_connect(user), Some(MAX_CONNECTIONS_PER_USER));
+        assert_eq!(registry.try_connect(user), None);
     }
 
     #[test]

--- a/fido-server/src/security/AGENTS.md
+++ b/fido-server/src/security/AGENTS.md
@@ -14,6 +14,7 @@ Environment-aware security configuration, CORS, cookies, headers, admin access, 
 - Do not weaken secure-cookie, CORS, admin, header, or token requirements to make a local test pass.
 - Make policy changes explicit in tests for development and production behavior.
 - Keep secrets out of logs and error messages.
+- `validation::contains_dangerous_patterns` is a non-authoritative input denylist (defense-in-depth), NOT the XSS boundary. XSS safety comes from contextual output encoding at each render sink. Do NOT add a server- or client-side path that renders stored user content into HTML/SVG while trusting this filter; encode at the sink instead.
 
 ## Verification
 

--- a/fido-server/src/security/admin.rs
+++ b/fido-server/src/security/admin.rs
@@ -12,30 +12,9 @@ use axum::{
 };
 use serde_json::json;
 
+use crate::http::{extract_client_ip, extract_user_agent};
 use crate::security::{AuditEvent, AuditEventType};
 use crate::state::AppState;
-
-/// Helper function to extract client IP address from headers
-fn extract_client_ip(headers: &axum::http::HeaderMap) -> Option<String> {
-    headers
-        .get("X-Forwarded-For")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.split(',').next().unwrap_or(s).trim().to_string())
-        .or_else(|| {
-            headers
-                .get("X-Real-IP")
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string())
-        })
-}
-
-/// Helper function to extract User-Agent from headers
-fn extract_user_agent(headers: &axum::http::HeaderMap) -> Option<String> {
-    headers
-        .get("User-Agent")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string())
-}
 
 /// Middleware that requires the authenticated user to be an admin.
 ///

--- a/fido-server/src/security/admin.rs
+++ b/fido-server/src/security/admin.rs
@@ -16,6 +16,23 @@ use crate::http::{extract_client_ip, extract_user_agent};
 use crate::security::{AuditEvent, AuditEventType};
 use crate::state::AppState;
 
+/// Whether the given GitHub login is granted admin via the `FIDO_ADMIN_LOGINS`
+/// allowlist (comma-separated, case-insensitive). This is the supported
+/// production grant path for the admin endpoints.
+fn admin_login_allowlisted(github_login: Option<&str>) -> bool {
+    let Some(login) = github_login else {
+        return false;
+    };
+    match std::env::var("FIDO_ADMIN_LOGINS") {
+        Ok(list) => list
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .any(|entry| entry.eq_ignore_ascii_case(login)),
+        Err(_) => false,
+    }
+}
+
 /// Middleware that requires the authenticated user to be an admin.
 ///
 /// This middleware:
@@ -146,8 +163,14 @@ pub async fn require_admin(
         }
     };
 
+    // A user is admin if the DB flag is set OR their current GitHub login is in
+    // the FIDO_ADMIN_LOGINS allowlist. The allowlist is the supported production
+    // grant path (seed-data admins are dev-only and not seeded in production).
+    let github_login = state.repos.users.get_github_login(&user_id).ok().flatten();
+    let is_admin = user.is_admin || admin_login_allowlisted(github_login.as_deref());
+
     // Check if user is an admin
-    if !user.is_admin {
+    if !is_admin {
         tracing::warn!(
             "Non-admin user {} ({}) attempted to access admin endpoint",
             user.username,
@@ -238,6 +261,21 @@ mod tests {
             .expect("User not found");
 
         assert!(user.is_admin, "Admin user should have is_admin = true");
+    }
+
+    #[test]
+    fn admin_allowlist_grants_case_insensitively() {
+        let _guard = crate::test_utils::env_lock().lock().unwrap();
+        std::env::set_var("FIDO_ADMIN_LOGINS", "octocat, Alice ,bob");
+
+        assert!(super::admin_login_allowlisted(Some("octocat")));
+        assert!(super::admin_login_allowlisted(Some("ALICE"))); // case-insensitive
+        assert!(super::admin_login_allowlisted(Some("bob")));
+        assert!(!super::admin_login_allowlisted(Some("mallory")));
+        assert!(!super::admin_login_allowlisted(None));
+
+        std::env::remove_var("FIDO_ADMIN_LOGINS");
+        assert!(!super::admin_login_allowlisted(Some("octocat")));
     }
 
     #[test]

--- a/fido-server/src/security/headers.rs
+++ b/fido-server/src/security/headers.rs
@@ -51,7 +51,10 @@ pub async fn security_headers_middleware(
 
     // X-Content-Type-Options: Prevents MIME type sniffing
     // Requirement 9.1
-    headers.insert(header::X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
 
     // X-Frame-Options: Prevents clickjacking attacks
     // Requirement 9.2
@@ -59,7 +62,10 @@ pub async fn security_headers_middleware(
 
     // X-XSS-Protection: Enables XSS filtering in older browsers
     // Requirement 9.3
-    headers.insert(header::X_XSS_PROTECTION, HeaderValue::from_static("1; mode=block"));
+    headers.insert(
+        header::X_XSS_PROTECTION,
+        HeaderValue::from_static("1; mode=block"),
+    );
 
     // Content-Security-Policy: Restricts resource loading to same origin
     // Requirement 9.4

--- a/fido-server/src/security/headers.rs
+++ b/fido-server/src/security/headers.rs
@@ -13,7 +13,7 @@
 
 use axum::{
     body::Body,
-    http::{header, Request, Response},
+    http::{header, HeaderValue, Request, Response},
     middleware::Next,
 };
 
@@ -51,30 +51,30 @@ pub async fn security_headers_middleware(
 
     // X-Content-Type-Options: Prevents MIME type sniffing
     // Requirement 9.1
-    headers.insert(header::X_CONTENT_TYPE_OPTIONS, "nosniff".parse().unwrap());
+    headers.insert(header::X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
 
     // X-Frame-Options: Prevents clickjacking attacks
     // Requirement 9.2
-    headers.insert(header::X_FRAME_OPTIONS, "DENY".parse().unwrap());
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
 
     // X-XSS-Protection: Enables XSS filtering in older browsers
     // Requirement 9.3
-    headers.insert(header::X_XSS_PROTECTION, "1; mode=block".parse().unwrap());
+    headers.insert(header::X_XSS_PROTECTION, HeaderValue::from_static("1; mode=block"));
 
     // Content-Security-Policy: Restricts resource loading to same origin
     // Requirement 9.4
     headers.insert(
         header::CONTENT_SECURITY_POLICY,
-        "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'"
-            .parse()
-            .unwrap(),
+        HeaderValue::from_static(
+            "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'",
+        ),
     );
 
     // Referrer-Policy: Controls how much referrer information is sent
     // Requirement 9.5
     headers.insert(
         header::REFERRER_POLICY,
-        "strict-origin-when-cross-origin".parse().unwrap(),
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
     );
 
     // Strict-Transport-Security: Enforces HTTPS (production only)
@@ -82,7 +82,7 @@ pub async fn security_headers_middleware(
     if environment.is_production() {
         headers.insert(
             header::STRICT_TRANSPORT_SECURITY,
-            "max-age=31536000; includeSubDomains".parse().unwrap(),
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
         );
     }
 

--- a/fido-server/src/security/validation.rs
+++ b/fido-server/src/security/validation.rs
@@ -206,13 +206,21 @@ impl InputValidator {
         Ok(())
     }
 
-    /// Check if text contains potentially dangerous patterns
+    /// Heuristic input denylist for common XSS payloads (script tags, `on*=`
+    /// handlers, `javascript:`/`data:` URLs, `expression()`, `vbscript:`).
     ///
-    /// Detects common XSS attack patterns including:
-    /// - Script tags
-    /// - Event handlers (onclick, onerror, etc.)
-    /// - JavaScript URLs
-    /// - Data URLs with script content
+    /// # This is NOT the XSS boundary
+    ///
+    /// A denylist is defense-in-depth only and is trivially bypassable
+    /// (`<svg>`, `<iframe>`, `<img src=x>`, mixed/percent encodings, or plain
+    /// HTML injection with no event handler). XSS safety is guaranteed by
+    /// **contextual output encoding at every render sink**, not by this filter.
+    ///
+    /// Today the server never renders stored user content into HTML/SVG (the
+    /// TUI renders to a terminal, the badge interpolates only an `i64`, and the
+    /// static `web/` client inserts no user data), so there is no live XSS
+    /// surface. Do NOT add a render path that trusts this filter instead of
+    /// encoding its output — see `src/security/AGENTS.md`.
     fn contains_dangerous_patterns(&self, text: &str) -> bool {
         let lower = text.to_lowercase();
 

--- a/fido-server/src/services/communities.rs
+++ b/fido-server/src/services/communities.rs
@@ -99,7 +99,12 @@ impl CommunityService {
     /// Guard: the caller must belong to the community. Roster and metadata reads
     /// are member-only even though communities map to public GitHub repos.
     fn require_membership(&self, user_id: Uuid, community_id: &Uuid) -> ApiResult<()> {
-        if self.repos.memberships.get(community_id, &user_id)?.is_none() {
+        if self
+            .repos
+            .memberships
+            .get(community_id, &user_id)?
+            .is_none()
+        {
             return Err(ApiError::Forbidden(
                 "You are not a member of this community".to_string(),
             ));

--- a/fido-server/src/services/communities.rs
+++ b/fido-server/src/services/communities.rs
@@ -96,12 +96,24 @@ impl CommunityService {
             .collect()
     }
 
+    /// Guard: the caller must belong to the community. Roster and metadata reads
+    /// are member-only even though communities map to public GitHub repos.
+    fn require_membership(&self, user_id: Uuid, community_id: &Uuid) -> ApiResult<()> {
+        if self.repos.memberships.get(community_id, &user_id)?.is_none() {
+            return Err(ApiError::Forbidden(
+                "You are not a member of this community".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     pub fn get_view(&self, user_id: Uuid, community_id: Uuid) -> ApiResult<CommunityView> {
         let community = self
             .repos
             .communities
             .get_by_id(&community_id)?
             .ok_or_else(|| ApiError::NotFound("Community not found".to_string()))?;
+        self.require_membership(user_id, &community.id)?;
         self.view_for_community(user_id, community)
     }
 
@@ -148,10 +160,13 @@ impl CommunityService {
     }
 
     /// Members of a community with usernames, admins first then alphabetical.
+    /// Requires the caller to be a member (roster is member-only).
     pub fn list_members_with_usernames(
         &self,
+        user_id: Uuid,
         community_id: &Uuid,
     ) -> ApiResult<Vec<(String, MembershipRole)>> {
+        self.require_membership(user_id, community_id)?;
         let memberships = self.repos.memberships.list_members(community_id)?;
         let mut members: Vec<(String, MembershipRole)> = memberships
             .into_iter()
@@ -482,9 +497,17 @@ mod tests {
         };
         let service = CommunityService::new(repos, github);
 
-        let members = service.list_members_with_usernames(&community.id)?;
+        // alice is a member, so she may read the roster.
+        let members = service.list_members_with_usernames(alice_id, &community.id)?;
         assert_eq!(members[0], ("alice".to_string(), MembershipRole::Admin));
         assert_eq!(members[1], ("zed".to_string(), MembershipRole::Member));
+
+        // A non-member is refused.
+        let outsider_id = Uuid::new_v4();
+        assert!(matches!(
+            service.list_members_with_usernames(outsider_id, &community.id),
+            Err(ApiError::Forbidden(_))
+        ));
         Ok(())
     }
 

--- a/fido-server/src/services/dms.rs
+++ b/fido-server/src/services/dms.rs
@@ -45,26 +45,14 @@ impl DMService {
 
         let mut conversations = Vec::with_capacity(summaries.len());
         for summary in summaries {
-            let user = self
-                .repos
-                .users
-                .get_by_id(&summary.other_user_id)?
-                .ok_or_else(|| ApiError::NotFound("User not found".to_string()))?;
-
-            let conversation = self
-                .repos
-                .dm_conversations
-                .get(user_id, &summary.other_user_id)?
-                .ok_or_else(|| ApiError::NotFound("DM conversation not found".to_string()))?;
-
             conversations.push(ConversationSummary {
                 other_user_id: summary.other_user_id.to_string(),
-                other_username: user.username,
+                other_username: summary.other_username,
                 last_message: summary.last_message,
                 last_message_time: summary.last_message_time.to_rfc3339(),
                 unread_count: summary.unread_count,
-                state: conversation.state,
-                initiated_by_me: conversation.initiator_id == *user_id,
+                state: summary.state,
+                initiated_by_me: summary.initiator_id == *user_id,
             });
         }
 

--- a/fido-server/src/services/dms.rs
+++ b/fido-server/src/services/dms.rs
@@ -216,9 +216,11 @@ impl DMService {
             ));
         }
 
+        // The responder must be the recipient of the request, not its initiator:
+        // the request must have been initiated by the other party (requester_id).
         if conversation.initiator_id != *requester_id {
             return Err(ApiError::Forbidden(
-                "Only the request recipient can update this DM request".to_string(),
+                "You cannot accept or decline a DM request you initiated".to_string(),
             ));
         }
 

--- a/fido-server/src/services/github.rs
+++ b/fido-server/src/services/github.rs
@@ -255,18 +255,28 @@ impl GithubService {
     }
 
     pub async fn is_contributor(&self, user_id: Uuid, owner: &str, name: &str) -> Result<bool> {
-        let user = self
-            .repos
-            .users
-            .get_by_id(&user_id)
-            .with_context(|| format!("Failed to load user {}", user_id))?
-            .ok_or_else(|| anyhow!("User {} not found", user_id))?;
-        let github_login = user.username;
+        // Prefer the current github_login (updated on re-login) over the frozen
+        // signup username, and compare case-insensitively since GitHub logins
+        // are case-insensitive. Falls back to username if no login is stored.
+        let github_login = match self.repos.users.get_github_login(&user_id)? {
+            Some(login) => login,
+            None => self
+                .repos
+                .users
+                .get_by_id(&user_id)
+                .with_context(|| format!("Failed to load user {}", user_id))?
+                .ok_or_else(|| anyhow!("User {} not found", user_id))?
+                .username,
+        };
         let url = format!("{}/repos/{}/{}/contributors", self.api_base, owner, name);
         let result = self
             .get_public::<Vec<GithubContributor>>(url, "is_contributor")
             .await
-            .map(|contributors| contributors.iter().any(|c| c.login == github_login));
+            .map(|contributors| {
+                contributors
+                    .iter()
+                    .any(|c| c.login.eq_ignore_ascii_case(&github_login))
+            });
 
         let op = format!("GET /repos/{}/{}/contributors", owner, name);
         self.log_result("is_contributor", user_id, Some(&op), &result);
@@ -372,12 +382,14 @@ impl GithubService {
 
     async fn try_revoke_remote_token(&self, token: &str) {
         let Some(client_id) = self.oauth_client_id.as_deref() else {
-            tracing::debug!("Skipping GitHub token revocation: GITHUB_CLIENT_ID not configured");
+            tracing::warn!(
+                "Skipping GitHub token revocation: GITHUB_CLIENT_ID not configured; the upstream grant remains live"
+            );
             return;
         };
         let Some(client_secret) = self.oauth_client_secret.as_deref() else {
-            tracing::debug!(
-                "Skipping GitHub token revocation: GITHUB_CLIENT_SECRET not configured"
+            tracing::warn!(
+                "Skipping GitHub token revocation: GITHUB_CLIENT_SECRET not configured; the upstream grant remains live"
             );
             return;
         };

--- a/fido-server/src/services/github.rs
+++ b/fido-server/src/services/github.rs
@@ -260,13 +260,14 @@ impl GithubService {
         // are case-insensitive. Falls back to username if no login is stored.
         let github_login = match self.repos.users.get_github_login(&user_id)? {
             Some(login) => login,
-            None => self
-                .repos
-                .users
-                .get_by_id(&user_id)
-                .with_context(|| format!("Failed to load user {}", user_id))?
-                .ok_or_else(|| anyhow!("User {} not found", user_id))?
-                .username,
+            None => {
+                self.repos
+                    .users
+                    .get_by_id(&user_id)
+                    .with_context(|| format!("Failed to load user {}", user_id))?
+                    .ok_or_else(|| anyhow!("User {} not found", user_id))?
+                    .username
+            }
         };
         let url = format!("{}/repos/{}/{}/contributors", self.api_base, owner, name);
         let result = self

--- a/fido-server/src/services/posts.rs
+++ b/fido-server/src/services/posts.rs
@@ -443,8 +443,21 @@ impl PostService {
     }
 
     fn populate_posts(&self, posts: &mut [Post], user_id: Option<Uuid>) -> ApiResult<()> {
+        let Some(uid) = user_id else {
+            return Ok(());
+        };
+        if posts.is_empty() {
+            return Ok(());
+        }
+
+        // One batched vote lookup for the whole slice instead of one query per
+        // post (N+1). Covers feed and reply trees, which both route here.
+        let ids: Vec<Uuid> = posts.iter().map(|post| post.id).collect();
+        let votes = self.repos.votes.get_votes_for_posts(&uid, &ids)?;
         for post in posts {
-            self.populate_post(post, user_id)?;
+            if let Some(direction) = votes.get(&post.id) {
+                post.user_vote = Some(direction.as_str().to_string());
+            }
         }
         Ok(())
     }

--- a/fido-server/src/services/posts.rs
+++ b/fido-server/src/services/posts.rs
@@ -367,6 +367,13 @@ impl PostService {
             .ok_or_else(|| ApiError::NotFound("Post not found".to_string()))?;
         self.ensure_visible(&post, *user_id)?;
 
+        // Reject self-votes so a user cannot inflate their own karma.
+        if post.author_id == *user_id {
+            return Err(ApiError::BadRequest(
+                "You cannot vote on your own post".to_string(),
+            ));
+        }
+
         self.repos.votes.upsert_vote(user_id, post_id, direction)?;
         self.repos.posts.update_vote_counts(post_id)?;
 
@@ -521,6 +528,16 @@ impl PostService {
         let notifications = NotificationService::new(self.repos.clone(), self.event_bus.clone());
         for username in extract_mentions(&post.content) {
             if let Some(user) = self.repos.users.get_by_username(&username)? {
+                // Only notify mentioned users who belong to this community, so a
+                // mention cannot fan out cross-community notification spam.
+                if self
+                    .repos
+                    .memberships
+                    .get(&post.community_id, &user.id)?
+                    .is_none()
+                {
+                    continue;
+                }
                 notifications.create(
                     user.id,
                     NotificationType::Mention,

--- a/fido-server/src/services/posts.rs
+++ b/fido-server/src/services/posts.rs
@@ -374,8 +374,9 @@ impl PostService {
             ));
         }
 
-        self.repos.votes.upsert_vote(user_id, post_id, direction)?;
-        self.repos.posts.update_vote_counts(post_id)?;
+        self.repos
+            .votes
+            .upsert_vote_with_recount(user_id, post_id, direction)?;
 
         Ok(())
     }

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -60,7 +60,10 @@ async fn spawn_server(github_api_base: Option<&str>) -> Result<TestServer> {
         std::env::remove_var("GITHUB_API_BASE");
         state
     };
-    let router = fido_server::create_router(state.clone());
+    let router = fido_server::create_router_with_security_config(
+        state.clone(),
+        &fido_server::security::SecurityConfig::default(),
+    );
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -85,7 +85,7 @@ async fn spawn_server(github_api_base: Option<&str>) -> Result<TestServer> {
 /// Deterministic fixture repo id so parallel joins of the same owner/name agree.
 fn fixture_repo_id(owner: &str, name: &str) -> i64 {
     let mut hash: i64 = 7;
-    for byte in owner.bytes().chain([b'/']).chain(name.bytes()) {
+    for byte in owner.bytes().chain(*b"/").chain(name.bytes()) {
         hash = hash.wrapping_mul(31).wrapping_add(byte as i64);
     }
     hash.abs().max(2)

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -1025,3 +1025,47 @@ async fn community_badge_is_public_and_reflects_member_count() -> Result<()> {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Stint 0025: authenticate user search + profile-read endpoints
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn user_search_and_profile_read_require_auth() -> Result<()> {
+    let server = spawn_server(None).await?;
+    let repos = &server.state.repos;
+    let alice = create_user(repos, "e2e-auth-alice")?;
+
+    let anon = reqwest::Client::new();
+    let base = format!("http://{}", server.addr);
+
+    // Anonymous user search is rejected.
+    let search = anon
+        .get(format!("{}/users/search?q=e2e", base))
+        .send()
+        .await?;
+    assert_eq!(search.status(), StatusCode::UNAUTHORIZED);
+
+    // Anonymous profile read is rejected.
+    let profile = anon
+        .get(format!("{}/users/{}/profile", base, alice.id))
+        .send()
+        .await?;
+    assert_eq!(profile.status(), StatusCode::UNAUTHORIZED);
+
+    // With a valid session token both succeed.
+    let client = login(&server, &alice)?;
+    assert_eq!(
+        client.get("/users/search?q=e2e").await?.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        client
+            .get(&format!("/users/{}/profile", alice.id))
+            .await?
+            .status(),
+        StatusCode::OK
+    );
+
+    Ok(())
+}

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -1196,3 +1196,31 @@ async fn contributor_role_matches_github_login_case_insensitively() -> Result<()
     assert_eq!(view["membership"]["role"], "contributor");
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Stint 0038: the server now accepts the session cookie as an auth source
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn session_cookie_authenticates_requests() -> Result<()> {
+    let server = spawn_server(None).await?;
+    let repos = &server.state.repos;
+    let alice = create_user(repos, "cookie-alice")?;
+    let token = server.state.session_manager.create_session(alice.id)?;
+
+    let base = format!("http://{}", server.addr);
+    let http = reqwest::Client::new();
+
+    // No credentials at all -> rejected.
+    let anon = http.get(format!("{base}/social/following")).send().await?;
+    assert_eq!(anon.status(), StatusCode::UNAUTHORIZED);
+
+    // Authenticated purely via the session_token cookie -> accepted.
+    let via_cookie = http
+        .get(format!("{base}/social/following"))
+        .header("Cookie", format!("session_token={token}"))
+        .send()
+        .await?;
+    assert_eq!(via_cookie.status(), StatusCode::OK);
+    Ok(())
+}

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -1163,7 +1163,10 @@ async fn self_vote_is_rejected_and_mentions_are_member_scoped() -> Result<()> {
     let outsider_notifs =
         json_body(login(&server, &outsider)?.get("/notifications").await?).await?;
     assert!(
-        outsider_notifs.as_array().map(|a| a.is_empty()).unwrap_or(true),
+        outsider_notifs
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true),
         "non-member must not receive a mention notification"
     );
 

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -1072,3 +1072,40 @@ async fn user_search_and_profile_read_require_auth() -> Result<()> {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Stint 0032: enforce membership on community roster/metadata reads
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn community_detail_and_roster_are_member_only() -> Result<()> {
+    let server = spawn_server(None).await?;
+    let repos = &server.state.repos;
+
+    let (community, _channel) = seed_community(repos, false)?;
+    let member = create_user(repos, "roster-member")?;
+    let outsider = create_user(repos, "roster-outsider")?;
+    add_member(repos, community.id, member.id, MembershipRole::Member)?;
+
+    let member_client = login(&server, &member)?;
+    let outsider_client = login(&server, &outsider)?;
+
+    let detail = format!("/communities/{}", community.id);
+    let roster = format!("/communities/{}/members", community.id);
+
+    // Members get 200 on both.
+    assert_eq!(member_client.get(&detail).await?.status(), StatusCode::OK);
+    assert_eq!(member_client.get(&roster).await?.status(), StatusCode::OK);
+
+    // Non-members are forbidden on both.
+    assert_eq!(
+        outsider_client.get(&detail).await?.status(),
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        outsider_client.get(&roster).await?.status(),
+        StatusCode::FORBIDDEN
+    );
+
+    Ok(())
+}

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -1169,3 +1169,30 @@ async fn self_vote_is_rejected_and_mentions_are_member_scoped() -> Result<()> {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Stint 0037: case-insensitive GitHub contributor matching
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn contributor_role_matches_github_login_case_insensitively() -> Result<()> {
+    let fixture_base = github_fixture_server().await?;
+    let server = spawn_server(Some(&fixture_base)).await?;
+    let repos = &server.state.repos;
+
+    // The contributors fixture lists "alice"; this user's login differs only in
+    // case, so a case-insensitive match must grant the Contributor role.
+    let alice = create_user(repos, "ALICE")?;
+    let client = login(&server, &alice)?;
+
+    let response = client
+        .post(
+            "/communities/join",
+            &json!({ "owner": "octocat", "name": "Hello-World" }),
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK, "join should succeed");
+    let view = json_body(response).await?;
+    assert_eq!(view["membership"]["role"], "contributor");
+    Ok(())
+}

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -1109,3 +1109,63 @@ async fn community_detail_and_roster_are_member_only() -> Result<()> {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Stint 0033: reject self-votes + scope mention notifications to members
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn self_vote_is_rejected_and_mentions_are_member_scoped() -> Result<()> {
+    let server = spawn_server(None).await?;
+    let repos = &server.state.repos;
+
+    let (community, _channel) = seed_community(repos, false)?;
+    let author = create_user(repos, "vote-author")?;
+    let member = create_user(repos, "mention-member")?;
+    let outsider = create_user(repos, "mention-outsider")?;
+    add_member(repos, community.id, author.id, MembershipRole::Member)?;
+    add_member(repos, community.id, member.id, MembershipRole::Member)?;
+    // `outsider` is a real user but NOT a member of this community.
+
+    let author_client = login(&server, &author)?;
+
+    // Author creates a thread mentioning both a member and a non-member.
+    let response = author_client
+        .post(
+            "/posts",
+            &json!({
+                "community_id": community.id,
+                "content": "hey @mention-member and @mention-outsider"
+            }),
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let post = json_body(response).await?;
+    let post_id = post["id"].as_str().unwrap().to_string();
+
+    // Self-vote is rejected.
+    let response = author_client
+        .post(
+            &format!("/posts/{}/vote", post_id),
+            &json!({ "direction": "up" }),
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // The member mention produces a notification; the non-member's does not.
+    let member_notifs = json_body(login(&server, &member)?.get("/notifications").await?).await?;
+    assert_eq!(
+        member_notifs.as_array().map(|a| a.len()).unwrap_or(0),
+        1,
+        "member should receive the mention notification"
+    );
+
+    let outsider_notifs =
+        json_body(login(&server, &outsider)?.get("/notifications").await?).await?;
+    assert!(
+        outsider_notifs.as_array().map(|a| a.is_empty()).unwrap_or(true),
+        "non-member must not receive a mention notification"
+    );
+
+    Ok(())
+}

--- a/fido-server/tests/ws_integration_tests.rs
+++ b/fido-server/tests/ws_integration_tests.rs
@@ -51,7 +51,10 @@ async fn spawn_server() -> Result<TestServer> {
 
     let repos = Repositories::new(db.pool.clone());
     let state = AppState::new_with_repos(db, repos).context("Failed to build app state")?;
-    let router = fido_server::create_router(state.clone());
+    let router = fido_server::create_router_with_security_config(
+        state.clone(),
+        &fido_server::security::SecurityConfig::default(),
+    );
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await

--- a/fido-server/tests/ws_integration_tests.rs
+++ b/fido-server/tests/ws_integration_tests.rs
@@ -335,11 +335,7 @@ async fn ws_inbound_frame_flood_closes_connection() -> Result<()> {
 
     // Well past MAX_INBOUND_FRAMES_PER_WINDOW (60): the server must close.
     for i in 0..200u32 {
-        if ws
-            .send(WsMessage::Text(format!("spam {i}")))
-            .await
-            .is_err()
-        {
+        if ws.send(WsMessage::Text(format!("spam {i}"))).await.is_err() {
             break; // server already closed the socket
         }
     }

--- a/fido-server/tests/ws_integration_tests.rs
+++ b/fido-server/tests/ws_integration_tests.rs
@@ -305,3 +305,78 @@ async fn ws_accepts_query_token_and_delivers_notifications_to_recipient_only() -
     assert_eq!(envelope["payload"]["to_user_id"], recipient.id.to_string());
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Stint 0029: bound WebSocket resource usage per user
+// ---------------------------------------------------------------------------
+
+/// Drain frames until the socket closes (Close frame, stream end, or error),
+/// returning Ok(()) if it closed within the timeout.
+async fn expect_socket_closed(socket: &mut WsClient) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        match tokio::time::timeout_at(deadline, socket.next()).await {
+            Ok(Some(Ok(WsMessage::Close(_)))) | Ok(None) => return Ok(()),
+            Ok(Some(Ok(_))) => continue, // pings/pongs/text before the close
+            Ok(Some(Err(_))) => return Ok(()), // connection reset counts as closed
+            Err(_) => anyhow::bail!("socket did not close within timeout"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn ws_inbound_frame_flood_closes_connection() -> Result<()> {
+    let server = spawn_server().await?;
+    let repos = &server.state.repos;
+    let user = create_user(repos, "flooder")?;
+    let token = server.state.session_manager.create_session(user.id)?;
+
+    let mut ws = connect_ws(server.addr, &token).await?;
+
+    // Well past MAX_INBOUND_FRAMES_PER_WINDOW (60): the server must close.
+    for i in 0..200u32 {
+        if ws
+            .send(WsMessage::Text(format!("spam {i}")))
+            .await
+            .is_err()
+        {
+            break; // server already closed the socket
+        }
+    }
+
+    expect_socket_closed(&mut ws).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn ws_per_user_connection_cap_rejects_excess() -> Result<()> {
+    let server = spawn_server().await?;
+    let repos = &server.state.repos;
+    let user = create_user(repos, "greedy")?;
+    let token = server.state.session_manager.create_session(user.id)?;
+
+    let cap = fido_server::realtime::MAX_CONNECTIONS_PER_USER;
+
+    // Open exactly `cap` connections and wait until all are registered.
+    let mut sockets = Vec::new();
+    for _ in 0..cap {
+        sockets.push(connect_ws(server.addr, &token).await?);
+    }
+    let registry = server.state.realtime.registry();
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    while registry.count(&user.id) < cap {
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("connections never reached the cap");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // The next connection is over the cap: the server accepts the upgrade then
+    // immediately closes it with a policy-violation frame.
+    let mut excess = connect_ws(server.addr, &token).await?;
+    expect_socket_closed(&mut excess).await?;
+
+    // The original connections are unaffected and still counted.
+    assert_eq!(registry.count(&user.id), cap);
+    Ok(())
+}

--- a/fido-tui/Cargo.toml
+++ b/fido-tui/Cargo.toml
@@ -45,3 +45,6 @@ tempfile = "3.8"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = ["Win32_System_Console"] }
+
+[lints]
+workspace = true

--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -67,7 +67,11 @@ pub struct ApiClient {
     session_token: Option<String>,
 }
 
-const DEFAULT_PUBLIC_SERVER_URL: &str = "https://fido-web-production.up.railway.app";
+/// Default server for the installed TUI: the persistent **API** service, NOT the
+/// public web-terminal demo (fido-web-production), whose DB is ephemeral and is
+/// shared with anonymous ttyd visitors. These must be two separate Railway
+/// services; see docs/DEPLOY.md. Override with FIDO_SERVER_URL or ~/.fido/server_url.
+const DEFAULT_PUBLIC_SERVER_URL: &str = "https://fido-api-production.up.railway.app";
 
 fn read_server_url_from_config() -> Option<String> {
     let config_path = dirs::home_dir()?.join(".fido").join("server_url");

--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -155,13 +155,35 @@ impl ApiClient {
         format!("{}/ws", websocket_base)
     }
 
+    /// Whether the session token may be transmitted to the configured server.
+    ///
+    /// The token is a bearer credential, so it must only travel over `https://`
+    /// or a loopback `http://` origin (local dev / the containerized web mode).
+    /// A plaintext remote would leak it on the wire.
+    fn token_transport_is_safe(&self) -> bool {
+        let url = self.base_url.trim();
+        if url.starts_with("https://") {
+            return true;
+        }
+        if let Some(rest) = url.strip_prefix("http://") {
+            let host = rest.split(['/', ':']).next().unwrap_or("");
+            return matches!(host, "127.0.0.1" | "localhost" | "[::1]" | "::1");
+        }
+        false
+    }
+
     /// Helper to add session token to request if available
     fn add_auth_header(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         if let Some(token) = &self.session_token {
-            req.header("X-Session-Token", token)
-        } else {
-            req
+            if self.token_transport_is_safe() {
+                return req.header("X-Session-Token", token);
+            }
+            log::warn!(
+                "Refusing to send session token over insecure transport ({}); use https:// or a loopback address",
+                self.base_url
+            );
         }
+        req
     }
 
     /// Helper to handle API responses
@@ -834,4 +856,19 @@ pub struct BrowseCommunityResponse {
 struct JoinCommunityRequest {
     owner: String,
     name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApiClient;
+
+    #[test]
+    fn token_transport_safety_allows_https_and_loopback_only() {
+        assert!(ApiClient::new("https://example.com").token_transport_is_safe());
+        assert!(ApiClient::new("http://127.0.0.1:3000").token_transport_is_safe());
+        assert!(ApiClient::new("http://localhost:3000/").token_transport_is_safe());
+        // Plaintext to a remote host must not carry the token.
+        assert!(!ApiClient::new("http://example.com").token_transport_is_safe());
+        assert!(!ApiClient::new("http://10.0.0.5:3000").token_transport_is_safe());
+    }
 }

--- a/fido-tui/src/api/realtime.rs
+++ b/fido-tui/src/api/realtime.rs
@@ -150,11 +150,33 @@ async fn run_realtime_client(api_client: ApiClient, tx: mpsc::Sender<RealtimeCli
     }
 }
 
+/// The token may only travel over `wss://` or a loopback `ws://` origin.
+fn ws_transport_is_safe(url: &str) -> bool {
+    let url = url.trim();
+    if url.starts_with("wss://") {
+        return true;
+    }
+    if let Some(rest) = url.strip_prefix("ws://") {
+        let host = rest.split(['/', ':']).next().unwrap_or("");
+        return matches!(host, "127.0.0.1" | "localhost" | "[::1]" | "::1");
+    }
+    false
+}
+
 async fn connect_and_read(
     websocket_url: &str,
     token: &str,
     tx: &mpsc::Sender<RealtimeClientEvent>,
 ) -> ConnectionOutcome {
+    if !ws_transport_is_safe(websocket_url) {
+        log::warn!(
+            "Refusing to send session token over insecure transport ({websocket_url}); use wss:// or a loopback address"
+        );
+        return ConnectionOutcome::Unauthorized(
+            "insecure ws:// transport; use wss:// or a loopback server".to_string(),
+        );
+    }
+
     let mut request = match websocket_url.into_client_request() {
         Ok(request) => request,
         Err(e) => return ConnectionOutcome::Retry(format!("invalid websocket url: {e}")),
@@ -251,5 +273,15 @@ mod tests {
             ApiClient::new("http://127.0.0.1:3000/").websocket_url(),
             "ws://127.0.0.1:3000/ws"
         );
+    }
+
+    #[test]
+    fn ws_transport_safety_allows_wss_and_loopback_only() {
+        assert!(ws_transport_is_safe("wss://example.com/ws"));
+        assert!(ws_transport_is_safe("ws://127.0.0.1:3000/ws"));
+        assert!(ws_transport_is_safe("ws://localhost:3000/ws"));
+        // Plaintext to a remote host must not carry the token.
+        assert!(!ws_transport_is_safe("ws://example.com/ws"));
+        assert!(!ws_transport_is_safe("ws://10.0.0.5:3000/ws"));
     }
 }

--- a/fido-tui/src/app/handlers/modals.rs
+++ b/fido-tui/src/app/handlers/modals.rs
@@ -132,14 +132,13 @@ pub fn handle_filter_modal_keys(app: &mut App, key: KeyEvent) -> Result<()> {
             app.toggle_filter_item();
         }
         KeyCode::Char('x') | KeyCode::Char('X') if in_hashtags_tab => {}
-        KeyCode::Enter => {
+        KeyCode::Enter
             if in_hashtags_tab
                 && app.posts_state.filter_modal_state.selected_index
-                    == app.posts_state.filter_modal_state.hashtag_list.len()
-            {
-                app.posts_state.filter_modal_state.show_add_hashtag_input = true;
-                app.posts_state.filter_modal_state.add_hashtag_input.clear();
-            }
+                    == app.posts_state.filter_modal_state.hashtag_list.len() =>
+        {
+            app.posts_state.filter_modal_state.show_add_hashtag_input = true;
+            app.posts_state.filter_modal_state.add_hashtag_input.clear();
         }
         _ => {}
     }

--- a/fido-tui/src/app/hashtags.rs
+++ b/fido-tui/src/app/hashtags.rs
@@ -87,14 +87,14 @@ impl App {
                     self.hashtags_state.error = None;
                 }
             }
-            KeyCode::Char('x') | KeyCode::Char('X') => {
-                // Unfollow selected hashtag (if not on "Follow Hashtag" option)
-                if self.hashtags_state.selected_hashtag < self.hashtags_state.hashtags.len() {
-                    let hashtag =
-                        self.hashtags_state.hashtags[self.hashtags_state.selected_hashtag].clone();
-                    self.hashtags_state.show_unfollow_confirmation = true;
-                    self.hashtags_state.hashtag_to_unfollow = Some(hashtag);
-                }
+            // Unfollow selected hashtag (if not on the "Follow Hashtag" option).
+            KeyCode::Char('x') | KeyCode::Char('X')
+                if self.hashtags_state.selected_hashtag < self.hashtags_state.hashtags.len() =>
+            {
+                let hashtag =
+                    self.hashtags_state.hashtags[self.hashtags_state.selected_hashtag].clone();
+                self.hashtags_state.show_unfollow_confirmation = true;
+                self.hashtags_state.hashtag_to_unfollow = Some(hashtag);
             }
             _ => {}
         }

--- a/fido-tui/src/app/realtime.rs
+++ b/fido-tui/src/app/realtime.rs
@@ -196,7 +196,7 @@ impl App {
             SortOrder::Newest => self
                 .posts_state
                 .posts
-                .sort_by(|a, b| b.created_at.cmp(&a.created_at)),
+                .sort_by_key(|a| std::cmp::Reverse(a.created_at)),
             SortOrder::Popular => self.posts_state.posts.sort_by(|a, b| {
                 b.upvotes
                     .cmp(&a.upvotes)

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -18,7 +18,7 @@ pub struct EventLoop {
     last_device_poll: Instant,
     startup_started: bool,
     startup_data_load_pending: bool,
-    session_restore_task: Option<JoinHandle<Result<Option<RestoredSession>, String>>>,
+    session_restore_task: Option<JoinHandle<anyhow::Result<Option<RestoredSession>>>>,
     update_check_task: Option<JoinHandle<Option<String>>>,
     realtime_task: Option<JoinHandle<()>>,
     realtime_rx: Option<mpsc::Receiver<crate::api::RealtimeClientEvent>>,
@@ -201,9 +201,7 @@ impl EventLoop {
 
             let api_client = app.api_client.clone();
             self.session_restore_task = Some(tokio::spawn(async move {
-                auth::restore_existing_session(api_client)
-                    .await
-                    .map_err(|e| e.to_string())
+                auth::restore_existing_session(api_client).await
             }));
 
             if !self.is_web_mode {

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -273,7 +273,7 @@ impl EventLoop {
 
         // Check for timeout (15 minutes)
         if let Some(start_time) = app.auth_state.github_auth_start_time {
-            if start_time.elapsed() > Duration::from_secs(900) {
+            if start_time.elapsed() > Duration::from_mins(15) {
                 log::warn!("GitHub Device Flow timeout after 15 minutes");
                 app.auth_state.error =
                     Some("Device authorization timeout: Please try again.".to_string());
@@ -387,10 +387,10 @@ impl EventLoop {
                     app.load_chat().await?;
                 }
             }
-            Tab::Settings => {
-                if app.settings_state.config.is_none() || app.settings_state.error.is_some() {
-                    app.load_settings().await?;
-                }
+            Tab::Settings
+                if app.settings_state.config.is_none() || app.settings_state.error.is_some() =>
+            {
+                app.load_settings().await?;
             }
             _ => {}
         }

--- a/fido-tui/src/logging.rs
+++ b/fido-tui/src/logging.rs
@@ -80,6 +80,24 @@ impl LogConfig {
     }
 }
 
+/// Open the log file 0600 (owner read/write only) on unix. When `truncate` is
+/// set the file is cleared; otherwise it is opened for append.
+fn open_log_file(path: &PathBuf, truncate: bool) -> std::io::Result<File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true);
+    if truncate {
+        opts.write(true).truncate(true);
+    } else {
+        opts.append(true);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)
+}
+
 /// Initialize the logging system with the given configuration
 pub fn init_logging(config: &LogConfig) -> anyhow::Result<()> {
     if !config.enabled {
@@ -90,20 +108,22 @@ pub fn init_logging(config: &LogConfig) -> anyhow::Result<()> {
 
     // Clear log file if requested
     if config.clear_on_startup {
-        let _ = File::create(&config.log_file)?;
+        let _ = open_log_file(&config.log_file, true)?;
     }
 
-    // Open log file
-    let log_file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&config.log_file)?;
+    // Open log file (owner-only, since debug logs may contain sensitive data).
+    let log_file = open_log_file(&config.log_file, false)?;
 
-    // Configure log format
+    // Configure log format. Third-party crates are capped below the app level:
+    // at TRACE, tungstenite dumps the WebSocket handshake — including the
+    // `x-session-token` header — into this plaintext file, so those targets are
+    // filtered out entirely rather than allowed to leak the credential.
     let log_config = ConfigBuilder::new()
         .set_time_format_rfc3339()
         .set_time_offset_to_local()
         .unwrap_or_else(|builder| builder)
+        .add_filter_ignore_str("tungstenite")
+        .add_filter_ignore_str("tokio_tungstenite")
         .build();
 
     // Initialize logger

--- a/fido-tui/src/session.rs
+++ b/fido-tui/src/session.rs
@@ -144,9 +144,21 @@ impl SessionStore {
         // Use atomic write: write to temporary file, then rename
         let temp_path = self.file_path.with_extension("tmp");
 
-        // Write to temporary file
-        let mut file =
-            fs::File::create(&temp_path).context("Failed to create temporary session file")?;
+        // Create the temp file 0600 up front with create_new so the plaintext
+        // token is never briefly group/other-readable through the umask window
+        // (a leak on shared hosts). A stale temp from a prior crash is removed
+        // first so create_new does not spuriously fail.
+        let _ = fs::remove_file(&temp_path);
+        let mut open_opts = fs::OpenOptions::new();
+        open_opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            open_opts.mode(0o600);
+        }
+        let mut file = open_opts
+            .open(&temp_path)
+            .context("Failed to create temporary session file")?;
 
         file.write_all(token.as_bytes())
             .context("Failed to write session token")?;
@@ -155,15 +167,6 @@ impl SessionStore {
             .context("Failed to sync session file to disk")?;
 
         drop(file);
-
-        // Set permissions to 0600 (owner read/write only)
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let permissions = fs::Permissions::from_mode(0o600);
-            fs::set_permissions(&temp_path, permissions)
-                .context("Failed to set session file permissions")?;
-        }
 
         // Atomic rename
         fs::rename(&temp_path, &self.file_path)

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -18,7 +18,6 @@ use super::formatting::*;
 use super::modals::*;
 use super::theme::{get_theme_colors, ThemeColors};
 use crate::app::{App, Conversation, DMSelection};
-use crate::{log_modal_state, log_rendering};
 
 pub fn render_auth_screen(frame: &mut Frame, app: &mut App) {
     let theme = get_theme_colors(app);

--- a/fido-types/Cargo.toml
+++ b/fido-types/Cargo.toml
@@ -18,3 +18,6 @@ chrono.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/nginx-api.conf
+++ b/nginx-api.conf
@@ -1,0 +1,76 @@
+# Fido production API service nginx config (FIDO_DEPLOY_MODE=api).
+#
+# This is the persistent-API deployment: it proxies ONLY to fido-server. There
+# is no ttyd, no anonymous web terminal, and no static demo site. It exists so
+# the API service gets the same trustworthy client-IP resolution and edge rate
+# limiting as the demo (see nginx.conf), rather than exposing fido-server
+# directly to Railway's edge where X-Real-IP would never be set.
+pid /var/log/fido/nginx.pid;
+error_log /var/log/fido/nginx-error.log;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    server_tokens off;
+
+    # Resolve the real client IP behind Railway's edge (see nginx.conf for the
+    # full rationale). Only safe because fido-server (port 3000) is not publicly
+    # reachable — only nginx listens on the external ${NGINX_PORT}.
+    set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
+    set_real_ip_from 100.64.0.0/10;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    limit_req_zone $binary_remote_addr zone=fido_api:10m rate=10r/s;
+
+    upstream fido_server {
+        server 127.0.0.1:3000;
+    }
+
+    server {
+        listen ${NGINX_PORT};
+
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "no-referrer" always;
+
+        location = /health {
+            proxy_pass http://fido_server/health;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Realtime gateway: must forward WebSocket upgrade headers explicitly.
+        location = /ws {
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_read_timeout 1d;
+            proxy_pass http://fido_server/ws;
+        }
+
+        # All API routes.
+        location / {
+            limit_req zone=fido_api burst=20 nodelay;
+
+            proxy_pass http://fido_server;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,7 +13,35 @@ http {
     # Hide nginx version in responses and error pages.
     server_tokens off;
 
+    # Resolve the real client IP behind Railway's edge proxy.
+    #
+    # The path is client -> Railway edge -> nginx, so the connection nginx sees
+    # originates from Railway's private network and the true client address is
+    # carried in X-Forwarded-For. Trusting that hop lets the real_ip module
+    # rewrite $remote_addr / $binary_remote_addr (and therefore the X-Real-IP we
+    # forward upstream) to the actual client instead of the edge.
+    #
+    # The ranges below cover Railway's internal networking (private + CGNAT).
+    # real_ip_recursive walks XFF right-to-left, skipping trusted hops, so a
+    # client-forged left-most entry cannot win. Tighten to Railway's documented
+    # edge CIDR if/when it is published. NOTE: this is only safe because the
+    # fido-server port (3000) is NOT publicly reachable — only nginx listens on
+    # the external ${NGINX_PORT}; verify that invariant on every deploy.
+    set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
+    set_real_ip_from 100.64.0.0/10;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
     # Basic per-IP rate limiting shared across proxied locations.
+    # Keyed on the real_ip-resolved client address (above), so each external
+    # visitor gets its own bucket instead of everyone sharing the edge IP.
+    #
+    # NOTE: this nginx zone is the authoritative per-client edge limit. The
+    # in-process limiter in fido-server (rate_limit.rs) is a secondary guard and
+    # assumes a single server instance; with >1 replica its per-IP counts
+    # multiply, so edge limiting must stay here.
     limit_req_zone $binary_remote_addr zone=fido:10m rate=10r/s;
 
     # Upstream servers

--- a/start.sh
+++ b/start.sh
@@ -118,6 +118,62 @@ check_local_deps() {
 # Create log directory
 mkdir -p "$LOG_DIR"
 
+# Deployment mode selects which service this container runs:
+#   demo (default) - public web terminal: ttyd + nginx + ephemeral DB, no real data.
+#   api            - persistent API service: fido-server behind an API-only nginx,
+#                    persistent volume, NO ttyd, NO anonymous terminal, NO DB wipe.
+# The two must be separate Railway services; see docs/DEPLOY.md.
+FIDO_DEPLOY_MODE=${FIDO_DEPLOY_MODE:-demo}
+
+if [ "$FIDO_DEPLOY_MODE" = "api" ]; then
+    # Persistent API service. Never wipe the DB; default to the mounted volume.
+    API_DATABASE_PATH=${DATABASE_PATH:-/data/fido.db}
+    echo -e "${BLUE}Starting Fido API service (persistent DB at $API_DATABASE_PATH)...${NC}"
+
+    if [ "$ENV_MODE" = "docker" ] && [ -f /etc/nginx/nginx-api.conf.template ]; then
+        export NGINX_PORT
+        envsubst '${NGINX_PORT}' < /etc/nginx/nginx-api.conf.template > /etc/nginx/nginx.conf
+        echo -e "${GREEN}  ✓ API nginx.conf rendered (listen on port $NGINX_PORT)${NC}"
+    fi
+
+    # fido-server stays on the internal loopback port; nginx is the only external
+    # listener, so client-IP resolution and edge rate limiting apply.
+    export HOST=127.0.0.1
+    export PORT=$FIDO_SERVER_PORT
+    export DATABASE_PATH=$API_DATABASE_PATH
+    export RUST_LOG=${RUST_LOG:-info}
+
+    $FIDO_SERVER_BIN > "$LOG_DIR/fido-server.log" 2>&1 &
+    FIDO_SERVER_PID=$!
+    echo -e "${GREEN}  ✓ fido-server started (PID: $FIDO_SERVER_PID)${NC}"
+
+    if [ "$ENV_MODE" = "docker" ]; then
+        tail -n +1 -F "$LOG_DIR/fido-server.log" &
+        FIDO_LOG_TAIL_PID=$!
+    fi
+
+    sleep 2
+    if ! kill -0 "$FIDO_SERVER_PID" 2>/dev/null; then
+        echo -e "${RED}Error: fido-server exited during startup${NC}"
+        tail -n 200 "$LOG_DIR/fido-server.log" || true
+        exit 1
+    fi
+    if ! curl -fsS "http://127.0.0.1:${FIDO_SERVER_PORT}/health" >/dev/null 2>&1; then
+        echo -e "${RED}Error: fido-server health endpoint failed during startup${NC}"
+        tail -n 200 "$LOG_DIR/fido-server.log" || true
+        exit 1
+    fi
+
+    echo -e "${YELLOW}Starting nginx on port $NGINX_PORT...${NC}"
+    nginx -g "daemon off;" &
+    NGINX_PID=$!
+    echo -e "${GREEN}  ✓ nginx started (PID: $NGINX_PID)${NC}"
+
+    echo -e "${GREEN}🐕 Fido API service is running (mode=api).${NC}"
+    wait
+    exit 0
+fi
+
 # The hosted web terminal is a public demo. Keep it detached from any persisted
 # deployment volume and reset it on every boot so visitors only see fixture data.
 export FIDO_WEB_MODE=true


### PR DESCRIPTION
Security & quality hardening sweep implementing stints 0025–0043 from the 2026-07-11 audit. One commit per stint; all 19 implemented.

## What changed (per stint)

- **0025** — `search_users` and `get_profile` now require `AuthenticatedUser` (were fully anonymous, allowing user-table enumeration / profile disclosure). Regression test asserts 401 without a token.
- **0026** — Deleted the fail-open `create_router` (it defaulted to `Development` on config error, mounting passwordless login). Production already uses `create_router_with_security_config`; the two integration tests now pass an explicit config.
- **0027** — nginx resolves the real client IP behind Railway's edge (`set_real_ip_from` + `real_ip_recursive`) and keys `limit_req` on it. `http::extract_client_ip` now trusts only the nginx-written `X-Real-IP` (no forgeable XFF); `admin.rs` consolidated onto that helper. In-process limiter's single-instance scope documented.
- **0028** — Split demo vs persistent-API deployments in-repo: `FIDO_DEPLOY_MODE` (demo/api) in `start.sh`, an API-only `nginx-api.conf`, Dockerfile default `demo`, and the installed TUI default server URL now points at the API host (not the demo). Two-service topology documented in `docs/DEPLOY.md`.
- **0029** — Per-user WebSocket connection cap (`try_connect`), `max_message_size`/`max_frame_size` on the upgrade, and an inbound-frame throttle that closes floods with a policy-violation frame. Unit + integration tests.
- **0030** — Added `idx_memberships_user_id`, `idx_posts_author_id`, `idx_notifications_user_created`. EXPLAIN QUERY PLAN test asserts index use and no temp B-tree.
- **0031** — Batched feed vote lookups (`get_votes_for_posts`, one bound `IN (...)` query) replacing the per-post N+1; DM conversation list now JOINs username + conversation state so the service no longer loops.
- **0032** — `list_members` and community detail (`get_view`) now enforce `require_membership`; non-members get 403.
- **0033** — `record_vote` rejects self-votes; `notify_mentions` only notifies mentioned users who are community members.
- **0034** — TUI session temp file created `0600` via `create_new`; token refused over non-loopback `http://`/`ws://`; tungstenite capped below TRACE so `--verbose` can't leak the token; debug log created `0600`; stray `fido_debug.log` removed.
- **0035** — Repository transactions: vote write (upsert + recount) and DM soft-delete each run in one transaction; user creation is idempotent (`INSERT ... ON CONFLICT DO NOTHING` + re-select), username collisions disambiguated; corrected the misleading DM request-state error message.
- **0036** — In-memory test pool now shares one DB across connections (unique named shared-cache URI); migrations propagate real errors and ignore only "duplicate column name".
- **0037** — Production startup now requires `GITHUB_CLIENT_SECRET`; revocation-skip logs at warn; contributor check compares the current `github_login` case-insensitively; username tracks GitHub renames.
- **0038** — Server now accepts the `session_token` cookie as an auth source (CSRF-safe via SameSite=Strict); `max_request_size` config is wired into the body-limit layer; admin endpoints get a supported production grant path (`FIDO_ADMIN_LOGINS` allowlist).
- **0039** — Dockerfile base images pinned by verified multi-arch digest (`rust:1.91-bookworm`, `debian:bookworm-slim`), with a documented refresh command.
- **0040** — Documented `contains_dangerous_patterns` as a non-authoritative defense-in-depth denylist (not the XSS boundary); added a note to `security/AGENTS.md`. Verified the current `web/` client renders no user content into HTML.
- **0041** — Added `[workspace.lints.clippy]` (`all = deny`, `pedantic = warn` with the noisy lints allowed, `redundant_clone = warn`), each crate opts in, plus a GitHub Actions CI workflow (fmt/clippy/test) using verified action tags (`actions/checkout@v4`, `actions/cache@v4`).
- **0042** — Removed `#![allow(dead_code)]` from the seven v2 repository files; the layer is fully wired (all pub and used), so no feature gate or deletion was needed and no dead code remains.
- **0043** — Server `ApiError` now derives `thiserror::Error` (+ `#[non_exhaustive]`); `event_loop.rs` session-restore task uses `anyhow::Result` instead of `String`; static security headers use `HeaderValue::from_static`.

## Regression gate

All four pass on this branch:

1. `cargo fmt --all -- --check` — **PASS**
2. `cargo clippy --workspace --all-targets --all-features -- -D warnings` — **PASS**
3. `cargo test --workspace --features sqlite-tests` — **PASS** (no failures)
4. `just e2e-tui` (tmux end-to-end) — **PASS** (all scenarios)

## MANUAL FOLLOW-UP

- **0028 — create the second Railway service (cannot be done from the repo).** Create a persistent-API Railway service from the same image with `FIDO_DEPLOY_MODE=api`, `ENVIRONMENT=production`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `FIDO_TOKEN_KEY`, and a volume mounted at `/data`. Point `https://fido-api-production.up.railway.app` (or your chosen API domain) at it and update `DEFAULT_PUBLIC_SERVER_URL` if the domain differs. Verify the demo service has no persistent volume and still resets its DB, and that fido-server's port 3000 is not publicly reachable on either service. Full checklist in `docs/DEPLOY.md`.
- **0037 — set `GITHUB_CLIENT_SECRET` on the production API service** before deploy; startup now hard-fails without it in production.
- **0038 — set `FIDO_ADMIN_LOGINS`** (comma-separated GitHub logins) on the API service to grant admin-endpoint access; seed-data admins are dev-only.
- **0039 — refresh base-image digests** periodically using the command documented in the Dockerfile.

No stint was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
