### PR TITLE
docs: correct stale global-board language in steering guidelines (stint 0025)

### DIFF
--- a/.kiro/steering/fido-project-guidelines.md
+++ b/.kiro/steering/fido-project-guidelines.md
@@ -59,9 +59,15 @@ Fido is a blazing-fast, keyboard-driven social platform for developers, featurin
 ## API Design Standards
 
 ### Core Routes
+Posts are scoped to a community, never global. Every board read names the
+community it belongs to.
+
 - `POST /login/github` - GitHub OAuth authentication
-- `GET /posts` - List global board posts (with sort options)
-- `POST /posts` - Create new post (markdown body)
+- `GET /communities/browse` - Browse the caller's starred, owned, and contributed repos
+- `POST /communities/join` - Join a community, lazily creating it from a GitHub repo
+- `GET /communities` - List communities the caller has joined
+- `GET /posts?community_id=<uuid>` - List a community's board posts (required `community_id`, with sort options)
+- `POST /posts` - Create new post in a community (markdown body)
 - `GET /dms` - List direct messages for user
 - `POST /dms` - Send direct message
 - `POST /vote` - Vote on post (single endpoint with direction param)
@@ -77,9 +83,14 @@ Use single `/vote` endpoint with direction parameter:
 
 ### Core Tables
 - **users**: id (uuid), github_id, username
-- **posts**: id (uuid), author_id, content (text), created_at, upvotes, downvotes
+- **communities**: id (uuid), github_repo_id, owner, name, claimed_by, created_at
+- **memberships**: community_id, user_id, role ('admin'|'contributor'|'member')
+- **posts**: id (uuid), author_id, community_id (required, FK to communities), content (text), created_at, upvotes, downvotes, approved, parent_post_id
 - **votes**: user_id, post_id, direction ('up'|'down') - PRIMARY KEY (user_id, post_id)
 - **dms**: id (uuid), from_id, to_id, content, created_at
+
+A post cannot exist outside a community: `community_id` is NOT NULL and
+foreign-keyed, so every board read is community-scoped.
 
 ## Development Workflow
 


### PR DESCRIPTION
## Why

`.kiro/steering/fido-project-guidelines.md` documented `GET /posts` as "List global board posts" — the v1 MVP model. v2 rescoped posts to per-community in stint 0007. Steering docs are living guidance and must match current behaviour. Stint task 0025.

## What

Verified against the actual code, not inferred:

- `fido-types/src/models.rs` — `Post.community_id: Uuid`, required
- `fido-server/src/api/posts.rs` — `GetPostsQuery.community_id: Uuid`, mandatory query param
- `fido-server/src/db/schema.rs` — `community_id TEXT NOT NULL`, FK to `communities`
- `fido-server/src/lib.rs` — the `/communities/*` routes that carry the scoping

Changes:

1. `GET /posts` documented as `GET /posts?community_id=<uuid>` with the requirement called out.
2. The `/communities/*` routes added to Core Routes, since they were absent entirely and are what makes scoping work.
3. **Scope note:** the Database Schema section listed a `posts` table with no `community_id`. Fixing only the route line would have left the doc contradicting itself on exactly the point this task is about, so the schema entry is corrected too, with `communities` and `memberships` added.

`.kiro/specs/**` is deliberately untouched — those are frozen point-in-time specs and correctly still describe the old global-board MVP, per the task's gotcha.

## Testing

Docs-only change, but the repo requires the full gate before merge and it was run:

- `cargo test --workspace` — 13 suites, all ok
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `just e2e-tui` — all 10 scenarios pass

Task's acceptance grep is clean:

```
$ grep -rn -i "global board\|global feed\|global post" .kiro/steering/
(no matches)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)