### PR TITLE
fix: move dev server off port 3000 and repair the manual run path (stint 0031)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,26 @@
 # -----------------------------------------------------------------------------
 # TUI Client Configuration
 # -----------------------------------------------------------------------------
-# Server URL for the TUI client to connect to
-# For local development: http://localhost:3000
+# Server URL for the TUI client to connect to.
+# Use 127.0.0.1, not localhost: localhost resolves to IPv6 ::1 first on macOS
+# while fido-server binds IPv4, so localhost can reach a different process
+# listening on the same port over IPv6.
+# For local development: http://127.0.0.1:4747
 # For production: https://fido-web-production.up.railway.app
-FIDO_SERVER_URL=http://localhost:3000
+FIDO_SERVER_URL=http://127.0.0.1:4747
 
 # -----------------------------------------------------------------------------
 # Server Configuration
 # -----------------------------------------------------------------------------
+# REQUIRED. The server refuses to start without this; there is no default.
+# Must be exactly 'development' or 'production' (RUST_ENV also works).
+ENVIRONMENT=development
+
+# Port the API server binds. Defaults to 4747, chosen to stay clear of the
+# crowded 3000/8000/8080 range. Managed platforms (Railway, Cloud Run) set
+# PORT themselves.
+PORT=4747
+
 # GitHub OAuth credentials (for Device Flow authentication)
 # Register an OAuth app at: https://github.com/settings/developers
 # Note: Device Flow doesn't require a callback URL.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ cargo run --bin fido
 cargo run --bin fido-server
 
 # Run client against local server
-cargo run --bin fido -- --server http://localhost:3000
+cargo run --bin fido -- --server http://127.0.0.1:4747
 
 # Build for release
 cargo build --release
@@ -357,7 +357,7 @@ Important runtime pitfall:
 ### Web Terminal Stack (see `start.sh`)
 - **nginx** (port 8080): Reverse proxy for static files and routing
 - **ttyd** (port 7681): Terminal-over-WebSocket server, runs `fido-tui` against the real API server
-- **fido-server** (port 3000): API server
+- **fido-server** (port 4747): API server
 
 ## Testing Strategy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ ENV HOST=0.0.0.0
 # External listener (nginx). Railway/Cloud Run inject PORT at runtime.
 ENV PORT=8080
 # Internal API listener (fido-server) behind nginx.
-ENV FIDO_SERVER_PORT=3000
+ENV FIDO_SERVER_PORT=4747
 ENV TTYD_PORT=7681
 ENV DATABASE_PATH=/tmp/fido-web-demo.db
 ENV LOG_DIR=/var/log/fido

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -119,7 +119,7 @@ Or use Cargo directly:
 
 ```bash
 cargo run --bin fido-server
-cargo run --bin fido -- --server http://localhost:3000
+cargo run --bin fido -- --server http://127.0.0.1:4747
 ```
 
 Required server environment for GitHub auth:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Or use Cargo directly:
 
 ```bash
 cargo run --bin fido-server
-cargo run --bin fido -- --server http://localhost:3000
+cargo run --bin fido -- --server http://127.0.0.1:4747
 ```
 
 Required server environment:
@@ -135,7 +135,7 @@ Run the browser-based terminal stack:
 
 This starts:
 
-- `fido-server` on port 3000
+- `fido-server` on port 4747
 - `ttyd` on port 7681
 - `nginx` on port 8080
 

--- a/fido-server/settings.toml
+++ b/fido-server/settings.toml
@@ -1,6 +1,6 @@
 [server]
 host = "127.0.0.1"
-port = 3000
+port = 4747
 
 [database]
 path = "../fido.db"

--- a/fido-server/src/config.rs
+++ b/fido-server/src/config.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 // Configuration constants
 const CONFIG_FILE_NAME: &str = "settings.toml";
 const DEFAULT_HOST: &str = "0.0.0.0";
-const DEFAULT_PORT: u16 = 3000;
+const DEFAULT_PORT: u16 = 4747;
 const DEFAULT_DB_PATH: &str = "fido.db";
 const DEV_CONFIG_DIR: &str = "fido-server";
 

--- a/fido-tui/src/api/client.rs
+++ b/fido-tui/src/api/client.rs
@@ -746,8 +746,9 @@ impl Default for ApiClient {
     fn default() -> Self {
         // Determine the appropriate base URL based on environment
         let base_url = if std::env::var("FIDO_WEB_MODE").is_ok() {
-            // In web mode (containerized ttyd), connect to localhost API server
-            "http://127.0.0.1:3000".to_string()
+            // In web mode (containerized ttyd), connect to the API server on
+            // the internal port nginx proxies to (see Dockerfile FIDO_SERVER_PORT).
+            "http://127.0.0.1:4747".to_string()
         } else {
             // For local TUI client:
             // 1) explicit runtime override

--- a/justfile
+++ b/justfile
@@ -1,9 +1,27 @@
 set dotenv-load
 
-# Start the Fido server locally with SQLite
-server:
+# Refuse to start when the port is already taken, naming the process holding it.
+# Without this the server can appear to start while something else answers:
+# a process bound to IPv6 *:PORT and fido-server bound to IPv4 127.0.0.1:PORT
+# coexist without a bind error, and `localhost` resolves to IPv6 first on macOS.
+_server-preflight:
     #!/usr/bin/env bash
     set -euo pipefail
+    port="${PORT:-4747}"
+    if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+        echo "FATAL: port $port is already in use. fido-server will not start." >&2
+        echo "" >&2
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >&2
+        echo "" >&2
+        echo "Stop that process, or run on another port: PORT=<free port> just server" >&2
+        exit 1
+    fi
+
+# Start the Fido server locally with SQLite
+server: _server-preflight
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export ENVIRONMENT="${ENVIRONMENT:-development}"
     log="${FIDO_SERVER_LOG:-logs/fido-server.log}"
     max_bytes="${FIDO_SERVER_LOG_MAX_BYTES:-10485760}"
     mkdir -p "$(dirname "$log")"
@@ -18,9 +36,10 @@ server:
     done
 
 # Start the Fido server with fresh database (deletes and recreates)
-server-reset:
+server-reset: _server-preflight
     #!/usr/bin/env bash
     set -euo pipefail
+    export ENVIRONMENT="${ENVIRONMENT:-development}"
     log="${FIDO_SERVER_LOG:-logs/fido-server.log}"
     max_bytes="${FIDO_SERVER_LOG_MAX_BYTES:-10485760}"
     mkdir -p "$(dirname "$log")"
@@ -44,9 +63,12 @@ server-log:
 tui:
     cargo run --bin fido
 
-# Start TUI connected to local server
+# Start TUI connected to local server.
+# 127.0.0.1, never `localhost`: localhost resolves to IPv6 ::1 first on macOS
+# while fido-server binds IPv4, so `localhost` can silently reach a different
+# process listening on the same port over IPv6.
 tui-local:
-    cargo run --bin fido -- --server http://localhost:3000
+    cargo run --bin fido -- --server http://127.0.0.1:{{env_var_or_default("PORT", "4747")}}
 
 # Start full local web stack (fido-server + ttyd + nginx)
 web:

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,7 +18,7 @@ http {
 
     # Upstream servers
     upstream fido_server {
-        server 127.0.0.1:3000;
+        server 127.0.0.1:4747;
     }
     
     upstream ttyd_server {

--- a/start.sh
+++ b/start.sh
@@ -15,7 +15,7 @@ NC='\033[0m' # No Color
 # `PORT` is the externally exposed port in managed environments (Railway/Cloud Run).
 # Keep fido-server on an internal port to avoid colliding with nginx.
 APP_PORT=${PORT:-8080}
-FIDO_SERVER_PORT=${FIDO_SERVER_PORT:-3000}
+FIDO_SERVER_PORT=${FIDO_SERVER_PORT:-4747}
 TTYD_PORT=${TTYD_PORT:-7681}
 NGINX_PORT=${NGINX_PORT:-$APP_PORT}
 DATABASE_PATH=${DATABASE_PATH:-${TMPDIR:-/tmp}/fido-web-demo.db}


### PR DESCRIPTION
## Why

The documented way to run Fido by hand was broken two separate ways. Both surfaced tonight when Ian tried `just server` + `just tui-local`. Stint task 0031.

### 1. `just server` could not start

```
FATAL: Missing required configuration: ENVIRONMENT (or RUST_ENV) must be set
```

`ENVIRONMENT` is required at startup but appears in neither `.env` nor `.env.example`. The e2e harness sets it itself (`scripts/e2e_tui.sh:99`), so CI stayed green while the manual path failed for anyone following the README.

### 2. Port 3000 collided with narrator-ai, silently

This is the interesting one. The two processes **do not conflict on bind**: narrator holds IPv6 `*:3000`, fido-server bound IPv4 `127.0.0.1:3000`. Different address families, so fido-server started cleanly with no "address already in use" error. But `just tui-local` hardcoded `http://localhost:3000`, and `localhost` resolves to IPv6 `::1` first on macOS — so the TUI talked to **narrator** and 404'd on every Fido route, with nothing anywhere reporting a conflict.

Reproduced with both running:

```
curl 127.0.0.1:3000/health  -> 200   (fido-server)
curl localhost:3000/health  -> 404   (narrator)
```

Additionally `start.sh:72` runs `lsof -ti:$FIDO_SERVER_PORT | xargs kill -9`, so `just web` on the 3000 default would have killed narrator outright.

## What

Default moves to **4747**, chosen clear of the crowded 3000/8000/8080 range and verified free. Every place that must agree moves together:

- `fido-server/settings.toml` and `DEFAULT_PORT` in `fido-server/src/config.rs`
- `nginx.conf` upstream and `start.sh` `FIDO_SERVER_PORT` (must match or `just web` breaks)
- `Dockerfile` `ENV FIDO_SERVER_PORT`
- the web-mode `ApiClient::default()` in `fido-tui/src/api/client.rs`, which hardcoded `127.0.0.1:3000` and would otherwise have pointed the containerized TUI at nothing

Plus:

- **`tui-local` targets `127.0.0.1`, never `localhost`**, so IPv6-first resolution can never redirect it to another process. It also honours `PORT`.
- **Preflight on `just server` / `just server-reset`** that refuses to start when the port is held and prints the owning process, rather than appearing to start while something else answers:

```
FATAL: port 4747 is already in use. fido-server will not start.

COMMAND     PID     USER   FD   TYPE  ...  NAME
fido-serv 95209 ianburke   29u  IPv4  ...  TCP 127.0.0.1:4747 (LISTEN)

Stop that process, or run on another port: PORT=<free port> just server
```

- `ENVIRONMENT` and `PORT` documented in `.env.example`; `just server` sets `ENVIRONMENT=development` explicitly.
- `README.md`, `QUICKSTART.md`, `AGENTS.md` updated.

## Deliberately not changed

- `.kiro/specs/**` — frozen historical specs.
- `localhost:3000` inside `#[cfg(test)]` blocks (`session.rs`, `auth.rs`, `realtime.rs`) — arbitrary test data, not runtime defaults.
- CORS allowed-origin lists in `fido-server/src/security/` — those are browser *origins*, unrelated to which port the API binds.

## Testing

Verified by hand with narrator still running on 3000:

- `just server` starts bare, no env vars, on `127.0.0.1:4747`
- `/health` returns 200 on 4747
- preflight correctly names the holder when 4747 is occupied and exits non-zero
- narrator unaffected, still answering on 3000

Full gate:

- `cargo test --workspace` — all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `just e2e-tui` — all 10 scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)