### PR TITLE
feat: browse owned and contributed repos alongside starred (stint 0026)

### DIFF
--- a/fido-server/src/api/auth.rs
+++ b/fido-server/src/api/auth.rs
@@ -18,6 +18,11 @@ use crate::security::{
 };
 use crate::state::AppState;
 
+/// Placeholder GitHub token stored for test-user logins so token-backed GitHub
+/// calls resolve against the local stub. Only reachable from the dev-only
+/// test-login route.
+const TEST_USER_GITHUB_TOKEN: &str = "gho_test_user_stub_token";
+
 // In-memory store for active device codes: device_code -> unix timestamp of creation
 static DEVICE_CODES: LazyLock<Mutex<HashMap<String, i64>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -126,6 +131,16 @@ pub async fn login(
     let session_token = state
         .session_manager
         .create_session(user.id)
+        .map_err(|e| ApiError::InternalError(e.to_string()))?;
+
+    // A real OAuth login leaves the user holding a GitHub token; without one
+    // here, test users sit in a state no real user is ever in and every
+    // token-backed GitHub call (repo browsing especially) is untestable. This
+    // route is only mounted outside production, so the placeholder never
+    // reaches a real deployment.
+    state
+        .github_service
+        .store_token(user.id, TEST_USER_GITHUB_TOKEN)
         .map_err(|e| ApiError::InternalError(e.to_string()))?;
 
     // Log successful login

--- a/fido-server/src/api/communities.rs
+++ b/fido-server/src/api/communities.rs
@@ -3,7 +3,7 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use fido_types::{Channel, Community, Membership, MembershipRole};
+use fido_types::{Channel, Community, Membership, MembershipRole, RepoSource};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -21,6 +21,7 @@ pub struct BrowseCommunityResponse {
     pub name: String,
     pub full_name: String,
     pub private: bool,
+    pub sources: Vec<RepoSource>,
     pub community: Option<CommunityResponse>,
     pub membership: Option<MembershipResponse>,
 }
@@ -72,13 +73,14 @@ pub struct CommunityMemberResponse {
     pub role: MembershipRole,
 }
 
-/// GET /communities/browse - Browse the user's starred repos with community state
+/// GET /communities/browse - Browse the user's starred, owned, and affiliated
+/// repos with community state
 pub async fn browse_communities(
     State(state): State<AppState>,
     AuthenticatedUser(user_id): AuthenticatedUser,
 ) -> ApiResult<Json<Vec<BrowseCommunityResponse>>> {
     let service = CommunityService::new(state.repos.clone(), state.github_service);
-    let communities = service.browse_starred(user_id).await?;
+    let communities = service.browse(user_id).await?;
 
     Ok(Json(
         communities.into_iter().map(map_browse_community).collect(),
@@ -180,6 +182,7 @@ fn map_browse_community(item: BrowseCommunity) -> BrowseCommunityResponse {
         name: item.name,
         full_name: item.full_name,
         private: item.private,
+        sources: item.sources,
         community: item.community.map(map_community),
         membership: item.membership.map(map_membership),
     }

--- a/fido-server/src/services/communities.rs
+++ b/fido-server/src/services/communities.rs
@@ -1,12 +1,15 @@
 //! Community-related business logic.
 
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
 use chrono::Utc;
 use uuid::Uuid;
 
 use crate::api::{ApiError, ApiResult};
 use crate::db::repositories::Repositories;
 use crate::services::github::{GithubRepo, GithubService, RepoPermission};
-use fido_types::{Channel, Community, Membership, MembershipRole};
+use fido_types::{Channel, Community, Membership, MembershipRole, RepoSource};
 
 pub struct CommunityService {
     repos: Repositories,
@@ -20,6 +23,8 @@ pub struct BrowseCommunity {
     pub name: String,
     pub full_name: String,
     pub private: bool,
+    /// Every relationship that surfaced this repo, ordered and deduplicated.
+    pub sources: Vec<RepoSource>,
     pub community: Option<Community>,
     pub membership: Option<Membership>,
 }
@@ -37,12 +42,63 @@ impl CommunityService {
         Self { repos, github }
     }
 
-    pub async fn browse_starred(&self, user_id: Uuid) -> ApiResult<Vec<BrowseCommunity>> {
+    /// Browse every repo the user can turn into a community: the ones they
+    /// starred, plus the ones they own or are affiliated with. A repo reachable
+    /// through several relationships appears once, carrying all of them.
+    pub async fn browse(&self, user_id: Uuid) -> ApiResult<Vec<BrowseCommunity>> {
+        let login = self.github_login(&user_id)?;
         let starred = self.github.starred_repos(user_id).await?;
-        starred
+        let affiliated = self.github.affiliated_repos(user_id).await?;
+
+        let tagged = starred
             .into_iter()
-            .map(|repo| self.annotate_starred_repo(repo, &user_id))
+            .map(|repo| (RepoSource::Starred, repo))
+            .chain(affiliated.into_iter().map(|repo| {
+                let source = if repo.owner.login.eq_ignore_ascii_case(&login) {
+                    RepoSource::Owned
+                } else {
+                    RepoSource::Contributor
+                };
+                (source, repo)
+            }));
+
+        // Preserve first-seen order (starred first, then affiliated) so the
+        // list stays stable across reloads.
+        let mut order: Vec<i64> = Vec::new();
+        let mut merged: HashMap<i64, (GithubRepo, Vec<RepoSource>)> = HashMap::new();
+        for (source, repo) in tagged {
+            match merged.entry(repo.id) {
+                Entry::Occupied(mut existing) => {
+                    let sources = &mut existing.get_mut().1;
+                    if !sources.contains(&source) {
+                        sources.push(source);
+                        sources.sort();
+                    }
+                }
+                Entry::Vacant(slot) => {
+                    order.push(repo.id);
+                    slot.insert((repo, vec![source]));
+                }
+            }
+        }
+
+        order
+            .into_iter()
+            .map(|id| {
+                let (repo, sources) = merged
+                    .remove(&id)
+                    .expect("merged entry exists for every id recorded in order");
+                self.annotate_repo(repo, sources, &user_id)
+            })
             .collect()
+    }
+
+    fn github_login(&self, user_id: &Uuid) -> ApiResult<String> {
+        self.repos
+            .users
+            .get_by_id(user_id)?
+            .map(|user| user.username)
+            .ok_or_else(|| ApiError::NotFound(format!("User {} not found", user_id)))
     }
 
     pub async fn join(&self, user_id: Uuid, owner: &str, name: &str) -> ApiResult<CommunityView> {
@@ -171,9 +227,10 @@ impl CommunityService {
         Ok(members)
     }
 
-    fn annotate_starred_repo(
+    fn annotate_repo(
         &self,
         repo: GithubRepo,
+        sources: Vec<RepoSource>,
         user_id: &Uuid,
     ) -> ApiResult<BrowseCommunity> {
         let community = self.repos.communities.get_by_github_repo_id(repo.id)?;
@@ -189,6 +246,7 @@ impl CommunityService {
             name: repo.name,
             full_name: repo.full_name,
             private: repo.private,
+            sources,
             community,
             membership,
         })
@@ -279,8 +337,37 @@ mod tests {
             ]))
         }
 
+        // alice/dotfiles is owned; acme-inc/widgets is collaborator-affiliated;
+        // octocat/Hello-World is also starred, so it must merge into one row.
+        async fn affiliated() -> Json<serde_json::Value> {
+            Json(json!([
+                {
+                    "id": 900001,
+                    "name": "dotfiles",
+                    "full_name": "alice/dotfiles",
+                    "private": false,
+                    "owner": { "login": "alice" }
+                },
+                {
+                    "id": 900002,
+                    "name": "widgets",
+                    "full_name": "acme-inc/widgets",
+                    "private": false,
+                    "owner": { "login": "acme-inc" }
+                },
+                {
+                    "id": 1296269,
+                    "name": "Hello-World",
+                    "full_name": "octocat/Hello-World",
+                    "private": false,
+                    "owner": { "login": "octocat" }
+                }
+            ]))
+        }
+
         let app = Router::new()
             .route("/user/starred", get(starred))
+            .route("/user/repos", get(affiliated))
             .route("/repos/octocat/Hello-World", get(repo))
             .route("/repos/octocat/Hello-World/contributors", get(contributors));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -385,11 +472,28 @@ mod tests {
             CommunityService::new(repos.clone(), github)
         };
 
-        let browse = service.browse_starred(user_id).await.expect("browse");
-        assert_eq!(browse.len(), 1);
+        let browse = service.browse(user_id).await.expect("browse");
+        assert_eq!(browse.len(), 3, "starred + affiliated, deduplicated");
         assert_eq!(browse[0].full_name, "octocat/Hello-World");
         assert!(browse[0].community.is_none());
         assert!(browse[0].membership.is_none());
+        assert_eq!(
+            browse[0].sources,
+            vec![RepoSource::Starred, RepoSource::Contributor],
+            "a repo reachable both ways appears once carrying both sources"
+        );
+
+        let owned = browse
+            .iter()
+            .find(|item| item.full_name == "alice/dotfiles")
+            .expect("owned repo is listed");
+        assert_eq!(owned.sources, vec![RepoSource::Owned]);
+
+        let contributed = browse
+            .iter()
+            .find(|item| item.full_name == "acme-inc/widgets")
+            .expect("affiliated repo is listed");
+        assert_eq!(contributed.sources, vec![RepoSource::Contributor]);
 
         let joined = service
             .join(user_id, "octocat", "Hello-World")
@@ -403,10 +507,7 @@ mod tests {
             Some(MembershipRole::Contributor)
         );
 
-        let browse = service
-            .browse_starred(user_id)
-            .await
-            .expect("browse after join");
+        let browse = service.browse(user_id).await.expect("browse after join");
         assert!(browse[0].community.is_some());
         assert_eq!(
             browse[0].membership.as_ref().map(|m| m.role),

--- a/fido-server/src/services/github.rs
+++ b/fido-server/src/services/github.rs
@@ -176,6 +176,31 @@ impl GithubService {
         result
     }
 
+    /// List repos the user owns or is affiliated with as a collaborator or org
+    /// member. GitHub exposes no "repos I have contributed commits to" listing,
+    /// so collaborator/org-member affiliation is the closest listable notion of
+    /// having contributed. Owned vs contributor is resolved by the caller from
+    /// each repo's owner login.
+    pub async fn affiliated_repos(&self, user_id: Uuid) -> Result<Vec<GithubRepo>> {
+        let result = self
+            .get_with_token(
+                user_id,
+                format!(
+                    "{}/user/repos?affiliation=owner,collaborator,organization_member&per_page=100&sort=updated",
+                    self.api_base
+                ),
+                "affiliated_repos",
+            )
+            .await;
+        self.log_result(
+            "affiliated_repos",
+            user_id,
+            Some("GET /user/repos"),
+            &result,
+        );
+        result
+    }
+
     /// Resolve a repo by owner/name. Uses the caller's stored token when present
     /// (required for private repos), otherwise queries unauthenticated.
     /// Returns Ok(None) when GitHub reports the repo does not exist (404).

--- a/fido-server/tests/e2e_community_rewrite.rs
+++ b/fido-server/tests/e2e_community_rewrite.rs
@@ -114,6 +114,38 @@ async fn github_fixture_server() -> Result<String> {
         ]))
     }
 
+    // alice/alice-owned-repo is owned, acme-inc/acme-widgets is
+    // collaborator-affiliated, and octocat/Hello-World is also starred so the
+    // merge path collapses it into one row carrying both sources.
+    // Ids must agree with what GET /repos/:owner/:name reports for the same
+    // repo, otherwise joining a listed repo creates a community the listing
+    // can no longer match.
+    async fn affiliated() -> Json<Value> {
+        Json(json!([
+            {
+                "id": fixture_repo_id("alice", "alice-owned-repo"),
+                "name": "alice-owned-repo",
+                "full_name": "alice/alice-owned-repo",
+                "private": false,
+                "owner": { "login": "alice" }
+            },
+            {
+                "id": fixture_repo_id("acme-inc", "acme-widgets"),
+                "name": "acme-widgets",
+                "full_name": "acme-inc/acme-widgets",
+                "private": false,
+                "owner": { "login": "acme-inc" }
+            },
+            {
+                "id": 1296269,
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+                "private": false,
+                "owner": { "login": "octocat" }
+            }
+        ]))
+    }
+
     async fn repo() -> Json<Value> {
         Json(json!({
             "id": 1296269,
@@ -158,6 +190,7 @@ async fn github_fixture_server() -> Result<String> {
 
     let app = Router::new()
         .route("/user/starred", get(starred))
+        .route("/user/repos", get(affiliated))
         .route("/repos/octocat/Hello-World", get(repo))
         .route("/repos/octocat/Hello-World/contributors", get(contributors))
         .route("/repos/:owner/:name", get(dynamic_repo))
@@ -390,9 +423,9 @@ async fn communities_browse_and_claim_e2e() -> Result<()> {
         .github_service
         .store_token(alice.id, "gho_recorded_fixture")?;
 
-    // Browse lists starred repos with no community state yet.
+    // Browse lists starred and affiliated repos with no community state yet.
     let browse = json_body(client.get("/communities/browse").await?).await?;
-    assert_eq!(browse.as_array().unwrap().len(), 1);
+    assert_eq!(browse.as_array().unwrap().len(), 3);
     assert_eq!(browse[0]["full_name"], "octocat/Hello-World");
     assert!(browse[0]["community"].is_null());
     assert!(browse[0]["membership"].is_null());
@@ -422,6 +455,74 @@ async fn communities_browse_and_claim_e2e() -> Result<()> {
     let view = json_body(response).await?;
     assert_eq!(view["community"]["claimed_by"], alice.id.to_string());
     assert_eq!(view["membership"]["role"], "admin");
+
+    Ok(())
+}
+
+/// Stint 0026: the browser surfaces owned and contributed repos alongside
+/// starred ones, deduplicating repos reachable through several relationships.
+#[tokio::test]
+async fn browse_merges_starred_owned_and_contributed_repos() -> Result<()> {
+    let fixture_base = github_fixture_server().await?;
+    let server = spawn_server(Some(&fixture_base)).await?;
+    let repos = &server.state.repos;
+
+    let alice = create_user(repos, "alice")?;
+    let client = login(&server, &alice)?;
+    server
+        .state
+        .github_service
+        .store_token(alice.id, "gho_recorded_fixture")?;
+
+    let browse = json_body(client.get("/communities/browse").await?).await?;
+    let items = browse.as_array().expect("browse returns an array");
+    assert_eq!(items.len(), 3, "one row per distinct repo");
+
+    let by_name = |full_name: &str| -> &Value {
+        items
+            .iter()
+            .find(|item| item["full_name"] == full_name)
+            .unwrap_or_else(|| panic!("{} should be listed", full_name))
+    };
+
+    // Starred and affiliated: one row, both sources.
+    assert_eq!(
+        by_name("octocat/Hello-World")["sources"],
+        json!(["starred", "contributor"])
+    );
+    // Owner login matches the caller's login.
+    assert_eq!(
+        by_name("alice/alice-owned-repo")["sources"],
+        json!(["owned"])
+    );
+    // Affiliated but not owned or starred.
+    assert_eq!(
+        by_name("acme-inc/acme-widgets")["sources"],
+        json!(["contributor"])
+    );
+
+    // An owned repo joins exactly like a starred one.
+    let response = client
+        .post(
+            "/communities/join",
+            &json!({ "owner": "alice", "name": "alice-owned-repo" }),
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let view = json_body(response).await?;
+    assert_eq!(view["community"]["owner"], "alice");
+    assert_eq!(view["community"]["name"], "alice-owned-repo");
+
+    let browse = json_body(client.get("/communities/browse").await?).await?;
+    let joined = browse
+        .as_array()
+        .expect("browse returns an array")
+        .iter()
+        .find(|item| item["full_name"] == "alice/alice-owned-repo")
+        .expect("owned repo still listed after joining")
+        .clone();
+    assert!(joined["community"].is_object());
+    assert!(joined["membership"].is_object());
 
     Ok(())
 }

--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -822,6 +822,8 @@ pub struct BrowseCommunityResponse {
     pub name: String,
     pub full_name: String,
     pub private: bool,
+    /// Every relationship that surfaced this repo (starred, owned, contributor).
+    pub sources: Vec<fido_types::RepoSource>,
     pub community: Option<CommunityResponse>,
     pub membership: Option<MembershipResponse>,
 }

--- a/fido-tui/src/app/communities.rs
+++ b/fido-tui/src/app/communities.rs
@@ -201,7 +201,7 @@ impl App {
         move_home_selection(&mut self.home_state, -1);
     }
 
-    /// Open the starred-repo browser, loading it on first use.
+    /// Open the repo browser (starred, owned, and contributed), loading it on first use.
     pub async fn open_community_browser(&mut self) -> Result<()> {
         self.community_browser_state.show = true;
         self.community_browser_state.error = None;
@@ -233,7 +233,7 @@ impl App {
                 }
             }
             Err(e) => {
-                log::error!("Failed to browse starred communities: {}", e);
+                log::error!("Failed to browse communities: {}", e);
                 self.community_browser_state.error = Some(categorize_error(&e.to_string()));
             }
         }
@@ -307,8 +307,7 @@ impl App {
             KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => self.previous_browser_repo(),
             KeyCode::Char('r') | KeyCode::Char('R') => {
                 self.community_browser_state.loaded = false;
-                self.community_browser_state.message =
-                    Some("Reloading starred repos...".to_string());
+                self.community_browser_state.message = Some("Reloading repos...".to_string());
             }
             KeyCode::Enter => {}
             _ => {}

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -27,6 +27,7 @@ fn test_browse_repo(name: &str) -> crate::api::BrowseCommunityResponse {
         name: name.to_string(),
         full_name: format!("octocat/{}", name),
         private: false,
+        sources: vec![fido_types::RepoSource::Starred],
         community: None,
         membership: None,
     }

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -582,6 +582,15 @@ fn rail_line(selected: bool, label: &str, accent: Color, theme: &ThemeColors) ->
     Line::from(Span::styled(format!("{} {}", prefix, label), style))
 }
 
+/// Render a repo's relationships as one compact label, e.g. "starred+owned".
+fn repo_sources_label(sources: &[fido_types::RepoSource]) -> String {
+    sources
+        .iter()
+        .map(|source| source.as_str())
+        .collect::<Vec<_>>()
+        .join("+")
+}
+
 fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme = get_theme_colors(app);
     let popup_area = centered_rect(76, 76, area);
@@ -594,7 +603,7 @@ fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let items: Vec<ListItem> = if app.community_browser_state.loading {
         vec![ListItem::new(Line::from(Span::styled(
-            "Loading starred repositories...",
+            "Loading repositories...",
             Style::default().fg(theme.text_dim),
         )))]
     } else if let Some(error) = &app.community_browser_state.error {
@@ -604,7 +613,7 @@ fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
         )))]
     } else if app.community_browser_state.repos.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
-            "No starred repositories found.",
+            "No starred, owned, or contributed repositories found.",
             Style::default().fg(theme.text_dim),
         )))]
     } else {
@@ -626,6 +635,10 @@ fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
                         format!("{:<38}", repo.full_name),
                         Style::default().fg(theme.text),
                     ),
+                    Span::styled(
+                        format!("{:<24}", repo_sources_label(&repo.sources)),
+                        Style::default().fg(theme.secondary),
+                    ),
                     Span::styled(status, Style::default().fg(theme.text_dim)),
                 ]))
             })
@@ -636,7 +649,7 @@ fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(" Browse starred repos "),
+                .title(" Browse repos (starred · owned · contributed) "),
         )
         .highlight_style(
             Style::default()

--- a/fido-types/src/enums.rs
+++ b/fido-types/src/enums.rs
@@ -108,6 +108,40 @@ impl MembershipRole {
     }
 }
 
+/// How a repo surfaced in the community browser. A repo can reach the browser
+/// through more than one relationship, so items carry a set of these rather
+/// than a single value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RepoSource {
+    /// The user starred the repo (`GET /user/starred`).
+    Starred,
+    /// The repo's GitHub owner login is the user's own login.
+    Owned,
+    /// The user is a collaborator or org member on the repo, GitHub's closest
+    /// listable notion of "contributed to".
+    Contributor,
+}
+
+impl RepoSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RepoSource::Starred => "starred",
+            RepoSource::Owned => "owned",
+            RepoSource::Contributor => "contributor",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "starred" => Some(RepoSource::Starred),
+            "owned" => Some(RepoSource::Owned),
+            "contributor" => Some(RepoSource::Contributor),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationType {

--- a/scripts/e2e_tui.sh
+++ b/scripts/e2e_tui.sh
@@ -7,7 +7,8 @@
 # Covers: test-user login, directory-scoped community join (repo mode),
 # legacy reply-log cleanup, board title with role, posting, channel chat,
 # community modal, Home mode outside a repo, opening a community from the Home
-# list, search -> profile -> DM, and GitHub issues synced as interactive posts.
+# list, search -> profile -> DM, GitHub issues synced as interactive posts, and
+# the repo browser listing starred, owned, and contributed repos.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -366,6 +367,41 @@ wait_for "Stub issue for e2e" "stub issue interleaved into posts feed"
 
 count=$(sqlite3 "$WORK/fido.db" "SELECT COUNT(*) FROM posts WHERE github_id IS NOT NULL;")
 [ "$count" -ge 1 ] || fail "expected synced GitHub post"
+
+tmux kill-session -t "$SESSION"
+
+# --- Scenario 6: repo browser lists starred, owned, and contributed ----------
+# The stub serves /user/starred and /user/repos; testowner/testrepo appears in
+# both and must collapse into a single row carrying both sources.
+echo "==> scenario 6: browse starred + owned + contributed repos"
+launch_tui "$REPO"
+wait_for "testowner/testrepo" "repo community board (session restored, scenario 6)"
+
+keys 'b'
+wait_for "Browse repos" "community browser opens"
+wait_for "octocat/Hello-World" "starred repo listed"
+pane | grep -qE "alice/alice-owned-repo +owned" \
+    || fail "owned repo should be listed and labelled owned"
+pane | grep -qE "acme-inc/acme-widgets +contributor" \
+    || fail "contributed repo should be listed and labelled contributor"
+pane | grep -qF "starred+contributor" \
+    || fail "a repo reachable both ways should collapse into one row with both sources"
+
+# Joining from the owned source behaves exactly like joining a starred repo.
+keys Down
+keys Down
+pane | grep -qE "> alice/alice-owned-repo" || fail "owned repo should be selected"
+keys Enter
+wait_for "alice/alice-owned-repo" "board opened for the joined owned repo"
+
+OWNED_JOINED=$(sqlite3 "$WORK/fido.db" \
+    "SELECT count(*) FROM memberships m
+       JOIN communities c ON m.community_id = c.id
+       JOIN users u ON m.user_id = u.id
+      WHERE u.username = 'alice'
+        AND c.owner = 'alice'
+        AND c.name = 'alice-owned-repo';")
+[[ "$OWNED_JOINED" == "1" ]] || fail "joining an owned repo did not create a membership (count=$OWNED_JOINED)"
 
 tmux kill-session -t "$SESSION"
 

--- a/scripts/github_stub.py
+++ b/scripts/github_stub.py
@@ -3,8 +3,10 @@
 
 Resolves any /repos/:owner/:name with a deterministic id, returns an empty
 contributors list, one stub open issue from /repos/:owner/:name/issues, and
-404s owner "ghost" to exercise the unresolvable-repo path. Mirrors the
-fixture server in fido-server/tests/e2e_community_rewrite.rs.
+404s owner "ghost" to exercise the unresolvable-repo path. Also serves the two
+community-browser listings: /user/starred and /user/repos (owned plus
+collaborator-affiliated, under the "acme-inc" test org). Mirrors the fixture
+server in fido-server/tests/e2e_community_rewrite.rs.
 """
 
 import json
@@ -24,9 +26,41 @@ def repo_id(owner: str, name: str) -> int:
     return max(h, 2)
 
 
+def repo_entry(owner: str, name: str) -> dict:
+    return {
+        "id": repo_id(owner, name),
+        "name": name,
+        "full_name": f"{owner}/{name}",
+        "private": False,
+        "owner": {"login": owner},
+    }
+
+
+# The e2e harness logs in as the seeded test user "alice", so owned repos sit
+# under that login. acme-inc/* stands in for a repo she collaborates on but
+# does not own, and testowner/testrepo is deliberately both starred and
+# affiliated to exercise the dedup path.
+STARRED_REPOS = [
+    repo_entry("octocat", "Hello-World"),
+    repo_entry("testowner", "testrepo"),
+]
+
+AFFILIATED_REPOS = [
+    repo_entry("alice", "alice-owned-repo"),
+    repo_entry("acme-inc", "acme-widgets"),
+    repo_entry("testowner", "testrepo"),
+]
+
+
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         path = self.path.split("?")[0]
+        if path == "/user/starred":
+            return self._reply(200, STARRED_REPOS)
+
+        if path == "/user/repos":
+            return self._reply(200, AFFILIATED_REPOS)
+
         if CONTRIBUTORS_RE.fullmatch(path):
             return self._reply(200, [])
 


### PR DESCRIPTION
## Why

The community browser could only list **starred** repos, so a maintainer's own repos never appeared unless they had also starred them. Stint task 0026.

## What

`GET /communities/browse` now merges `GET /user/starred` with `GET /user/repos?affiliation=owner,collaborator,organization_member`.

- GitHub exposes no "repos I contributed commits to" listing, so collaborator/org-member affiliation is the closest listable notion of having contributed. Called out in the doc comment on `affiliated_repos`.
- Owned vs contributor is resolved by comparing each repo's owner login to the caller's login.
- A repo reachable through several relationships appears **once**, carrying all of them. Rows are tagged with a new shared `RepoSource` enum (`starred` / `owned` / `contributor`) and the TUI renders e.g. `starred+contributor`.
- Single merged list rather than tabbed sources, which is what stint 0027 (fuzzy search) assumes it will filter over.
- Both listings fail closed: no silent fallback to a partial list if one call errors.

## Dev-only test login now seeds a GitHub token

A real OAuth login leaves the user holding a GitHub token. The dev-only `POST /auth/login` test-user path did not, so test users sat in a state no real user is ever in and **every** token-backed GitHub call was untestable. That is why the repo browser had zero e2e coverage before this change. The route is only mounted outside production (already covered by `omits_test_login_routes_in_production`), so the placeholder never reaches a real deployment.

## Testing

Full gate green:

- `cargo test --workspace` — all suites pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `just e2e-tui` — all 9 scenarios pass, including new **scenario 6**

Per the task's gotcha, no new mocking infra was built. Existing fixtures were extended:

- `scripts/github_stub.py` serves `/user/starred` and `/user/repos` with `acme-inc` test-org data
- new integration test `browse_merges_starred_owned_and_contributed_repos` covers merge, dedup, source tagging, and joining an owned repo
- `e2e_tui.sh` scenario 6 opens the browser with `b`, asserts owned/contributed rows and the deduped `starred+contributor` row via `capture-pane`, joins an owned repo, and verifies the membership in SQLite

## Note

Fixture repo ids in the integration server now derive from `fixture_repo_id` rather than being hardcoded, so a listed repo and `GET /repos/:owner/:name` agree on its id. Without that, joining a listed repo created a community the listing could no longer match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)