### PR TITLE
docs: surface notifications and browse shortcuts where new users look (stint 0028)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -94,6 +94,8 @@ selected repo community. `r` reloads the list.
 - `j/k` or arrows - Navigate
 - `Enter` - Open selected item or submit focused input
 - `Esc` - Back, clear input, close modal, or quit from Home
+- `v` - Open notifications
+- `b` - Browse repos to join
 - `?` - Help
 - `q` - Quit
 - `Shift+L` - Logout

--- a/fido-tui/README.md
+++ b/fido-tui/README.md
@@ -24,6 +24,7 @@ Login with GitHub or try a test user. Press `?` for help.
 - **Home mode** - Browse communities you have joined
 - **Threads and channels** - Talk inside the repo context
 - **Direct messages** - Message other developers
+- **Notifications** - Replies, mentions, and DM requests in one panel
 - **GitHub auth** - Login with your GitHub account
 - **Keyboard-driven** - `j/k` to navigate, `u/d` to vote, `n` to post
 
@@ -35,6 +36,8 @@ Login with GitHub or try a test user. Press `?` for help.
 - `i` - Open community settings
 - `u/d` - Upvote/Downvote
 - `n` - New post
+- `v` - Open notifications
+- `b` - Browse repos to join
 - `?` - Help
 - `q` - Quit
 


### PR DESCRIPTION
## Why

Stint 0028 asked whether a new user can discover the notifications panel, after Ian's "why isn't it accessible from tabbing through pages?"

**In-app, discoverability is already fine.** Audit found `v` surfaced in three always-on places before a user does anything:

- persistent global footer: `v: Notifications` (`fido-tui/src/ui/tabs.rs:739`)
- left rail always renders a `v Notifications` row, unconditionally (`tabs.rs:543-553`; only the `(N)` count is conditional)
- `?` help modal, Global section (`fido-tui/src/ui/modals/help.rs:118`)

Plus a dedicated QUICKSTART section (`:76-84`) and the key in root README (`:78`).

So no code change and **no `Tab` enum entry** — the task explicitly withheld authority for that, and the audit says it isn't warranted.

## The two real gaps, both docs

1. **`fido-tui/README.md` is the crates.io page** — what someone sees before ever running the binary — and mentioned neither notifications nor `v`.
2. **QUICKSTART's own "Controls" cheat sheet omitted `v`**, even though the prose section above it documents the feature.

Also added `b` (browse repos) to both lists: it shipped in #36/#37 and was missing from the same two places for the same reason.

## Testing status — read before merging

- `cargo test --workspace` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `just e2e-tui` — **not verified.** Could not get a clean run: the machine is at load average 78 from unrelated cargo builds in another repo (PLEXI worktrees). The harness gives each `wait_for` a fixed 15s budget, which a debug-build TUI cannot meet under that contention. Two runs failed at two different scenarios (4b, then 1), both pure timeouts with clean server logs — the signature of contention, not a regression.

This branch changes two markdown files and no code, so e2e is not meaningfully at risk, but I am not claiming a green gate I did not get. Re-run `just e2e-tui` when the machine is quiet before merging.

Filed separately: the harness's fixed wait budget makes it fail spuriously under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)