### PR TITLE
Release Fido 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fido"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "fido-server"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "fido-types"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 authors = ["Ian Burke"]
 license = "MIT"
@@ -58,4 +58,4 @@ base64 = "0.22"
 aes-gcm-siv = "0.11"
 
 # Internal workspace crates
-fido-types = { path = "fido-types", version = "0.5.4" }
+fido-types = { path = "fido-types", version = "0.5.5" }

--- a/fido-server/src/main.rs
+++ b/fido-server/src/main.rs
@@ -214,7 +214,7 @@ async fn main() {
     // Start background task for periodic session cleanup
     let cleanup_state = state.clone();
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(3600)); // Run every hour
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_hours(1));
         loop {
             interval.tick().await;
             tracing::debug!("Running periodic session cleanup...");

--- a/fido-server/src/rate_limit.rs
+++ b/fido-server/src/rate_limit.rs
@@ -69,7 +69,9 @@ impl RateLimiter {
                 // Check if we're still in the same window
                 if now.duration_since(*window_start) < self.window_duration {
                     if *count >= self.max_requests {
-                        let remaining = self.window_duration - now.duration_since(*window_start);
+                        let remaining = self
+                            .window_duration
+                            .saturating_sub(now.duration_since(*window_start));
                         return RateLimitInfo {
                             exceeded: true,
                             request_count: *count,

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -82,7 +82,7 @@ async fn spawn_server(github_api_base: Option<&str>) -> Result<TestServer> {
 /// Deterministic fixture repo id so parallel joins of the same owner/name agree.
 fn fixture_repo_id(owner: &str, name: &str) -> i64 {
     let mut hash: i64 = 7;
-    for byte in owner.bytes().chain([b'/']).chain(name.bytes()) {
+    for byte in owner.bytes().chain(*b"/").chain(name.bytes()) {
         hash = hash.wrapping_mul(31).wrapping_add(byte as i64);
     }
     hash.abs().max(2)

--- a/fido-tui/src/app/handlers/modals.rs
+++ b/fido-tui/src/app/handlers/modals.rs
@@ -132,14 +132,13 @@ pub fn handle_filter_modal_keys(app: &mut App, key: KeyEvent) -> Result<()> {
             app.toggle_filter_item();
         }
         KeyCode::Char('x') | KeyCode::Char('X') if in_hashtags_tab => {}
-        KeyCode::Enter => {
+        KeyCode::Enter
             if in_hashtags_tab
                 && app.posts_state.filter_modal_state.selected_index
-                    == app.posts_state.filter_modal_state.hashtag_list.len()
-            {
-                app.posts_state.filter_modal_state.show_add_hashtag_input = true;
-                app.posts_state.filter_modal_state.add_hashtag_input.clear();
-            }
+                    == app.posts_state.filter_modal_state.hashtag_list.len() =>
+        {
+            app.posts_state.filter_modal_state.show_add_hashtag_input = true;
+            app.posts_state.filter_modal_state.add_hashtag_input.clear();
         }
         _ => {}
     }

--- a/fido-tui/src/app/hashtags.rs
+++ b/fido-tui/src/app/hashtags.rs
@@ -87,14 +87,14 @@ impl App {
                     self.hashtags_state.error = None;
                 }
             }
-            KeyCode::Char('x') | KeyCode::Char('X') => {
-                // Unfollow selected hashtag (if not on "Follow Hashtag" option)
-                if self.hashtags_state.selected_hashtag < self.hashtags_state.hashtags.len() {
-                    let hashtag =
-                        self.hashtags_state.hashtags[self.hashtags_state.selected_hashtag].clone();
-                    self.hashtags_state.show_unfollow_confirmation = true;
-                    self.hashtags_state.hashtag_to_unfollow = Some(hashtag);
-                }
+            // Unfollow selected hashtag (if not on the "Follow Hashtag" option).
+            KeyCode::Char('x') | KeyCode::Char('X')
+                if self.hashtags_state.selected_hashtag < self.hashtags_state.hashtags.len() =>
+            {
+                let hashtag =
+                    self.hashtags_state.hashtags[self.hashtags_state.selected_hashtag].clone();
+                self.hashtags_state.show_unfollow_confirmation = true;
+                self.hashtags_state.hashtag_to_unfollow = Some(hashtag);
             }
             _ => {}
         }

--- a/fido-tui/src/app/realtime.rs
+++ b/fido-tui/src/app/realtime.rs
@@ -196,7 +196,7 @@ impl App {
             SortOrder::Newest => self
                 .posts_state
                 .posts
-                .sort_by(|a, b| b.created_at.cmp(&a.created_at)),
+                .sort_by_key(|a| std::cmp::Reverse(a.created_at)),
             SortOrder::Popular => self.posts_state.posts.sort_by(|a, b| {
                 b.upvotes
                     .cmp(&a.upvotes)

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -275,7 +275,7 @@ impl EventLoop {
 
         // Check for timeout (15 minutes)
         if let Some(start_time) = app.auth_state.github_auth_start_time {
-            if start_time.elapsed() > Duration::from_secs(900) {
+            if start_time.elapsed() > Duration::from_mins(15) {
                 log::warn!("GitHub Device Flow timeout after 15 minutes");
                 app.auth_state.error =
                     Some("Device authorization timeout: Please try again.".to_string());
@@ -389,10 +389,10 @@ impl EventLoop {
                     app.load_chat().await?;
                 }
             }
-            Tab::Settings => {
-                if app.settings_state.config.is_none() || app.settings_state.error.is_some() {
-                    app.load_settings().await?;
-                }
+            Tab::Settings
+                if app.settings_state.config.is_none() || app.settings_state.error.is_some() =>
+            {
+                app.load_settings().await?;
             }
             _ => {}
         }

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -18,7 +18,6 @@ use super::formatting::*;
 use super::modals::*;
 use super::theme::{get_theme_colors, ThemeColors};
 use crate::app::{App, Conversation, DMSelection};
-use crate::{log_modal_state, log_rendering};
 
 pub fn render_auth_screen(frame: &mut Frame, app: &mut App) {
     let theme = get_theme_colors(app);


### PR DESCRIPTION
Prepares the 0.5.5 patch release for legacy reply debug-log cleanup.

Also clears strict Rust lint findings that blocked the release gate.

Validated:
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- just e2e-tui-startup
- just e2e-tui
- cargo package -p fido-types --allow-dirty

The fido package dry-run waits until fido-types 0.5.5 is published, as required by Cargo registry resolution.