### PR TITLE
fix(test): scenario 7 raced session restore (stint 0035)

### DIFF
--- a/scripts/e2e_tui.sh
+++ b/scripts/e2e_tui.sh
@@ -413,7 +413,10 @@ tmux kill-session -t "$SESSION"
 # matches nothing else, so a substring filter would not find it.
 echo "==> scenario 7: fuzzy filter narrows the repo browser"
 launch_tui "$REPO"
-wait_for "Fido" "TUI ready (session restored, scenario 7)"
+# Wait on the board title, not the header: "Fido" is painted on the very first
+# frame (rendered before network startup work by design), so keying off it
+# presses 'b' before session restore lands and the browser never opens.
+wait_for "testowner/testrepo" "repo community board (session restored, scenario 7)"
 
 # The global footer permanently reads "b: Browse repos", so popup presence
 # must be asserted on markers that only the popup renders.


### PR DESCRIPTION
## Why

e2e scenario 7 (which I added in #37) is racy and failed on an unrelated docs-only branch:

```
FAIL: timed out waiting for: community browser opens with an empty filter (pattern: type to filter)
```

It opened with `wait_for "Fido"`. That string lives in the workspace header, which is painted on the **very first frame** — stint 0020 deliberately renders frame one before any network startup work. Session restore has not finished at that point, so the following `keys 'b'` arrived while the app was not yet on `Screen::Main`, the open-browser guard rejected it, and the browser never opened.

It passed its first two runs purely on timing luck. That is the failure mode worth naming: green by accident until an unrelated change shifts timing.

## What

Wait on the board title `testowner/testrepo`, which only appears after the community loads — exactly what scenario 6 and every other scenario already do.

I audited all 30 `wait_for` calls in the harness; scenario 7 was the only one keying off a pre-restore marker.

## Not the fix

Raising the retry count. The wait was on the wrong *signal*, not too short — a longer timeout would still press `b` too early and just take longer to report that the browser never opened. Noted in the task's gotchas so nobody "fixes" it that way later.

## Testing

- `just e2e-tui` — all 10 scenarios pass, scenario 7 included
- `cargo test --workspace` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)