### PR TITLE
feat: fuzzy search filter in the repo browser (stint 0027)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,7 @@ dependencies = [
  "fido-types",
  "futures-util",
  "log",
+ "nucleo-matcher",
  "ratatui",
  "reqwest",
  "serde",
@@ -1433,6 +1434,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/fido-tui/Cargo.toml
+++ b/fido-tui/Cargo.toml
@@ -30,6 +30,7 @@ tokio.workspace = true
 tokio-tungstenite.workspace = true
 futures-util.workspace = true
 
+nucleo-matcher = "0.3"
 emojis = "0.6"
 dirs = "5.0"
 textwrap = "0.16.2"

--- a/fido-tui/src/app/communities.rs
+++ b/fido-tui/src/app/communities.rs
@@ -5,7 +5,7 @@
 //! and let the user open one.
 
 use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::api::CommunityViewResponse;
 
@@ -215,6 +215,8 @@ impl App {
         self.community_browser_state.show = false;
         self.community_browser_state.error = None;
         self.community_browser_state.message = None;
+        self.community_browser_state.filter.clear();
+        self.community_browser_state.apply_filter();
     }
 
     pub async fn load_community_browser(&mut self) {
@@ -226,11 +228,8 @@ impl App {
             Ok(repos) => {
                 self.community_browser_state.repos = repos;
                 self.community_browser_state.loaded = true;
-                if self.community_browser_state.repos.is_empty() {
-                    self.community_browser_state.list_state.select(None);
-                } else {
-                    self.community_browser_state.list_state.select(Some(0));
-                }
+                // Reloading keeps whatever the user has typed so far.
+                self.community_browser_state.apply_filter();
             }
             Err(e) => {
                 log::error!("Failed to browse communities: {}", e);
@@ -298,18 +297,33 @@ impl App {
         move_browser_selection(&mut self.community_browser_state, -1);
     }
 
+    /// The browser is a text-input surface: plain characters type into the
+    /// fuzzy filter, so navigation is arrow-keys only and reload moved to
+    /// Ctrl+R (handled in the event loop, which owns the async reload).
     pub fn handle_community_browser_keys(&mut self, key: KeyEvent) -> Result<()> {
         match key.code {
-            KeyCode::Esc | KeyCode::Char('b') | KeyCode::Char('B') => {
-                self.close_community_browser();
+            // Esc clears an active filter first, and only closes once empty.
+            KeyCode::Esc => {
+                if self.community_browser_state.filter.is_empty() {
+                    self.close_community_browser();
+                } else {
+                    self.community_browser_state.filter.clear();
+                    self.community_browser_state.apply_filter();
+                }
             }
-            KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('J') => self.next_browser_repo(),
-            KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('K') => self.previous_browser_repo(),
-            KeyCode::Char('r') | KeyCode::Char('R') => {
-                self.community_browser_state.loaded = false;
-                self.community_browser_state.message = Some("Reloading repos...".to_string());
+            KeyCode::Down => self.next_browser_repo(),
+            KeyCode::Up => self.previous_browser_repo(),
+            KeyCode::Backspace => {
+                self.community_browser_state.filter.pop();
+                self.community_browser_state.apply_filter();
             }
-            KeyCode::Enter => {}
+            KeyCode::Char(c)
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.community_browser_state.filter.push(c);
+                self.community_browser_state.apply_filter();
+            }
             _ => {}
         }
         Ok(())
@@ -328,7 +342,8 @@ fn move_home_selection(home: &mut crate::app::state::HomeState, delta: i64) {
 }
 
 fn move_browser_selection(browser: &mut crate::app::state::CommunityBrowserState, delta: i64) {
-    let len = browser.repos.len();
+    // Navigation walks the filtered rows, not the full repo list.
+    let len = browser.visible.len();
     if len == 0 {
         browser.list_state.select(None);
         return;

--- a/fido-tui/src/app/state.rs
+++ b/fido-tui/src/app/state.rs
@@ -3,6 +3,8 @@ use fido_types::{
     UserProfile,
 };
 
+use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher, Utf32Str};
 use ratatui::widgets::ListState;
 use std::collections::HashSet;
 use std::time::Instant;
@@ -299,6 +301,11 @@ impl ChatState {
 pub struct CommunityBrowserState {
     pub show: bool,
     pub repos: Vec<crate::api::BrowseCommunityResponse>,
+    /// Incremental fuzzy filter typed by the user.
+    pub filter: String,
+    /// Indices into `repos` that survive `filter`, best match first. Empty
+    /// filter means every repo in its original order.
+    pub visible: Vec<usize>,
     pub list_state: ListState,
     pub loading: bool,
     pub loaded: bool,
@@ -312,6 +319,8 @@ impl CommunityBrowserState {
         Self {
             show: false,
             repos: Vec::new(),
+            filter: String::new(),
+            visible: Vec::new(),
             list_state: ListState::default(),
             loading: false,
             loaded: false,
@@ -322,8 +331,51 @@ impl CommunityBrowserState {
     }
 
     pub fn selected(&self) -> Option<&crate::api::BrowseCommunityResponse> {
-        self.list_state.selected().and_then(|i| self.repos.get(i))
+        self.list_state
+            .selected()
+            .and_then(|row| self.visible.get(row))
+            .and_then(|&index| self.repos.get(index))
     }
+
+    /// Rows currently on screen, in display order.
+    pub fn visible_repos(&self) -> impl Iterator<Item = &crate::api::BrowseCommunityResponse> {
+        self.visible
+            .iter()
+            .filter_map(|&index| self.repos.get(index))
+    }
+
+    /// Recompute `visible` from `filter` and move the selection to the top.
+    /// Called on every keystroke and whenever `repos` is replaced.
+    pub fn apply_filter(&mut self) {
+        self.visible = fuzzy_filter(&self.repos, &self.filter);
+        if self.visible.is_empty() {
+            self.list_state.select(None);
+        } else {
+            self.list_state.select(Some(0));
+        }
+    }
+}
+
+/// Rank repos against `filter` by fuzzy match on their full name. Ties break on
+/// original order so the list stays stable while typing.
+fn fuzzy_filter(repos: &[crate::api::BrowseCommunityResponse], filter: &str) -> Vec<usize> {
+    if filter.trim().is_empty() {
+        return (0..repos.len()).collect();
+    }
+
+    let mut matcher = Matcher::new(Config::DEFAULT);
+    let pattern = Pattern::parse(filter, CaseMatching::Ignore, Normalization::Smart);
+    let mut scored: Vec<(usize, u32)> = repos
+        .iter()
+        .enumerate()
+        .filter_map(|(index, repo)| {
+            let mut buf = Vec::new();
+            let haystack = Utf32Str::new(&repo.full_name, &mut buf);
+            pattern.score(haystack, &mut matcher).map(|s| (index, s))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    scored.into_iter().map(|(index, _)| index).collect()
 }
 
 /// Settings tab state

--- a/fido-tui/src/app/tests.rs
+++ b/fido-tui/src/app/tests.rs
@@ -57,6 +57,7 @@ fn test_rail_tab_order_matches_launch_shell() {
 fn test_community_browser_selection_wraps() {
     let mut app = App::new();
     app.community_browser_state.repos = vec![test_browse_repo("alpha"), test_browse_repo("beta")];
+    app.community_browser_state.apply_filter();
     app.community_browser_state.list_state.select(Some(0));
 
     app.next_browser_repo();
@@ -65,6 +66,111 @@ fn test_community_browser_selection_wraps() {
     assert_eq!(app.community_browser_state.list_state.selected(), Some(0));
     app.previous_browser_repo();
     assert_eq!(app.community_browser_state.list_state.selected(), Some(1));
+}
+
+/// Seed an open browser with repos spanning both sources, as the merged list
+/// from stint 0026 produces.
+fn browser_app_with_repos() -> App {
+    let mut app = App::new();
+    app.current_screen = Screen::Main;
+    app.community_browser_state.show = true;
+    app.community_browser_state.repos = vec![
+        test_browse_repo("hello-world"),
+        test_browse_repo("dotfiles"),
+        test_browse_repo("widget-factory"),
+    ];
+    app.community_browser_state.apply_filter();
+    app
+}
+
+fn visible_names(app: &App) -> Vec<String> {
+    app.community_browser_state
+        .visible_repos()
+        .map(|repo| repo.full_name.clone())
+        .collect()
+}
+
+fn type_filter(app: &mut App, text: &str) {
+    for c in text.chars() {
+        app.handle_key_event(key_event(KeyCode::Char(c))).unwrap();
+    }
+}
+
+#[test]
+fn typing_fuzzy_filters_the_browser_list() {
+    let mut app = browser_app_with_repos();
+    assert_eq!(
+        visible_names(&app).len(),
+        3,
+        "unfiltered list shows all rows"
+    );
+
+    // Non-contiguous subsequence: fuzzy, not substring.
+    type_filter(&mut app, "dtfl");
+
+    assert_eq!(app.community_browser_state.filter, "dtfl");
+    assert_eq!(visible_names(&app), vec!["octocat/dotfiles".to_string()]);
+    assert_eq!(
+        app.community_browser_state
+            .selected()
+            .map(|repo| repo.full_name.clone()),
+        Some("octocat/dotfiles".to_string()),
+        "selection follows the filtered list"
+    );
+}
+
+#[test]
+fn browser_filter_keys_do_not_leak_to_shortcuts() {
+    let mut app = browser_app_with_repos();
+
+    // 'b' closed the browser and 'r' reloaded it before the filter existed.
+    type_filter(&mut app, "b");
+    assert!(app.community_browser_state.show, "'b' must type, not close");
+    type_filter(&mut app, "r");
+    assert_eq!(app.community_browser_state.filter, "br");
+}
+
+#[test]
+fn backspace_narrows_then_widens_the_filter() {
+    let mut app = browser_app_with_repos();
+    type_filter(&mut app, "wid");
+    assert_eq!(visible_names(&app).len(), 1);
+
+    app.handle_key_event(key_event(KeyCode::Backspace)).unwrap();
+    app.handle_key_event(key_event(KeyCode::Backspace)).unwrap();
+    app.handle_key_event(key_event(KeyCode::Backspace)).unwrap();
+
+    assert_eq!(app.community_browser_state.filter, "");
+    assert_eq!(visible_names(&app).len(), 3, "clearing restores every row");
+}
+
+#[test]
+fn escape_clears_filter_before_closing_the_browser() {
+    let mut app = browser_app_with_repos();
+    type_filter(&mut app, "dot");
+
+    app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
+    assert!(
+        app.community_browser_state.show,
+        "first Esc clears the filter and keeps the browser open"
+    );
+    assert_eq!(app.community_browser_state.filter, "");
+    assert_eq!(visible_names(&app).len(), 3);
+
+    app.handle_key_event(key_event(KeyCode::Esc)).unwrap();
+    assert!(!app.community_browser_state.show, "second Esc closes");
+}
+
+#[test]
+fn filter_with_no_matches_clears_the_selection() {
+    let mut app = browser_app_with_repos();
+    type_filter(&mut app, "zzzz");
+
+    assert!(app.community_browser_state.visible.is_empty());
+    assert!(
+        app.community_browser_state.selected().is_none(),
+        "nothing can be joined while nothing matches"
+    );
 }
 
 #[test]

--- a/fido-tui/src/event_loop.rs
+++ b/fido-tui/src/event_loop.rs
@@ -521,6 +521,30 @@ impl EventLoop {
             return Ok(());
         }
 
+        // The community browser types into its fuzzy filter, so it must claim
+        // every key before the arms below can read plain characters as their
+        // own shortcuts. Only its two async actions live here; the rest is
+        // synchronous and handled by handle_community_browser_keys.
+        if app.current_screen == Screen::Main && app.community_browser_state.show {
+            let busy = app.community_browser_state.loading || app.community_browser_state.joining;
+            match key.code {
+                KeyCode::Enter if !busy => {
+                    app.open_or_join_browser_selection().await?;
+                }
+                KeyCode::Char('r' | 'R')
+                    if !busy
+                        && key
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                {
+                    app.community_browser_state.loaded = false;
+                    app.load_community_browser().await;
+                }
+                _ => app.handle_key_event(key)?,
+            }
+            return Ok(());
+        }
+
         // Handle the async key events that were previously in main.rs
         match key.code {
             KeyCode::Char('l') if app.current_screen == Screen::Auth && !app.auth_state.loading => {
@@ -594,23 +618,6 @@ impl EventLoop {
                     && app.user_profile_view.is_none() =>
             {
                 app.open_community_browser().await?;
-            }
-            KeyCode::Enter
-                if app.current_screen == Screen::Main
-                    && app.community_browser_state.show
-                    && !app.community_browser_state.loading
-                    && !app.community_browser_state.joining =>
-            {
-                app.open_or_join_browser_selection().await?;
-            }
-            KeyCode::Char('r') | KeyCode::Char('R')
-                if app.current_screen == Screen::Main
-                    && app.community_browser_state.show
-                    && !app.community_browser_state.loading
-                    && !app.community_browser_state.joining =>
-            {
-                app.community_browser_state.loaded = false;
-                app.load_community_browser().await;
             }
             KeyCode::Enter | KeyCode::Char(' ')
                 if app.current_tab == Tab::Posts

--- a/fido-tui/src/ui/tabs.rs
+++ b/fido-tui/src/ui/tabs.rs
@@ -598,8 +598,32 @@ fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(0), Constraint::Length(3)])
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
         .split(popup_area);
+
+    let filter_display = if app.community_browser_state.filter.is_empty() {
+        Span::styled(
+            "type to filter",
+            Style::default()
+                .fg(theme.text_dim)
+                .add_modifier(Modifier::ITALIC),
+        )
+    } else {
+        Span::styled(
+            app.community_browser_state.filter.clone(),
+            Style::default().fg(theme.text),
+        )
+    };
+    let filter_input = Paragraph::new(Line::from(vec![
+        Span::styled("> ", Style::default().fg(theme.success)),
+        filter_display,
+    ]))
+    .block(Block::default().borders(Borders::ALL).title(" Filter "));
+    frame.render_widget(filter_input, chunks[0]);
 
     let items: Vec<ListItem> = if app.community_browser_state.loading {
         vec![ListItem::new(Line::from(Span::styled(
@@ -616,10 +640,17 @@ fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
             "No starred, owned, or contributed repositories found.",
             Style::default().fg(theme.text_dim),
         )))]
+    } else if app.community_browser_state.visible.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            format!(
+                "No repositories match \"{}\".",
+                app.community_browser_state.filter
+            ),
+            Style::default().fg(theme.text_dim),
+        )))]
     } else {
         app.community_browser_state
-            .repos
-            .iter()
+            .visible_repos()
             .map(|repo| {
                 let status = if repo.private {
                     "private"
@@ -658,16 +689,18 @@ fn render_community_browser(frame: &mut Frame, app: &mut App, area: Rect) {
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("> ");
-    frame.render_stateful_widget(list, chunks[0], &mut app.community_browser_state.list_state);
+    frame.render_stateful_widget(list, chunks[1], &mut app.community_browser_state.list_state);
 
     let footer = if app.community_browser_state.joining {
         "Joining..."
+    } else if app.community_browser_state.filter.is_empty() {
+        "Type: Filter | Up/Down: Move | Enter: Open/Join | Ctrl+R: Reload | Esc: Close"
     } else {
-        "Enter: Open/Join | r: Reload | b/Esc: Close"
+        "Type: Filter | Up/Down: Move | Enter: Open/Join | Ctrl+R: Reload | Esc: Clear filter"
     };
     render_footer_with_style(
         frame,
-        chunks[1],
+        chunks[2],
         footer,
         &theme,
         Style::default().fg(theme.text_dim),

--- a/scripts/e2e_tui.sh
+++ b/scripts/e2e_tui.sh
@@ -8,7 +8,8 @@
 # legacy reply-log cleanup, board title with role, posting, channel chat,
 # community modal, Home mode outside a repo, opening a community from the Home
 # list, search -> profile -> DM, GitHub issues synced as interactive posts, and
-# the repo browser listing starred, owned, and contributed repos.
+# the repo browser listing starred, owned, and contributed repos with a fuzzy
+# filter.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -378,7 +379,9 @@ launch_tui "$REPO"
 wait_for "testowner/testrepo" "repo community board (session restored, scenario 6)"
 
 keys 'b'
-wait_for "Browse repos" "community browser opens"
+# "Browse repos" alone also matches the global footer hint, so key off the
+# filter placeholder, which only the popup renders.
+wait_for "type to filter" "community browser opens"
 wait_for "octocat/Hello-World" "starred repo listed"
 pane | grep -qE "alice/alice-owned-repo +owned" \
     || fail "owned repo should be listed and labelled owned"
@@ -402,6 +405,42 @@ OWNED_JOINED=$(sqlite3 "$WORK/fido.db" \
         AND c.owner = 'alice'
         AND c.name = 'alice-owned-repo';")
 [[ "$OWNED_JOINED" == "1" ]] || fail "joining an owned repo did not create a membership (count=$OWNED_JOINED)"
+
+tmux kill-session -t "$SESSION"
+
+# --- Scenario 7: fuzzy filter in the repo browser ---------------------------
+# "acmwid" is a non-contiguous subsequence of "acme-inc/acme-widgets" and
+# matches nothing else, so a substring filter would not find it.
+echo "==> scenario 7: fuzzy filter narrows the repo browser"
+launch_tui "$REPO"
+wait_for "Fido" "TUI ready (session restored, scenario 7)"
+
+# The global footer permanently reads "b: Browse repos", so popup presence
+# must be asserted on markers that only the popup renders.
+keys 'b'
+wait_for "type to filter" "community browser opens with an empty filter"
+pane | grep -qF "octocat/Hello-World" || fail "unfiltered list should show every repo"
+
+tmux send-keys -t "$SESSION" -l "acmwid"
+sleep 0.5
+wait_for "acme-inc/acme-widgets" "fuzzy match survives the filter"
+# octocat/Hello-World is never joined, so it only ever appears inside the
+# popup; the header and rail cannot produce a false match for it.
+pane | grep -qF "octocat/Hello-World" \
+    && fail "non-matching repos should be filtered out"
+
+# Letters that used to be shortcuts now type into the filter instead.
+tmux send-keys -t "$SESSION" -l "b"
+sleep 0.4
+pane | grep -qF "acmwidb" || fail "'b' must type into the filter, not close the browser"
+
+# First Esc clears the filter, second closes the browser.
+keys Escape
+wait_for "type to filter" "Esc clears the filter"
+pane | grep -qF "octocat/Hello-World" || fail "clearing the filter should restore every repo"
+keys Escape
+sleep 0.4
+pane | grep -qF "type to filter" && fail "second Esc should close the browser"
 
 tmux kill-session -t "$SESSION"
 


### PR DESCRIPTION
## Why

With owned and contributed repos merged into the browser (#36 / stint 0026), the combined list got long enough that linear scanning stopped being practical. Stint task 0027.

## What

Typing in the repo browser filters it incrementally, ranked by fuzzy match on full name. Ties break on original order so the list stays stable while typing.

- `nucleo-matcher 0.3.1` added. Per the task's scope note I checked `Cargo.lock` first: no fuzzy matcher was already present (`matchers` is a regex-automata dep of `tracing-subscriber`, unrelated). nucleo is the matcher behind Helix.
- Filtering runs across the **merged** starred + owned/contributed list, so it spans both sources.
- New filter input box at the top of the popup, with a distinct empty-state when nothing matches.

## The part worth reviewing: key dispatch

Making the browser a text-input surface meant it had to claim input **before** the event loop's shortcut arms. I audited every `KeyCode::Char` arm in `handle_async_key_events` and most are unguarded against the browser overlay, so typing a repo name like `dotfiles` would have fired the reload, approve, upvote, delete and profile shortcuts mid-word.

The overlay now short-circuits key dispatch at the top of `handle_async_key_events`, the same way Ctrl+C already does, and the two scattered browser-guarded arms it supersedes are deleted. Filter logic itself stays synchronous in `handle_community_browser_keys` so it is unit-testable; only the two genuinely async actions (join, reload) live in the event loop.

### Keybinding changes, inherent to type-to-filter

| Before | Now |
|---|---|
| `j` / `k` navigate | Arrow keys only (letters type) |
| `r` reloads | `Ctrl+R` reloads |
| `b` closes | Esc closes (letters type) |
| Esc closes | Esc clears filter first, closes once empty |

This is the UX the task specified. Footer hint updated to match.

## Testing

Full gate green:

- `cargo test --workspace` — all pass, TUI suite 77 → 82 tests
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `just e2e-tui` — all 10 scenarios pass, including new **scenario 7**

New unit tests cover fuzzy ranking, non-contiguous matching, backspace widening, Esc precedence, the empty-match case clearing the selection, and specifically that `b`/`r` no longer leak to their old shortcuts.

Scenario 7 filters with `acmwid`, a non-contiguous subsequence of `acme-inc/acme-widgets` that matches nothing else and that a substring filter would not find.

## Incidental fix

Scenario 6 (added in #36) asserted on `"Browse repos"` to detect the popup, but the global footer permanently renders `b: Browse repos`, so that assertion passed trivially. Both scenarios now key off the filter placeholder, which only the popup renders. Caught because scenario 7's close-assertion failed on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)